### PR TITLE
Remove invoice un-posting logic

### DIFF
--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -87,22 +87,30 @@ object Lambda extends App with Logging {
     for {
       accountSummary <- restService.getAccountSummary(accountId)
       subToCancel <- getSubscriptionToCancel(accountSummary)
-      invoiceToUnpost <- getInvoiceToRollBack(accountSummary, date)
-      cancelSubscription <- restService.cancelSubscription(subToCancel, invoiceToUnpost.dueDate)
+      invoice <- getOverdueUnpaidInvoice(accountSummary, date)
+      cancelSubscription <- restService.cancelSubscription(subToCancel, invoice.dueDate)
       updateSubscription <- restService.updateCancellationReason(subToCancel)
-      unpostInvoice <- restService.unpostInvoice(invoiceToUnpost)
-      result <- handleZuoraResults(updateSubscription, cancelSubscription, unpostInvoice)
+      result <- handleZuoraResults(updateSubscription, cancelSubscription)
     } yield result
   }
 
-  def getOverdueUnpaidInvoices(accountSummary: AccountSummary, dateToday: LocalDate): String \/ List[Invoice] = {
-    val overdueUnpaidInvoices = accountSummary.invoices.filter { invoice => invoiceOverdue(invoice, dateToday) }
-    if (overdueUnpaidInvoices.isEmpty) {
-      logger.error(s"Failed to find an unpaid invoice that was overdue. The invoices we got were: ${accountSummary.invoices}")
-      "No unpaid and overdue invoices found!".left
+  def getOverdueUnpaidInvoice(accountSummary: AccountSummary, dateToday: LocalDate): String \/ Invoice = {
+    val unpaidAndOverdueInvoices = accountSummary.invoices.filter { invoice => invoiceOverdue(invoice, dateToday) }
+    if (unpaidAndOverdueInvoices.size > 1) {
+      logger.error(s"Found more unpaid invoices than expected for account: ${accountSummary.basicInfo.id}. The invoices we got were: ${unpaidAndOverdueInvoices.map(_.id)}")
+      "Multiple unpaid invoices".left
     } else {
-      logger.info(s"Found the following unpaid invoices: ${overdueUnpaidInvoices.map(_.id)}")
-      overdueUnpaidInvoices.right
+      val maybeOverdueInvoice = unpaidAndOverdueInvoices.headOption
+      maybeOverdueInvoice match {
+        case Some(overdueInvoice) => {
+          logger.info(s"Determined that InvoiceId: ${overdueInvoice.id} is the overdue unpaid invoice for Account Id: ${accountSummary.basicInfo.id}")
+          overdueInvoice.right
+        }
+        case None => {
+          logger.error(s"Failed to find an unpaid invoice that was overdue. The invoices we got were: ${accountSummary.invoices}")
+          "No unpaid and overdue invoices found!".left
+        }
+      }
     }
   }
 
@@ -115,52 +123,28 @@ object Lambda extends App with Logging {
     } else false
   }
 
-  def getInvoiceToRollBack(accountSummary: AccountSummary, dateToday: LocalDate): String \/ Invoice = {
-    val unpaidInvoices = getOverdueUnpaidInvoices(accountSummary, dateToday)
-    unpaidInvoices.flatMap { invoices =>
-      if (invoices.size > 1) {
-        logger.error(s"Found more unpaid invoices than expected for account: ${accountSummary.basicInfo.id}")
-        "Multiple unpaid invoices".left
-      } else {
-        val invoiceToRollback = invoices.head
-        logger.info(s"Determined that we should unpost InvoiceId: ${invoiceToRollback.id} (for Account Id: ${accountSummary.basicInfo.id})")
-        invoiceToRollback.right
-      }
-    }
-  }
-
-  def getActiveSubscriptions(accountSummary: AccountSummary): String \/ List[Subscription] = {
-    val activeSubs = accountSummary.subscriptions.filter(_.status == "Active")
-    if (activeSubs.isEmpty) { "No Active subscriptions to cancel!".left }
-    else {
-      logger.info(s"Found the following active subscriptions: ${activeSubs.map(_.id)}")
-      activeSubs.right
-    }
-  }
-
   def getSubscriptionToCancel(accountSummary: AccountSummary): String \/ Subscription = {
-    val activeSubs = getActiveSubscriptions(accountSummary)
-    activeSubs.flatMap { subs =>
-      {
-        if (subs.size > 1) {
-          // This should be a pretty rare scenario, because the Billing Account to Sub relationship is (supposed to be) 1-to-1
-          logger.error(s"More than one subscription is Active on account: ${accountSummary.basicInfo.id}. Subscription ids are: ${subs.map(_.id)}")
-          "More than one active sub found!".left // Don't continue because we don't know which active sub to cancel
-        } else {
-          val subToCancel = subs.head
+    val activeSubs = accountSummary.subscriptions.filter(_.status == "Active")
+    if (activeSubs.size > 1) {
+      // This should be a pretty rare scenario, because the Billing Account to Sub relationship is (supposed to be) 1-to-1
+      logger.error(s"More than one subscription is Active on account: ${accountSummary.basicInfo.id}. Subscription ids are: ${activeSubs.map(_.id)}")
+      "More than one active sub found!".left // Don't continue because we don't know which active sub to cancel
+    } else {
+      val maybeSubToCancel = activeSubs.headOption
+      maybeSubToCancel match {
+        case Some(subToCancel) => {
           logger.info(s"Determined that we should cancel SubscriptionId: ${subToCancel.id} (for AccountId: ${accountSummary.basicInfo.id})")
           subToCancel.right
+        }
+        case None => {
+          "No Active subscriptions to cancel!".left
         }
       }
     }
   }
 
-  def handleZuoraResults(
-    updateSubscriptionResult: UpdateSubscriptionResult,
-    cancelSubscriptionResult: CancelSubscriptionResult,
-    updateInvoiceResult: UpdateInvoiceResult
-  ): String \/ Unit = {
-    if (!cancelSubscriptionResult.success || !updateInvoiceResult.success || !updateSubscriptionResult.success) {
+  def handleZuoraResults(updateSubscriptionResult: UpdateSubscriptionResult, cancelSubscriptionResult: CancelSubscriptionResult): String \/ Unit = {
+    if (!cancelSubscriptionResult.success || !updateSubscriptionResult.success) {
       logger.error(s"Zuora rejected one (or more) of our calls during autoCancellation")
       "Received at least one failure result during autoCancellation".left
     } else {

--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -88,8 +88,8 @@ object Lambda extends App with Logging {
       accountSummary <- restService.getAccountSummary(accountId)
       subToCancel <- getSubscriptionToCancel(accountSummary)
       invoice <- getOverdueUnpaidInvoice(accountSummary, date)
-      cancelSubscription <- restService.cancelSubscription(subToCancel, invoice.dueDate)
       updateSubscription <- restService.updateCancellationReason(subToCancel)
+      cancelSubscription <- restService.cancelSubscription(subToCancel, invoice.dueDate)
       result <- handleZuoraResults(updateSubscription, cancelSubscription)
     } yield result
   }

--- a/src/main/scala/com/gu/autoCancel/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/autoCancel/ZuoraObjects.scala
@@ -15,13 +15,9 @@ object ZuoraModels {
 
   case class AccountSummary(basicInfo: BasicAccountInfo, subscriptions: List[Subscription], invoices: List[Invoice])
 
-  case class UpdateInvoiceResult(success: Boolean, id: String)
-
   case class CancelSubscriptionResult(success: Boolean, cancelledDate: LocalDate)
 
   case class UpdateSubscriptionResult(success: Boolean, subscriptionId: String)
-
-  case class InvoiceUpdate(id: String, Status: String)
 
   case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
 
@@ -54,11 +50,6 @@ object ZuoraReaders {
     (JsPath \ "invoices").read[List[Invoice]]
   )(AccountSummary.apply _)
 
-  implicit val updateInvoiceResultReads: Reads[UpdateInvoiceResult] = (
-    (JsPath \ "Success").read[Boolean] and
-    (JsPath \ "Id").read[String]
-  )(UpdateInvoiceResult.apply _)
-
   implicit val cancelSubscriptionResultReads: Reads[CancelSubscriptionResult] = (
     (JsPath \ "success").read[Boolean] and
     (JsPath \ "cancelledDate").read[LocalDate]
@@ -72,13 +63,6 @@ object ZuoraReaders {
 }
 
 object ZuoraWriters {
-
-  implicit val invoiceUpdateWrites = new Writes[InvoiceUpdate] {
-    def writes(invoiceUpdate: InvoiceUpdate) = Json.obj(
-      "Id" -> invoiceUpdate.id,
-      "Status" -> invoiceUpdate.Status.toString
-    )
-  }
 
   implicit val subscriptionCancellationWrites = new Writes[SubscriptionCancellation] {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(

--- a/src/main/scala/com/gu/autoCancel/ZuoraRestService.scala
+++ b/src/main/scala/com/gu/autoCancel/ZuoraRestService.scala
@@ -59,16 +59,6 @@ class ZuoraRestService(config: ZuoraRestConfig) extends Logging {
     convertResponseToCaseClass[CancelSubscriptionResult](response)
   }
 
-  def unpostInvoice(invoice: Invoice): String \/ UpdateInvoiceResult = {
-    val invoiceUpdate = InvoiceUpdate(invoice.id, "Draft")
-    val body = RequestBody.create(MediaType.parse("application/json"), Json.toJson(invoiceUpdate).toString)
-    val request = buildRequest(config, s"object/invoice/${invoice.id}").put(body).build()
-    val call = restClient.newCall(request)
-    logger.info(s"Attempting to Unpost an invoice with the following command: $invoiceUpdate")
-    val response = call.execute
-    convertResponseToCaseClass[UpdateInvoiceResult](response)
-  }
-
   def updateCancellationReason(subscription: Subscription): String \/ UpdateSubscriptionResult = {
     val subscriptionUpdate = SubscriptionUpdate("System AutoCancel")
     val body = RequestBody.create(MediaType.parse("application/json"), Json.toJson(subscriptionUpdate).toString)

--- a/src/test/scala/com/gu/autocancel/ZuoraRestServiceTest.scala
+++ b/src/test/scala/com/gu/autocancel/ZuoraRestServiceTest.scala
@@ -38,10 +38,10 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
       |}""".stripMargin
   )
 
-  val validUpdateInvoiceResult = Json.parse(
+  val validUpdateSubscriptionResult = Json.parse(
     """{
-      |  "Success": true,
-      |  "Id": "id123"
+      |  "success": true,
+      |  "subscriptionId": "id123"
       |}""".stripMargin
   )
 
@@ -66,20 +66,20 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
 
   "convertResponseToCaseClass" should "return a left[String] for an unsuccessful response code" in {
     val response = constructTestResponse(500)
-    val either = fakeRestService.convertResponseToCaseClass[UpdateInvoiceResult](response)
+    val either = fakeRestService.convertResponseToCaseClass[UpdateSubscriptionResult](response)
     assert(either == -\/("Request to Zuora was unsuccessful"))
   }
 
   it should "return a left[String] if the body of a successful response cannot be de-serialized" in {
     val response = constructTestResponse(200)
-    val either = fakeRestService.convertResponseToCaseClass[UpdateInvoiceResult](response)
+    val either = fakeRestService.convertResponseToCaseClass[UpdateSubscriptionResult](response)
     assert(either == -\/("Error when converting Zuora response to case class"))
   }
 
   it should "return a right[T] if the body of a successful response deserializes to T" in {
-    val response = constructTestResponse(200, validUpdateInvoiceResult)
-    val either = fakeRestService.convertResponseToCaseClass[UpdateInvoiceResult](response)
-    assert(either == \/-(UpdateInvoiceResult(true, "id123")))
+    val response = constructTestResponse(200, validUpdateSubscriptionResult)
+    val either = fakeRestService.convertResponseToCaseClass[UpdateSubscriptionResult](response)
+    assert(either == \/-(UpdateSubscriptionResult(true, "id123")))
   }
 
 }


### PR DESCRIPTION
This PR removes all code related to 'un-posting' invoices, which is now superfluous (following discussions with Stuart and Mark).

I've also taken the opportunity to tidy up some of the logic (other changes are test edits due to this re-factor).

@paulbrown1982 @johnduffell 