### PR TITLE
Add mandatory query strings to CloudFormation; make naming consistent

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -149,8 +149,8 @@ Resources:
             HttpMethod: POST
             AuthorizationType: NONE
             RequestParameters:
-              method.request.querystring.apiuser: true
-              method.request.querystring.apipass: true
+              method.request.querystring.apiClientId: true
+              method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
               IntegrationHttpMethod: POST

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -146,8 +146,11 @@ Resources:
             AuthorizationType: NONE
             RestApiId: !Ref ZuoraAutoCancelAPI
             ResourceId: !Ref ZuoraAutoCancelProxyResource
-            HttpMethod: ANY
+            HttpMethod: POST
             AuthorizationType: NONE
+            RequestParameters:
+              method.request.querystring.apiuser: true
+              method.request.querystring.apipass: true
             Integration:
               Type: AWS_PROXY
               IntegrationHttpMethod: POST

--- a/src/main/scala/com/gu/autoCancel/Auth.scala
+++ b/src/main/scala/com/gu/autoCancel/Auth.scala
@@ -4,18 +4,18 @@ import play.api.libs.json.JsValue
 
 object Auth extends Logging {
 
-  def credentialsAreValid(inputEvent: JsValue, username: String, password: String): Boolean = {
+  def credentialsAreValid(inputEvent: JsValue, trustedApiClientId: String, trustedApiToken: String): Boolean = {
 
     /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
     */
-    val maybeUsernameValue = (inputEvent \ "queryStringParameters" \ "apiuser").asOpt[String]
-    val maybePasswordValue = (inputEvent \ "queryStringParameters" \ "apipass").asOpt[String]
-    val maybeCredentials = (maybeUsernameValue, maybePasswordValue)
+    val maybeApiClientId = (inputEvent \ "queryStringParameters" \ "apiClientId").asOpt[String]
+    val maybeApiClientToken = (inputEvent \ "queryStringParameters" \ "apiToken").asOpt[String]
+    val maybeCredentials = (maybeApiClientId, maybeApiClientToken)
 
     maybeCredentials match {
-      case (Some(apiuser), Some(apipass)) => {
-        (apiuser == username && apipass == password)
+      case (Some(apiClientId), Some(apiToken)) => {
+        (apiClientId == trustedApiClientId && apiToken == trustedApiToken)
       }
       case _ => {
         logger.info(s"Could not find credentials in request")

--- a/src/main/scala/com/gu/autoCancel/Auth.scala
+++ b/src/main/scala/com/gu/autoCancel/Auth.scala
@@ -9,13 +9,13 @@ object Auth extends Logging {
     /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
     */
-    val maybeUsernameValue = (inputEvent \ "queryStringParameters" \ "username").asOpt[String]
-    val maybePasswordValue = (inputEvent \ "queryStringParameters" \ "password").asOpt[String]
+    val maybeUsernameValue = (inputEvent \ "queryStringParameters" \ "apiuser").asOpt[String]
+    val maybePasswordValue = (inputEvent \ "queryStringParameters" \ "apipass").asOpt[String]
     val maybeCredentials = (maybeUsernameValue, maybePasswordValue)
 
     maybeCredentials match {
-      case (Some(user), Some(pass)) => {
-        (user == username && pass == password)
+      case (Some(apiuser), Some(apipass)) => {
+        (apiuser == username && apipass == password)
       }
       case _ => {
         logger.info(s"Could not find credentials in request")

--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -23,7 +23,7 @@ object Lambda extends App with Logging {
     logger.info(s"Auto-cancel Lambda is starting up...")
     val inputEvent = Json.parse(inputStream)
     logger.info(s"Received input event as JsValue: \n $inputEvent")
-    if (credentialsAreValid(inputEvent, getenv("ApiUser"), getenv("ApiPass"))) {
+    if (credentialsAreValid(inputEvent, getenv("ApiClientId"), getenv("ApiToken"))) {
       logger.info("Authenticated request successfully...")
       val xmlBody = extractXmlBodyFromJson(inputEvent)
       cancellationAttemptForPayload(xmlBody, outputStream)

--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -23,7 +23,7 @@ object Lambda extends App with Logging {
     logger.info(s"Auto-cancel Lambda is starting up...")
     val inputEvent = Json.parse(inputStream)
     logger.info(s"Received input event as JsValue: \n $inputEvent")
-    if (credentialsAreValid(inputEvent, getenv("ApiUsername"), getenv("ApiPassword"))) {
+    if (credentialsAreValid(inputEvent, getenv("ApiUser"), getenv("ApiPass"))) {
       logger.info("Authenticated request successfully...")
       val xmlBody = extractXmlBodyFromJson(inputEvent)
       cancellationAttemptForPayload(xmlBody, outputStream)

--- a/src/test/scala/com/gu/autocancel/AuthTest.scala
+++ b/src/test/scala/com/gu/autocancel/AuthTest.scala
@@ -6,11 +6,11 @@ import play.api.libs.json.{ JsValue, Json }
 
 class AuthTest extends FlatSpec {
 
-  def generateInputEvent(apiuser: String, apipass: String): JsValue = {
+  def generateInputEvent(apiClientId: String, apiToken: String): JsValue = {
 
-    def constructQueryStrings(user: String, pass: String) = Json.obj(
-      "apiuser" -> user,
-      "apipass" -> pass
+    def constructQueryStrings(apiClientId: String, apiToken: String) = Json.obj(
+      "apiClientId" -> apiClientId,
+      "apiToken" -> apiToken
     )
     val headers = Json.obj(
       "Content-Type" -> "text/xml"
@@ -20,7 +20,7 @@ class AuthTest extends FlatSpec {
       "path" -> "/test-path",
       "httpMethod" -> "POST",
       "headers" -> headers,
-      "queryStringParameters" -> constructQueryStrings(apiuser, apipass)
+      "queryStringParameters" -> constructQueryStrings(apiClientId, apiToken)
     )
     sampleJson
   }

--- a/src/test/scala/com/gu/autocancel/AuthTest.scala
+++ b/src/test/scala/com/gu/autocancel/AuthTest.scala
@@ -6,11 +6,11 @@ import play.api.libs.json.{ JsValue, Json }
 
 class AuthTest extends FlatSpec {
 
-  def generateInputEvent(user: String, password: String): JsValue = {
+  def generateInputEvent(apiuser: String, apipass: String): JsValue = {
 
     def constructQueryStrings(user: String, pass: String) = Json.obj(
-      "username" -> user,
-      "password" -> pass
+      "apiuser" -> user,
+      "apipass" -> pass
     )
     val headers = Json.obj(
       "Content-Type" -> "text/xml"
@@ -20,7 +20,7 @@ class AuthTest extends FlatSpec {
       "path" -> "/test-path",
       "httpMethod" -> "POST",
       "headers" -> headers,
-      "queryStringParameters" -> constructQueryStrings(user, password)
+      "queryStringParameters" -> constructQueryStrings(apiuser, apipass)
     )
     sampleJson
   }


### PR DESCRIPTION
@paulbrown1982 