### PR TITLE
Handle accounts with multiple unpaid invoices

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.1.3",
   "com.typesafe.play" %% "play-json" % "2.4.6",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "com.github.nscala-time" % "nscala-time_2.12" % "2.16.0",
   "org.apache.commons" % "commons-io" % "1.3.2"
 )
 

--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -97,17 +97,14 @@ object Lambda extends App with Logging {
 
   def getCancellationDateFromInvoices(accountSummary: AccountSummary, dateToday: LocalDate): String \/ LocalDate = {
     val unpaidAndOverdueInvoices = accountSummary.invoices.filter { invoice => invoiceOverdue(invoice, dateToday) }
-    unpaidAndOverdueInvoices match {
-      case invoices @ (invoice :: _) => {
-        logger.info(s"Found at least one unpaid invoices for account: ${accountSummary.basicInfo.id}. Invoice id(s): ${unpaidAndOverdueInvoices.map(_.id)}")
-        val earliestDueDate = invoices.map(_.dueDate).min
-        logger.info(s"Earliest overdue invoice for account ${accountSummary.basicInfo.id} has due date: $earliestDueDate. Setting this as the cancellation date.")
-        earliestDueDate.right
-      }
-      case Nil => {
-        logger.error(s"Failed to find an unpaid invoice that was overdue. The invoices we got were: ${accountSummary.invoices}")
-        "No unpaid and overdue invoices found!".left
-      }
+    if (unpaidAndOverdueInvoices.isEmpty) {
+      logger.error(s"Failed to find an unpaid invoice that was overdue. The invoices we got were: ${accountSummary.invoices}")
+      "No unpaid and overdue invoices found!".left
+    } else {
+      logger.info(s"Found at least one unpaid invoices for account: ${accountSummary.basicInfo.id}. Invoice id(s): ${unpaidAndOverdueInvoices.map(_.id)}")
+      val earliestDueDate = unpaidAndOverdueInvoices.map(_.dueDate).min
+      logger.info(s"Earliest overdue invoice for account ${accountSummary.basicInfo.id} has due date: $earliestDueDate. Setting this as the cancellation date.")
+      earliestDueDate.right
     }
   }
 

--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -1,6 +1,7 @@
 package com.gu.autoCancel
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.autoCancel.APIGatewayResponse._
 import com.gu.autoCancel.Auth._
 import com.gu.autoCancel.Config._
@@ -87,27 +88,25 @@ object Lambda extends App with Logging {
     for {
       accountSummary <- restService.getAccountSummary(accountId)
       subToCancel <- getSubscriptionToCancel(accountSummary)
-      invoice <- getOverdueUnpaidInvoice(accountSummary, date)
+      cancellationDate <- getCancellationDateFromInvoices(accountSummary, date)
       updateSubscription <- restService.updateCancellationReason(subToCancel)
-      cancelSubscription <- restService.cancelSubscription(subToCancel, invoice.dueDate)
+      cancelSubscription <- restService.cancelSubscription(subToCancel, cancellationDate)
       result <- handleZuoraResults(updateSubscription, cancelSubscription)
     } yield result
   }
 
-  def getOverdueUnpaidInvoice(accountSummary: AccountSummary, dateToday: LocalDate): String \/ Invoice = {
+  def getCancellationDateFromInvoices(accountSummary: AccountSummary, dateToday: LocalDate): String \/ LocalDate = {
     val unpaidAndOverdueInvoices = accountSummary.invoices.filter { invoice => invoiceOverdue(invoice, dateToday) }
     unpaidAndOverdueInvoices match {
-      case invoice :: Nil => {
-        logger.info(s"Determined that InvoiceId: ${invoice.id} is the overdue unpaid invoice for Account Id: ${accountSummary.basicInfo.id}")
-        invoice.right
+      case invoices @ (invoice :: _) => {
+        logger.info(s"Found at least one unpaid invoices for account: ${accountSummary.basicInfo.id}. Invoice id(s): ${unpaidAndOverdueInvoices.map(_.id)}")
+        val earliestDueDate = invoices.map(_.dueDate).min
+        logger.info(s"Earliest overdue invoice for account ${accountSummary.basicInfo.id} has due date: $earliestDueDate. Setting this as the cancellation date.")
+        earliestDueDate.right
       }
       case Nil => {
         logger.error(s"Failed to find an unpaid invoice that was overdue. The invoices we got were: ${accountSummary.invoices}")
         "No unpaid and overdue invoices found!".left
-      }
-      case invoices => {
-        logger.error(s"Found more unpaid invoices than expected for account: ${accountSummary.basicInfo.id}. The invoices we got were: ${unpaidAndOverdueInvoices.map(_.id)}")
-        "Multiple unpaid invoices".left
       }
     }
   }
@@ -116,7 +115,7 @@ object Lambda extends App with Logging {
     if (invoice.balance > 0 && invoice.status == "Posted") {
       val zuoraGracePeriod = 14 // This needs to match with the timeframe for the 3rd payment retry attempt in Zuora
       val invoiceOverdueDate = invoice.dueDate.plusDays(zuoraGracePeriod)
-      logger.info(s"Zuora grace period is: $zuoraGracePeriod days. Invoice due date is ${invoice.dueDate}, so it will be considered overdue on: $invoiceOverdueDate.")
+      logger.info(s"Zuora grace period is: $zuoraGracePeriod days. Due date for Invoice id ${invoice.id} is ${invoice.dueDate}, so it will be considered overdue on: $invoiceOverdueDate.")
       dateToday.isEqual(invoiceOverdueDate) || dateToday.isAfter(invoiceOverdueDate)
     } else false
   }

--- a/src/test/scala/com/gu/autocancel/LambdaTest.scala
+++ b/src/test/scala/com/gu/autocancel/LambdaTest.scala
@@ -16,7 +16,7 @@ class LambdaTest extends FlatSpec {
   val invoiceNotPosted = Invoice("inv123", LocalDate.now.minusDays(5), 11.99, "Cancelled")
   val invoiceZeroBalance = Invoice("inv123", LocalDate.now.minusDays(1), 0.00, "Posted")
   val invoiceNotDue = Invoice("inv123", LocalDate.now.minusDays(3), 11.99, "Posted")
-  val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(21), 11.99, "Posted")
+  val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted")
   val twoOverdueInvoices = List(Invoice("inv123", LocalDate.now.minusDays(21), 11.99, "Posted"), Invoice("inv321", LocalDate.now.minusDays(35), 11.99, "Posted"))
 
   "parseXML" should "successfully parse a 'good' XML sample" in {
@@ -51,20 +51,20 @@ class LambdaTest extends FlatSpec {
     assert(invoiceOverdue(singleOverdueInvoice, LocalDate.now) == true)
   }
 
-  "getOverdueUnpaidInvoice" should "return a left[String] if there is more than one overdue invoice on the account" in {
-    val accountSummaryUnpaidInvs = AccountSummary(basicInfo, List(subscription), twoOverdueInvoices)
-    val either = getOverdueUnpaidInvoice(accountSummaryUnpaidInvs, LocalDate.now)
-    assert(either == -\/("Multiple unpaid invoices"))
-  }
-
-  "getOverdueUnpaidInvoices" should "return a left[String] if no overdue invoices are found" in {
-    val either = getOverdueUnpaidInvoice(AccountSummary(basicInfo, List(subscription), List(invoiceZeroBalance, invoiceNotDue, invoiceNotPosted)), LocalDate.now)
+  "getCancellationDateFromInvoices" should "return a left[String] if no overdue invoices are found" in {
+    val either = getCancellationDateFromInvoices(AccountSummary(basicInfo, List(subscription), List(invoiceZeroBalance, invoiceNotDue, invoiceNotPosted)), LocalDate.now)
     assert(either == -\/("No unpaid and overdue invoices found!"))
   }
 
-  "getOverdueUnpaidInvoices" should "return a right[Invoice] if exactly one overdue invoice is found on the account" in {
-    val either = getOverdueUnpaidInvoice(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice)), LocalDate.now)
-    assert(either == \/-(singleOverdueInvoice))
+  "getCancellationDateFromInvoices" should "return the due date of an invoice, if exactly one overdue invoice is found on the account" in {
+    val either = getCancellationDateFromInvoices(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice)), LocalDate.now)
+    assert(either == \/-(LocalDate.now.minusDays(14)))
+  }
+
+  "getCancellationDateFromInvoices" should "return the earliest due date of all unpaid invoices, if there is more than one overdue invoice on the account" in {
+    val accountSummaryUnpaidInvs = AccountSummary(basicInfo, List(subscription), twoOverdueInvoices)
+    val either = getCancellationDateFromInvoices(accountSummaryUnpaidInvs, LocalDate.now)
+    assert(either == \/-(LocalDate.now.minusDays(35)))
   }
 
   "getSubscriptionToCancel" should "return a left[String] if there is more than one active sub on the account summary" in {


### PR DESCRIPTION
Currently this Lambda will refuse to auto-cancel an account with multiple unpaid invoices.

As soon as we get 100% confirmation that the historical backlog can be cleared down, we will need to start processing accounts in this state. This PR allows us to do that.

Setting the cancellation date == due date of the first unpaid invoice, means that the negative invoice which is subsequently created in Zuora has the correct amount to balance out all outstanding positive charges.

@paulbrown1982 @johnduffell @ajosephides 