### PR TITLE
Refuse to process auto-cancellation for an account if autopay is not true

### DIFF
--- a/src/test/scala/com/gu/autocancel/LambdaTest.scala
+++ b/src/test/scala/com/gu/autocancel/LambdaTest.scala
@@ -22,9 +22,19 @@ class LambdaTest extends FlatSpec {
   "parseXML" should "successfully parse a 'good' XML sample" in {
     val body =
       <callout>
-        <parameter name="AccountID">acc123</parameter>
+        <parameter name="AccountId">acc123</parameter>
+        <parameter name="AutoPay">true</parameter>
       </callout>
     assert(parseXML(body) == \/-("acc123"))
+  }
+
+  "parseXML" should "reject an account if auto-pay is not true" in {
+    val body =
+      <callout>
+        <parameter name="AccountId">acc123</parameter>
+        <parameter name="AutoPay">false</parameter>
+      </callout>
+    assert(parseXML(body) == -\/("AutoRenew is not = true, we should not process a cancellation for this account"))
   }
 
   "parseXML" should "fail to parse a 'bad' XML sample" in {


### PR DESCRIPTION
@paulbrown1982 

This is very ugly but it does the trick.

Note that this will exclude users who pay by cheque from the auto-cancel process @ajosephides 