### PR TITLE
Remove duplicate entry from CF

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -148,7 +148,6 @@ Resources:
             RestApiId: !Ref ZuoraAutoCancelAPI
             ResourceId: !Ref ZuoraAutoCancelProxyResource
             HttpMethod: POST
-            AuthorizationType: NONE
             RequestParameters:
               method.request.querystring.apiClientId: true
               method.request.querystring.apiToken: true


### PR DESCRIPTION
`AuthorizationType` is already specified on [line 147](https://github.com/guardian/zuora-auto-cancel/compare/master...remove-duplicate-entry-from-cf?quick_pull=1#diff-cb222d20613245c796d9ce29c4fb26a8R147) 