### PR TITLE
Disable auto-pay after processing a cancellation

### DIFF
--- a/src/main/scala/com/gu/autoCancel/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/autoCancel/ZuoraObjects.scala
@@ -19,9 +19,13 @@ object ZuoraModels {
 
   case class UpdateSubscriptionResult(success: Boolean, subscriptionId: String)
 
+  case class UpdateAccountResult(success: Boolean)
+
   case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
 
   case class SubscriptionUpdate(cancellationReason: String)
+
+  case class AccountUpdate(autoPay: Boolean)
 
 }
 
@@ -60,6 +64,10 @@ object ZuoraReaders {
     (JsPath \ "subscriptionId").read[String]
   )(UpdateSubscriptionResult.apply _)
 
+  implicit val updateAccountResultReads: Reads[UpdateAccountResult] = (JsPath \ "success").read[Boolean].map {
+    success => UpdateAccountResult(success)
+  }
+
 }
 
 object ZuoraWriters {
@@ -72,9 +80,15 @@ object ZuoraWriters {
     )
   }
 
-  implicit val subscriptionUpdateResult = new Writes[SubscriptionUpdate] {
+  implicit val subscriptionUpdateWrites = new Writes[SubscriptionUpdate] {
     def writes(subscriptionUpdate: SubscriptionUpdate) = Json.obj(
       "CancellationReason__c" -> subscriptionUpdate.cancellationReason
+    )
+  }
+
+  implicit val accountUpdateWrites = new Writes[AccountUpdate] {
+    def writes(accountUpdate: AccountUpdate) = Json.obj(
+      "autoPay" -> accountUpdate.autoPay
     )
   }
 

--- a/src/main/scala/com/gu/autoCancel/ZuoraRestService.scala
+++ b/src/main/scala/com/gu/autoCancel/ZuoraRestService.scala
@@ -69,5 +69,15 @@ class ZuoraRestService(config: ZuoraRestConfig) extends Logging {
     convertResponseToCaseClass[UpdateSubscriptionResult](response)
   }
 
+  def disableAutoPay(accountId: String): String \/ UpdateAccountResult = {
+    val accountUpdate = AccountUpdate(autoPay = false)
+    val body = RequestBody.create(MediaType.parse("application/json"), Json.toJson(accountUpdate).toString)
+    val request = buildRequest(config, s"accounts/${accountId}").put(body).build()
+    val call = restClient.newCall(request)
+    logger.info(s"Attempting to disable autoPay with the following command: $accountUpdate")
+    val response = call.execute
+    convertResponseToCaseClass[UpdateAccountResult](response)
+  }
+
 }
 

--- a/src/test/scala/com/gu/autocancel/LambdaTest.scala
+++ b/src/test/scala/com/gu/autocancel/LambdaTest.scala
@@ -101,18 +101,23 @@ class LambdaTest extends FlatSpec {
     assert(either == \/-(subscription))
   }
 
-  "handleZuoraResults" should "return a left if the CancelSubscriptionResult indicates failure" in {
-    val either = handleZuoraResults(UpdateSubscriptionResult(true, "id321"), CancelSubscriptionResult(false, LocalDate.now()))
-    assert(either == -\/("Received at least one failure result during autoCancellation"))
-  }
-
   "handleZuoraResults" should "return a left if the UpdateSubscriptionResult indicates failure" in {
-    val either = handleZuoraResults(UpdateSubscriptionResult(false, "id321"), CancelSubscriptionResult(true, LocalDate.now()))
+    val either = handleZuoraResults(UpdateSubscriptionResult(false, "id321"), CancelSubscriptionResult(true, LocalDate.now()), UpdateAccountResult(true))
     assert(either == -\/("Received at least one failure result during autoCancellation"))
   }
 
-  "handleZuoraResults" should "return a right[Unit] if both CancelSubscriptionResult and UpdateSubscriptionResult indicate success" in {
-    val either = handleZuoraResults(UpdateSubscriptionResult(true, "id321"), CancelSubscriptionResult(true, LocalDate.now()))
+  "handleZuoraResults" should "return a left if the CancelSubscriptionResult indicates failure" in {
+    val either = handleZuoraResults(UpdateSubscriptionResult(true, "id321"), CancelSubscriptionResult(false, LocalDate.now()), UpdateAccountResult(true))
+    assert(either == -\/("Received at least one failure result during autoCancellation"))
+  }
+
+  "handleZuoraResults" should "return a left if the UpdateAccountResult indicates failure" in {
+    val either = handleZuoraResults(UpdateSubscriptionResult(true, "id321"), CancelSubscriptionResult(true, LocalDate.now()), UpdateAccountResult(false))
+    assert(either == -\/("Received at least one failure result during autoCancellation"))
+  }
+
+  "handleZuoraResults" should "return a right[Unit] if all Zuora results indicate success" in {
+    val either = handleZuoraResults(UpdateSubscriptionResult(true, "id321"), CancelSubscriptionResult(true, LocalDate.now()), UpdateAccountResult(true))
     assert(either == \/-(()))
   }
 


### PR DESCRIPTION
This ensures that the customer will not be automatically charged after auto-cancel has run.

@paulbrown1982 @ajosephides 