### PR TITLE
Respond to Zuora callouts with appropriate status codes 

### DIFF
--- a/src/test/scala/com/gu/autocancel/ZuoraRestServiceTest.scala
+++ b/src/test/scala/com/gu/autocancel/ZuoraRestServiceTest.scala
@@ -6,9 +6,8 @@ import com.gu.autoCancel.{ ZuoraRestConfig, ZuoraRestService }
 import okhttp3._
 import org.scalatest._
 import Matchers._
+import com.gu.autoCancel.APIGatewayResponse._
 import play.api.libs.json.{ JsValue, Json }
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import scalaz.{ -\/, \/- }
 
 class ZuoraRestServiceTest extends AsyncFlatSpec {
@@ -67,13 +66,13 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
   "convertResponseToCaseClass" should "return a left[String] for an unsuccessful response code" in {
     val response = constructTestResponse(500)
     val either = fakeRestService.convertResponseToCaseClass[UpdateSubscriptionResult](response)
-    assert(either == -\/("Request to Zuora was unsuccessful"))
+    assert(either == -\/(internalServerError("Request to Zuora was unsuccessful")))
   }
 
   it should "return a left[String] if the body of a successful response cannot be de-serialized" in {
     val response = constructTestResponse(200)
     val either = fakeRestService.convertResponseToCaseClass[UpdateSubscriptionResult](response)
-    assert(either == -\/("Error when converting Zuora response to case class"))
+    assert(either == -\/(internalServerError("Error when converting Zuora response to case class")))
   }
 
   it should "return a right[T] if the body of a successful response deserializes to T" in {


### PR DESCRIPTION
Zuora callouts (webhooks) are often made for accounts which do not meet the criteria for auto-cancellation (e.g. if AutoPay is false). 

The system is configured to automatically retry in the event of an error, so Zuora continues to send callouts for accounts which will never be accepted by the process.

This PR attempts to use the correct status codes to mitigate this behaviour and prevent retries.

cc @johnduffell @pvighi @michaelwmcnamara 