### PR TITLE
Return 200s if no processing is required

### DIFF
--- a/src/main/scala/com/gu/autoCancel/APIGatewayResponse.scala
+++ b/src/main/scala/com/gu/autoCancel/APIGatewayResponse.scala
@@ -41,10 +41,11 @@ object APIGatewayResponse extends Logging {
     writer.close()
   }
 
-  val success = AutoCancelResponse("200", new Headers, "Success")
+  val successfulCancellation = AutoCancelResponse("200", new Headers, "Success")
+  def noActionRequired(reason: String) = AutoCancelResponse("200", new Headers, s"Auto-cancellation is not required: $reason")
+
   val unauthorized = AutoCancelResponse("401", new Headers, "Credentials are missing or invalid")
   val badRequest = AutoCancelResponse("400", new Headers, "Failure to parse XML successfully")
-  def forbidden(reason: String) = AutoCancelResponse("403", new Headers, s"Refused to process auto-cancellation: $reason")
   def internalServerError(error: String) = AutoCancelResponse("500", new Headers, s"Failed to process auto-cancellation with the following error: $error")
 
 }

--- a/src/test/scala/com/gu/autocancel/LambdaTest.scala
+++ b/src/test/scala/com/gu/autocancel/LambdaTest.scala
@@ -35,7 +35,7 @@ class LambdaTest extends FlatSpec {
         <parameter name="AccountId">acc123</parameter>
         <parameter name="AutoPay">false</parameter>
       </callout>
-    assert(parseXML(body) == -\/(forbidden("AutoRenew is not = true, we should not process a cancellation for this account")))
+    assert(parseXML(body) == -\/(noActionRequired("AutoRenew is not = true, we should not process a cancellation for this account")))
   }
 
   "parseXML" should "fail to parse a 'bad' XML sample" in {
@@ -64,7 +64,7 @@ class LambdaTest extends FlatSpec {
 
   "getCancellationDateFromInvoices" should "return a left if no overdue invoices are found" in {
     val either = getCancellationDateFromInvoices(AccountSummary(basicInfo, List(subscription), List(invoiceZeroBalance, invoiceNotDue, invoiceNotPosted)), LocalDate.now)
-    assert(either == -\/(forbidden("No unpaid and overdue invoices found!")))
+    assert(either == -\/(noActionRequired("No unpaid and overdue invoices found!")))
   }
 
   "getCancellationDateFromInvoices" should "return the due date of an invoice, if exactly one overdue invoice is found on the account" in {
@@ -81,19 +81,19 @@ class LambdaTest extends FlatSpec {
   "getSubscriptionToCancel" should "return a left if there is more than one active sub on the account summary" in {
     val accountSummaryWithTwoSubs = AccountSummary(basicInfo, twoSubscriptions, twoOverdueInvoices)
     val either = getSubscriptionToCancel(accountSummaryWithTwoSubs)
-    assert(either == -\/(forbidden("More than one active sub found!")))
+    assert(either == -\/(noActionRequired("More than one active sub found!")))
   }
 
   "getSubscriptionToCancel" should "return a left if there are no subs on the account summary" in {
     val accountSummaryWithCancelledSub = AccountSummary(basicInfo, List(), List(invoiceNotDue))
     val either = getSubscriptionToCancel(accountSummaryWithCancelledSub)
-    assert(either == -\/(forbidden("No Active subscriptions to cancel!")))
+    assert(either == -\/(noActionRequired("No Active subscriptions to cancel!")))
   }
 
   "getSubscriptionToCancel" should "return a left if the account summary only contains cancelled and expired subs" in {
     val accountSummaryCancelledSub = AccountSummary(basicInfo, inactiveSubscriptions, List(singleOverdueInvoice))
     val either = getSubscriptionToCancel(accountSummaryCancelledSub)
-    assert(either == -\/(forbidden("No Active subscriptions to cancel!")))
+    assert(either == -\/(noActionRequired("No Active subscriptions to cancel!")))
   }
 
   "getSubscriptionToCancel" should "return a right[Subscription] if there is exactly one active sub on the account summary" in {


### PR DESCRIPTION
@johnduffell it turns out Zuora also retry when they receive a 403. So this PR incorporates your last comment on https://github.com/guardian/zuora-auto-cancel/pull/13 in order to fix this issue properly!