### PR TITLE
Don't log the full request in autocancel lambda

### DIFF
--- a/src/main/scala/com/gu/autoCancel/Lambda.scala
+++ b/src/main/scala/com/gu/autoCancel/Lambda.scala
@@ -24,7 +24,6 @@ object Lambda extends App with Logging {
   def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
     logger.info(s"Auto-cancel Lambda is starting up...")
     val inputEvent = Json.parse(inputStream)
-    logger.info(s"Received input event as JsValue: \n $inputEvent")
     if (credentialsAreValid(inputEvent, getenv("ApiClientId"), getenv("ApiToken"))) {
       logger.info("Authenticated request successfully...")
       val xmlBody = extractXmlBodyFromJson(inputEvent)


### PR DESCRIPTION
cc @pvighi - we shouldn't log the full request in this lambda either.