### PR TITLE
Temporarily exclude PayPal users from payment failure process

### DIFF
--- a/src/main/scala/com/gu/autoCancel/ZuoraRestService.scala
+++ b/src/main/scala/com/gu/autoCancel/ZuoraRestService.scala
@@ -17,6 +17,7 @@ case class ZuoraRestConfig(baseUrl: String, username: String, password: String)
 trait ZuoraService {
   def getAccountSummary(accountId: String): AutoCancelResponse \/ AccountSummary
   def getInvoiceTransactions(accountId: String): AutoCancelResponse \/ InvoiceTransactionSummary
+  def disableAutoPay(accountId: String): AutoCancelResponse \/ UpdateAccountResult
 }
 
 class ZuoraRestService(config: ZuoraRestConfig) extends ZuoraService with Logging {

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -43,7 +43,7 @@ trait PaymentFailureLambda extends Logging {
                   case -\/(errorResponse) => outputForAPIGateway(outputStream, errorResponse)
                   case \/-(updateAccountResult) if (!updateAccountResult.success) => outputForAPIGateway(outputStream, internalServerError("Failed to switch off AutoPay"))
                   case \/-(updateAccountResult) if (updateAccountResult.success) => {
-                    logger.info(s"$accountId | AutoPay disabled due to ongoing PayPal incident. Don't forget to turn me back on")
+                    logger.info(s"$accountId | AutoPay disabled due to ongoing PayPal incident. Don't forget to turn this setting back on")
                     outputForAPIGateway(outputStream, noActionRequired("payment failure process is currently suspended for PayPal"))
                   }
                 }

--- a/src/test/resources/paymentFailure/payPalRequest.json
+++ b/src/test/resources/paymentFailure/payPalRequest.json
@@ -1,0 +1,57 @@
+{
+  "resource": "/payment-failure",
+  "path": "/payment-failure",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept-Encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "Host": "321",
+    "Postman-Token": "123",
+    "User-Agent": "some user agent",
+    "Via": "test",
+    "X-Amz-Cf-Id": "test2",
+    "X-Amzn-Trace-Id": "3213",
+    "X-Forwarded-For": "222.222.222",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": {
+    "apiClientId": "validApiClientId",
+    "apiToken": "validApiToken"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "path": "/CODE/payment-failure",
+    "accountId": "someAccountId",
+    "resourceId": "someResourceId",
+    "stage": "CODE",
+    "requestId": "someRequestId",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "apiKey": "",
+      "sourceIp": "12.34.56.78",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "some agent",
+      "user": null
+    },
+    "resourcePath": "/payment-failure",
+    "httpMethod": "POST",
+    "apiId": "someApiId"
+  },
+  "body": "{\n \"paymentId\":\"somePaymentId\",\n    \"accountId\": \"accountId\",\n    \"email\": \"test.user123@guardian.co.uk\",\n    \"failureNumber\": \"1\",\n    \"firstName\": \"Test\",\n    \"lastName\": \"User\",\n    \"paymentMethodType\": \"PayPal\",\n    \"creditCardType\": \"Visa\",\n    \"creditCardExpirationMonth\": \"12\",\n    \"creditCardExpirationYear\": \"2017\",\n \"currency\": \"GBP\"\n,  \"tenantId\": \"testEnvTenantId\"\n}",
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
Pending a resolution to the increased number of PayPal errors we are seeing, we want to exclude these users from the payment failure process.

This change means that:
1. If a user fails a 1st or 2nd PayPal payment, they won't get an email notification
2. We will switch off autoPay so that no future payments (or retries) are attempted for these users.

Since autoPay is false, the check [here](https://github.com/guardian/zuora-auto-cancel/blob/master/src/main/scala/com/gu/autoCancel/Lambda.scala#L87) means that these users will not be cancelled on the 21 days overdue callout either.

We log the fact that we've done this, and we should also be able to observe this happening in @johnduffell's anomalies email, as well as by running standard reports in Zuora. 

Obviously, this means that we will need to revert this PR and perform some tidy up for these users once we have got to the bottom of this incident.

cc @paulbrown1982 @pvighi