### PR TITLE
Remove KMS from CFN

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -52,60 +52,6 @@ Resources:
                             Action: s3:GetObject
                             Resource: !Sub arn:aws:s3:::payment-failure-lambdas-private/${Stage}/*
 
-    ZuoraAutoCancelKMS:
-        Type: AWS::KMS::Key
-        Properties:
-            Description: !Sub Used by the zuora-auto-cancel ${Stage} lambda to encrypt and decrypt environment variables
-            KeyPolicy:
-              Version: '2012-10-17'
-              Id: key-policy-zuora-auto-cancel
-              Statement:
-              - Sid: Enable IAM User Permissions
-                Effect: Allow
-                Principal:
-                  AWS:
-                    !Sub arn:aws:iam::${AWS::AccountId}:root
-                Action: kms:*
-                Resource: "*"
-              - Sid: Allow access for Key Administrators
-                Effect: Allow
-                Action:
-                - kms:Create*
-                - kms:Describe*
-                - kms:Enable*
-                - kms:List*
-                - kms:Put*
-                - kms:Update*
-                - kms:Revoke*
-                - kms:Disable*
-                - kms:Get*
-                - kms:Delete*
-                - kms:ScheduleKeyDeletion
-                - kms:CancelKeyDeletion
-                Resource: "*"
-              - Sid: Allow use of the key
-                Effect: Allow
-                Principal:
-                  AWS:
-                    Fn::GetAtt:
-                    - ZuoraAutoCancelRole
-                    - Arn
-                Action:
-                - kms:Encrypt
-                - kms:Decrypt
-                - kms:ReEncrypt*
-                - kms:GenerateDataKey*
-                - kms:DescribeKey
-                Resource: "*"
-        DependsOn: ZuoraAutoCancelRole
-
-    ZuoraAutoCancelKMSAlias:
-        Type: AWS::KMS::Alias
-        Properties:
-          AliasName: !Sub alias/zuora-auto-cancel-kms-${Stage}
-          TargetKeyId: !Ref ZuoraAutoCancelKMS
-        DependsOn: ZuoraAutoCancelKMS
-
     ZuoraAutoCancelLambda:
         Type: AWS::Lambda::Function
         Properties:
@@ -123,16 +69,11 @@ Resources:
                 Fn::GetAtt:
                 - ZuoraAutoCancelRole
                 - Arn
-            KmsKeyArn:
-                Fn::GetAtt:
-                - ZuoraAutoCancelKMS
-                - Arn
             MemorySize: 512
             Runtime: java8
             Timeout: 300
         DependsOn:
         - ZuoraAutoCancelRole
-        - ZuoraAutoCancelKMS
 
     PaymentFailureLambda:
         Type: AWS::Lambda::Function
@@ -151,16 +92,11 @@ Resources:
                 Fn::GetAtt:
                 - ZuoraAutoCancelRole
                 - Arn
-            KmsKeyArn:
-                Fn::GetAtt:
-                - ZuoraAutoCancelKMS
-                - Arn
             MemorySize: 512
             Runtime: java8
             Timeout: 300
         DependsOn:
         - ZuoraAutoCancelRole
-        - ZuoraAutoCancelKMS
 
     ZuoraAutoCancelAPIPermission:
         Type: AWS::Lambda::Permission
@@ -236,6 +172,7 @@ Resources:
         - ZuoraAutoCancelAPI
         - ZuoraAutoCancelLambda
         - ZuoraAutoCancelProxyResource
+
     ZuoraAutoCancelAPIStage:
         Type: AWS::ApiGateway::Stage
         Properties:


### PR DESCRIPTION
Following on from https://github.com/guardian/zuora-auto-cancel/pull/24, the custom KMS keys that we were using (to decrypt env variables) are now redundant.  

I've tested this on the CODE stack (managed to find a workaround for the CloudFormation issues I was hitting last night).

cc @pvighi @paulbrown1982 

After merge:

- [ ] Update PROD CloudFormation stack.