### PR TITLE
Add alarms for PROD stack

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -2,10 +2,6 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: Handles auto-cancellations for membership and subscriptions, using API Gateway and Lambda
 
 Parameters:
-    App:
-        Description: Application name
-        Type: String
-        Default: zuora-auto-cancel
     Stage:
         Description: Stage name
         Type: String
@@ -13,6 +9,15 @@ Parameters:
             - PROD
             - CODE
         Default: CODE
+    ApiName:
+        Type: String
+        AllowedValues:
+            - zuora-auto-cancel-api-CODE
+            - zuora-auto-cancel-api-PROD
+        Default: zuora-auto-cancel-api-CODE
+
+Conditions:
+  CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]
 
 Resources:
     ZuoraAutoCancelRole:
@@ -105,6 +110,7 @@ Resources:
             FunctionName: !Sub zuora-auto-cancel-${Stage}
             Principal: apigateway.amazonaws.com
         DependsOn: ZuoraAutoCancelLambda
+
     PaymentFailureAPIPermission:
         Type: AWS::Lambda::Permission
         Properties:
@@ -117,7 +123,7 @@ Resources:
         Type: "AWS::ApiGateway::RestApi"
         Properties:
             Description: Zuora sends a callout to this endpoint to initiate an auto-cancellation on an overdue subscription
-            Name: !Sub zuora-auto-cancel-api-${Stage}
+            Name: !Sub ${ApiName}
 
     ZuoraAutoCancelProxyResource:
         Type: AWS::ApiGateway::Resource
@@ -189,5 +195,43 @@ Resources:
             RestApiId: !Ref ZuoraAutoCancelAPI
         DependsOn: ZuoraAutoCancelMethod
 
+    5xxApiAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdMonitoring
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        AlarmName: !Sub 5XX rate from ${ApiName}
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: ApiName
+            Value: !Sub ${ApiName}
+          - Name: Stage
+            Value: !Sub ${Stage}
+        EvaluationPeriods: 1
+        MetricName: 5XXError
+        Namespace: AWS/ApiGateway
+        Period: 3600
+        Statistic: Sum
+        Threshold: 5
 
+    4xxApiAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdMonitoring
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        AlarmName: !Sub 4XX rate from ${ApiName}
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: ApiName
+            Value: !Sub ${ApiName}
+          - Name: Stage
+            Value: !Sub ${Stage}
+        EvaluationPeriods: 1
+        MetricName: 4XXError
+        Namespace: AWS/ApiGateway
+        Period: 3600
+        Statistic: Sum
+        Threshold: 5
 


### PR DESCRIPTION
Very similar to https://github.com/guardian/fulfilment-lookup, with slightly more generous error thresholds. Again, these alarms will be created for the PROD stack only.

This change is useful because we've completely broken this process for direct debit users before (the API was being called with invalid credentials), and no-one noticed for several days because there was no monitoring configured. 

This PR just covers the very basics, but it should allow us to find out if things are fundamentally broken, which seems important as we're likely to make more regular changes to this project in support of KR1.

As with all alarms, the usual 'let's tune these as we go' disclaimers apply...

cc @paulbrown1982 @pvighi @lmath @AWare 

After +1 and before merge:

- [x] Cloudform PROD stack