### PR TITLE
Use JSON as input and re-factor

### DIFF
--- a/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -1,0 +1,12 @@
+package com.gu.autoCancel
+
+import play.api.libs.json.Json
+
+case class AutoCancelCallout(
+  accountId: String,
+  autoPay: Boolean
+)
+
+object AutoCancelCallout {
+  implicit val jf = Json.reads[AutoCancelCallout]
+}

--- a/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -3,9 +3,11 @@ package com.gu.autoCancel
 import play.api.libs.json.Json
 
 case class AutoCancelCallout(
-  accountId: String,
-  autoPay: Boolean
-)
+    accountId: String,
+    autoPay: String
+) {
+  def isAutoPay = autoPay == "true"
+}
 
 object AutoCancelCallout {
   implicit val jf = Json.reads[AutoCancelCallout]

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -94,22 +94,6 @@ object AutoCancelHandler extends App with Logging {
     if (callout.isAutoPay) \/-(()) else -\/(noActionRequired("AutoPay is false"))
   }
 
-  /* When developing, it's best to bypass handleRequest (since this requires actually invoking the Lambda)
-  and directly call cancellationAttemptForPayload.
-
-  To do this, prepare an account in Zuora and use some test XML with a dummy output stream e.g.
-
-  import org.apache.commons.io.output.NullOutputStream
-  val testXML = <callout>
-                  <parameter name="AccountId">12345</parameter>
-                  <parameter name="AutoPay">true</parameter>
-                  <parameter name="PaymentMethodType">CreditCard</parameter>
-                </callout>
-  val nullOutputStream = new NullOutputStream
-  cancellationAttemptForPayload(testXML, nullOutputStream)
-
-  The Response gets logged before we send it back to API Gateway
-  */
   def cancellationAttemptForPayload(zuoraConfig: ZuoraRestConfig, autoCancelCallout: AutoCancelCallout): ApiResponse = {
     val restService = new ZuoraRestService(zuoraConfig)
     autoCancellation(restService, LocalDate.now, autoCancelCallout) match {

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -38,7 +38,7 @@ object AutoCancelHandler extends App with Logging {
     }.fold(identity, identity)
   }
 
-  case class RequestAuth(apiClientId: String, apiClientToken: String)
+  case class RequestAuth(apiClientId: String, apiToken: String)
 
   /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -27,6 +27,7 @@ object AutoCancelHandler extends App with Logging {
       apiGatewayRequest <- parseApiGatewayInput(inputStream)
       auth <- authenticateCallout(apiGatewayRequest.queryStringParameters, config.trustedApiConfig)
       _ = logger.info("Authenticated request successfully...")
+      _ = logger.info(s"body from Zuora was: ${apiGatewayRequest.body}")
       autoCancelCallout <- parseBody(apiGatewayRequest)
     } yield cancelIfNecessary(autoCancelCallout, config.zuoraRestConfig)
     outputForAPIGateway(outputStream, response.fold(identity, identity))
@@ -90,7 +91,7 @@ object AutoCancelHandler extends App with Logging {
   }
 
   def filterInvalidAccount(callout: AutoCancelCallout): ApiResponse \/ Unit = {
-    if (callout.autoPay) \/-(()) else -\/(noActionRequired("AutoPay is false"))
+    if (callout.isAutoPay) \/-(()) else -\/(noActionRequired("AutoPay is false"))
   }
 
   /* When developing, it's best to bypass handleRequest (since this requires actually invoking the Lambda)

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureHandler.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureHandler.scala
@@ -7,10 +7,8 @@ import com.gu.util.{ Config, Logging, ZuoraRestService, ZuoraService }
 import com.gu.util.ZuoraModels._
 import java.io._
 import java.text.DecimalFormat
-
 import org.joda.time.LocalDate
 import play.api.libs.json.{ JsError, JsSuccess, JsValue, Json }
-
 import scala.math.BigDecimal.decimal
 import scala.util.{ Failure, Success, Try }
 import scalaz.{ -\/, \/, \/- }
@@ -41,7 +39,7 @@ trait PaymentFailureLambda extends Logging {
   }
 
   def processCallout(inputEvent: JsValue, outputStream: OutputStream, config: Config)(implicit zuoraService: ZuoraService): Unit = {
-    if (credentialsAreValid(inputEvent, config.trustedApiConfig)) {
+    if (deprecatedCredentialsAreValid(inputEvent, config.trustedApiConfig)) {
       logger.info(s"Authenticated request successfully in $stage")
       val maybeBody = (inputEvent \ "body").toOption
       maybeBody.map { body =>

--- a/src/main/scala/com/gu/util/ApiGatewayResponse.scala
+++ b/src/main/scala/com/gu/util/ApiGatewayResponse.scala
@@ -45,7 +45,7 @@ object ApiGatewayResponse extends Logging {
   def noActionRequired(reason: String) = ApiResponse("200", new Headers, s"Processing is not required: $reason")
 
   val unauthorized = ApiResponse("401", new Headers, "Credentials are missing or invalid")
-  val badRequest = ApiResponse("400", new Headers, "Failure to parse XML successfully")
+  val badRequest = ApiResponse("400", new Headers, "Failure to parse JSON successfully")
   def internalServerError(error: String) = ApiResponse("500", new Headers, s"Failed to process event due to the following error: $error")
 
 }

--- a/src/main/scala/com/gu/util/Auth.scala
+++ b/src/main/scala/com/gu/util/Auth.scala
@@ -1,12 +1,15 @@
 package com.gu.util
 
+import com.gu.autoCancel.AutoCancelHandler.RequestAuth
 import com.gu.paymentFailure.PaymentFailureCallout
 import play.api.libs.json.JsValue
 
 object Auth extends Logging {
 
-  def credentialsAreValid(inputEvent: JsValue, trustedApiConfig: TrustedApiConfig): Boolean = {
+  def credentialsAreValid(requestAuth: RequestAuth, trustedApiConfig: TrustedApiConfig): Boolean =
+    (requestAuth.apiClientId == trustedApiConfig.apiClientId && requestAuth.apiClientToken == trustedApiConfig.apiToken)
 
+  def deprecatedCredentialsAreValid(inputEvent: JsValue, trustedApiConfig: TrustedApiConfig): Boolean = {
     /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
     */

--- a/src/main/scala/com/gu/util/Auth.scala
+++ b/src/main/scala/com/gu/util/Auth.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.JsValue
 object Auth extends Logging {
 
   def credentialsAreValid(requestAuth: RequestAuth, trustedApiConfig: TrustedApiConfig): Boolean =
-    (requestAuth.apiClientId == trustedApiConfig.apiClientId && requestAuth.apiClientToken == trustedApiConfig.apiToken)
+    (requestAuth.apiClientId == trustedApiConfig.apiClientId && requestAuth.apiToken == trustedApiConfig.apiToken)
 
   def deprecatedCredentialsAreValid(inputEvent: JsValue, trustedApiConfig: TrustedApiConfig): Boolean = {
     /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -98,7 +98,7 @@ class AutoCancelHandlerTest extends FlatSpec {
   }
 
   "filterInvalidAccount" should "return a left if AutoPay = false" in {
-    val autoCancelCallout = AutoCancelCallout(accountId = "id123", autoPay = false)
+    val autoCancelCallout = AutoCancelCallout(accountId = "id123", autoPay = "false")
     val either = filterInvalidAccount(autoCancelCallout)
     assert(either match {
       case -\/(_) => true
@@ -107,7 +107,7 @@ class AutoCancelHandlerTest extends FlatSpec {
   }
 
   "filterInvalidAccount" should "return a left if AutoPay = true" in {
-    val autoCancelCallout = AutoCancelCallout(accountId = "id123", autoPay = true)
+    val autoCancelCallout = AutoCancelCallout(accountId = "id123", autoPay = "true")
     val either = filterInvalidAccount(autoCancelCallout)
     assert(either match {
       case \/-(_) => true

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -2,6 +2,7 @@ package com.gu.autoCancel
 
 import com.gu.autoCancel.AutoCancelHandler._
 import com.gu.util.ApiGatewayResponse._
+import com.gu.util.TrustedApiConfig
 import com.gu.util.ZuoraModels._
 import org.joda.time.LocalDate
 import org.scalatest._
@@ -19,32 +20,6 @@ class AutoCancelHandlerTest extends FlatSpec {
   val invoiceNotDue = Invoice("inv123", LocalDate.now.minusDays(3), 11.99, "Posted")
   val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted")
   val twoOverdueInvoices = List(Invoice("inv123", LocalDate.now.minusDays(21), 11.99, "Posted"), Invoice("inv321", LocalDate.now.minusDays(35), 11.99, "Posted"))
-
-  "parseXML" should "successfully parse a 'good' XML sample" in {
-    val body =
-      <callout>
-        <parameter name="AccountId">acc123</parameter>
-        <parameter name="AutoPay">true</parameter>
-      </callout>
-    assert(parseXML(body) == \/-("acc123"))
-  }
-
-  "parseXML" should "reject an account if auto-pay is not true" in {
-    val body =
-      <callout>
-        <parameter name="AccountId">acc123</parameter>
-        <parameter name="AutoPay">false</parameter>
-      </callout>
-    assert(parseXML(body) == -\/(noActionRequired("AutoRenew is not = true, we should not process a cancellation for this account")))
-  }
-
-  "parseXML" should "fail to parse a 'bad' XML sample" in {
-    val body =
-      <callout>
-        <fakeTag>badData</fakeTag>
-      </callout>
-    assert(parseXML(body) == -\/(badRequest))
-  }
 
   "invoiceOverdue" should "return false if the invoice is not in a 'Posted' state" in {
     assert(invoiceOverdue(invoiceNotPosted, LocalDate.now) == false)
@@ -120,6 +95,36 @@ class AutoCancelHandlerTest extends FlatSpec {
   "handleZuoraResults" should "return a right[Unit] if all Zuora results indicate success" in {
     val either = handleZuoraResults(UpdateSubscriptionResult(true, "id321"), CancelSubscriptionResult(true, LocalDate.now()), UpdateAccountResult(true))
     assert(either == \/-(()))
+  }
+
+  "filterInvalidAccount" should "return a left if AutoPay = false" in {
+    val autoCancelCallout = AutoCancelCallout(accountId = "id123", autoPay = false)
+    val either = filterInvalidAccount(autoCancelCallout)
+    assert(either match {
+      case -\/(_) => true
+      case _ => false
+    }, s"We got: $either")
+  }
+
+  "filterInvalidAccount" should "return a left if AutoPay = true" in {
+    val autoCancelCallout = AutoCancelCallout(accountId = "id123", autoPay = true)
+    val either = filterInvalidAccount(autoCancelCallout)
+    assert(either match {
+      case \/-(_) => true
+      case _ => false
+    }, s"We got: $either")
+  }
+
+  "authenticateCallout" should "return a left if the credentials are invalid" in {
+    val requestAuth = RequestAuth(apiClientId = "correctId", apiClientToken = "token")
+    val trustedApiConfig = TrustedApiConfig(apiClientId = "wrongId", apiToken = "token", tenantId = "tenant")
+    assert(authenticateCallout(requestAuth, trustedApiConfig) == -\/(unauthorized))
+  }
+
+  "authenticateCallout" should "return a right if the credentials are valid" in {
+    val requestAuth = RequestAuth(apiClientId = "correctId", apiClientToken = "token")
+    val trustedApiConfig = TrustedApiConfig(apiClientId = "correctId", apiToken = "token", tenantId = "tenant")
+    assert(authenticateCallout(requestAuth, trustedApiConfig) == \/-(()))
   }
 
 }

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -116,13 +116,13 @@ class AutoCancelHandlerTest extends FlatSpec {
   }
 
   "authenticateCallout" should "return a left if the credentials are invalid" in {
-    val requestAuth = RequestAuth(apiClientId = "correctId", apiClientToken = "token")
+    val requestAuth = RequestAuth(apiClientId = "correctId", apiToken = "token")
     val trustedApiConfig = TrustedApiConfig(apiClientId = "wrongId", apiToken = "token", tenantId = "tenant")
     assert(authenticateCallout(requestAuth, trustedApiConfig) == -\/(unauthorized))
   }
 
   "authenticateCallout" should "return a right if the credentials are valid" in {
-    val requestAuth = RequestAuth(apiClientId = "correctId", apiClientToken = "token")
+    val requestAuth = RequestAuth(apiClientId = "correctId", apiToken = "token")
     val trustedApiConfig = TrustedApiConfig(apiClientId = "correctId", apiToken = "token", tenantId = "tenant")
     assert(authenticateCallout(requestAuth, trustedApiConfig) == \/-(()))
   }

--- a/src/test/scala/com/gu/util/AuthTest.scala
+++ b/src/test/scala/com/gu/util/AuthTest.scala
@@ -53,17 +53,17 @@ class AuthTest extends FlatSpec {
   }
 
   "credentialsAreValid" should "return true for correct credentials" in {
-    val requestAuth = RequestAuth(apiClientId = "validUser", apiClientToken = "correctPassword")
+    val requestAuth = RequestAuth(apiClientId = "validUser", apiToken = "correctPassword")
     assert(credentialsAreValid(requestAuth, trustedApiConfig) == true)
   }
 
   "credentialsAreValid" should "return false for an incorrect user" in {
-    val requestAuth = RequestAuth(apiClientId = "invalidUser", apiClientToken = "correctPassword")
+    val requestAuth = RequestAuth(apiClientId = "invalidUser", apiToken = "correctPassword")
     assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
   }
 
   "credentialsAreValid" should "return false for an incorrect password" in {
-    val requestAuth = RequestAuth(apiClientId = "validUser", apiClientToken = "ndjashjkhajshs")
+    val requestAuth = RequestAuth(apiClientId = "validUser", apiToken = "ndjashjkhajshs")
     assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
   }
 

--- a/src/test/scala/com/gu/util/AuthTest.scala
+++ b/src/test/scala/com/gu/util/AuthTest.scala
@@ -1,5 +1,6 @@
 package com.gu.util
 
+import com.gu.autoCancel.AutoCancelHandler.RequestAuth
 import com.gu.util.Auth._
 import org.scalatest.FlatSpec
 import play.api.libs.json.{ JsValue, Json }
@@ -27,28 +28,43 @@ class AuthTest extends FlatSpec {
     sampleJson
   }
 
-  "credentialsAreValid" should "return false if the username query string is missing" in {
+  "deprecatedCredentialsAreValid" should "return false if the username query string is missing" in {
     val sampleJson = Json.obj(
       "resource" -> "test-resource",
       "path" -> "/test-path",
       "httpMethod" -> "POST"
     )
-    assert(credentialsAreValid(sampleJson, trustedApiConfig) == false)
+    assert(deprecatedCredentialsAreValid(sampleJson, trustedApiConfig) == false)
   }
 
-  "credentialsAreValid" should "return false for an incorrect password" in {
+  "deprecatedCredentialsAreValid" should "return false for an incorrect password" in {
     val inputEvent = generateInputEvent("validUser", "incorrectPassword")
-    assert(credentialsAreValid(inputEvent, trustedApiConfig) == false)
+    assert(deprecatedCredentialsAreValid(inputEvent, trustedApiConfig) == false)
   }
 
-  "credentialsAreValid" should "return false for an incorrect username" in {
+  "deprecatedCredentialsAreValid" should "return false for an incorrect username" in {
     val inputEvent = generateInputEvent("invalidUser", "correctPassword")
-    assert(credentialsAreValid(inputEvent, trustedApiConfig) == false)
+    assert(deprecatedCredentialsAreValid(inputEvent, trustedApiConfig) == false)
+  }
+
+  "deprecatedCredentialsAreValid" should "return true for correct credentials" in {
+    val inputEvent = generateInputEvent("validUser", "correctPassword")
+    assert(deprecatedCredentialsAreValid(inputEvent, trustedApiConfig) == true)
   }
 
   "credentialsAreValid" should "return true for correct credentials" in {
-    val inputEvent = generateInputEvent("validUser", "correctPassword")
-    assert(credentialsAreValid(inputEvent, trustedApiConfig) == true)
+    val requestAuth = RequestAuth(apiClientId = "validUser", apiClientToken = "correctPassword")
+    assert(credentialsAreValid(requestAuth, trustedApiConfig) == true)
+  }
+
+  "credentialsAreValid" should "return false for an incorrect user" in {
+    val requestAuth = RequestAuth(apiClientId = "invalidUser", apiClientToken = "correctPassword")
+    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
+  }
+
+  "credentialsAreValid" should "return false for an incorrect password" in {
+    val requestAuth = RequestAuth(apiClientId = "validUser", apiClientToken = "ndjashjkhajshs")
+    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
   }
 
 }


### PR DESCRIPTION
Zuora now supports JSON callouts, so this PR changes the code to read a JSON body, rather than XML.

We've also taken the opportunity to have a general tidy-up/refactor of the lambda logic.

cc @johnduffell 