### PR TITLE
add a direct-debit only filter to the url params for auto cancel

### DIFF
--- a/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -4,9 +4,11 @@ import play.api.libs.json.Json
 
 case class AutoCancelCallout(
     accountId: String,
-    autoPay: String
+    autoPay: String,
+    paymentMethodType: String
 ) {
   def isAutoPay = autoPay == "true"
+  def nonDirectDebit = paymentMethodType != "BankTransfer"
 }
 
 object AutoCancelCallout {

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -35,14 +35,14 @@ object AutoCancelHandler extends App with Logging {
   }
 
   case class RequestAuth(apiClientId: String, apiToken: String)
-  case class URLParams(apiClientId: String, apiToken: String, onlyCancelDirectDebit: Option[String])
+  case class URLParams(apiClientId: String, apiToken: String, onlyCancelDirectDebit: Option[Boolean])
 
   /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
     */
   case class ApiGatewayRequest(queryStringParameters: URLParams, body: String) {
     def parsedBody: JsResult[AutoCancelCallout] = Json.fromJson[AutoCancelCallout](Json.parse(body))
-    def onlyCancelDirectDebit: Boolean = queryStringParameters.onlyCancelDirectDebit.contains("true")
+    def onlyCancelDirectDebit: Boolean = queryStringParameters.onlyCancelDirectDebit.contains(true)
     def requestAuth: RequestAuth = RequestAuth(queryStringParameters.apiClientId, queryStringParameters.apiToken)
   }
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -25,31 +25,29 @@ object AutoCancelHandler extends App with Logging {
     val response = for {
       config <- loadConfig(stage)
       apiGatewayRequest <- parseApiGatewayInput(inputStream)
-      auth <- authenticateCallout(apiGatewayRequest.queryStringParameters, config.trustedApiConfig)
+      auth <- authenticateCallout(apiGatewayRequest.requestAuth, config.trustedApiConfig)
       _ = logger.info("Authenticated request successfully...")
       _ = logger.info(s"body from Zuora was: ${apiGatewayRequest.body}")
       autoCancelCallout <- parseBody(apiGatewayRequest)
-    } yield cancelIfNecessary(autoCancelCallout, config.zuoraRestConfig)
+      _ <- filterInvalidAccount(autoCancelCallout, onlyCancelDirectDebit = apiGatewayRequest.onlyCancelDirectDebit)
+    } yield cancellationAttemptForPayload(config.zuoraRestConfig, autoCancelCallout)
     outputForAPIGateway(outputStream, response.fold(identity, identity))
   }
 
-  def cancelIfNecessary(autoCancelCallout: AutoCancelCallout, zuoraRestConfig: ZuoraRestConfig): ApiResponse = {
-    filterInvalidAccount(autoCancelCallout).map {
-      _ => cancellationAttemptForPayload(zuoraRestConfig, autoCancelCallout)
-    }.fold(identity, identity)
-  }
-
   case class RequestAuth(apiClientId: String, apiToken: String)
+  case class URLParams(apiClientId: String, apiToken: String, onlyCancelDirectDebit: Option[String])
 
   /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
     */
-  case class ApiGatewayRequest(queryStringParameters: RequestAuth, body: String) {
+  case class ApiGatewayRequest(queryStringParameters: URLParams, body: String) {
     def parsedBody: JsResult[AutoCancelCallout] = Json.fromJson[AutoCancelCallout](Json.parse(body))
+    def onlyCancelDirectDebit: Boolean = queryStringParameters.onlyCancelDirectDebit.contains("true")
+    def requestAuth: RequestAuth = RequestAuth(queryStringParameters.apiClientId, queryStringParameters.apiToken)
   }
 
-  object RequestAuth {
-    implicit val jf = Json.reads[RequestAuth]
+  object URLParams {
+    implicit val jf = Json.reads[URLParams]
   }
 
   object ApiGatewayRequest {
@@ -90,8 +88,22 @@ object AutoCancelHandler extends App with Logging {
     if (credentialsAreValid(requestAuth, trustedApiConfig)) \/-(()) else -\/(unauthorized)
   }
 
-  def filterInvalidAccount(callout: AutoCancelCallout): ApiResponse \/ Unit = {
+  def filterInvalidAccount(callout: AutoCancelCallout, onlyCancelDirectDebit: Boolean): ApiResponse \/ Unit = {
+    for {
+      _ <- filterAutoPay(callout)
+      _ <- filterDirectDebit(onlyCancelDirectDebit = onlyCancelDirectDebit, nonDirectDebit = callout.nonDirectDebit)
+    } yield ()
+  }
+
+  def filterAutoPay(callout: AutoCancelCallout): ApiResponse \/ Unit = {
     if (callout.isAutoPay) \/-(()) else -\/(noActionRequired("AutoPay is false"))
+  }
+
+  def filterDirectDebit(onlyCancelDirectDebit: Boolean, nonDirectDebit: Boolean) = {
+    if (onlyCancelDirectDebit && nonDirectDebit)
+      -\/(noActionRequired("it's not direct debit so we will wait longer"))
+    else
+      \/-(())
   }
 
   def cancellationAttemptForPayload(zuoraConfig: ZuoraRestConfig, autoCancelCallout: AutoCancelCallout): ApiResponse = {

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -27,7 +27,7 @@ object AutoCancelHandler extends App with Logging {
       apiGatewayRequest <- parseApiGatewayInput(inputStream)
       auth <- authenticateCallout(apiGatewayRequest.requestAuth, config.trustedApiConfig)
       _ = logger.info("Authenticated request successfully...")
-      _ = logger.info(s"body from Zuora was: ${apiGatewayRequest.body}")
+      _ = logger.info(s"Body from Zuora was: ${apiGatewayRequest.body}, onlyDirectDebit queryString was: ${apiGatewayRequest.queryStringParameters.onlyCancelDirectDebit}")
       autoCancelCallout <- parseBody(apiGatewayRequest)
       _ <- filterInvalidAccount(autoCancelCallout, onlyCancelDirectDebit = apiGatewayRequest.onlyCancelDirectDebit)
     } yield cancellationAttemptForPayload(config.zuoraRestConfig, autoCancelCallout)

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -35,14 +35,14 @@ object AutoCancelHandler extends App with Logging {
   }
 
   case class RequestAuth(apiClientId: String, apiToken: String)
-  case class URLParams(apiClientId: String, apiToken: String, onlyCancelDirectDebit: Option[Boolean])
+  case class URLParams(apiClientId: String, apiToken: String, onlyCancelDirectDebit: Option[String])
 
   /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
     header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
     */
   case class ApiGatewayRequest(queryStringParameters: URLParams, body: String) {
     def parsedBody: JsResult[AutoCancelCallout] = Json.fromJson[AutoCancelCallout](Json.parse(body))
-    def onlyCancelDirectDebit: Boolean = queryStringParameters.onlyCancelDirectDebit.contains(true)
+    def onlyCancelDirectDebit: Boolean = queryStringParameters.onlyCancelDirectDebit.contains("true")
     def requestAuth: RequestAuth = RequestAuth(queryStringParameters.apiClientId, queryStringParameters.apiToken)
   }
 

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -165,7 +165,7 @@ class DeserialiserTest extends FlatSpec with Matchers {
   }
 
   it should "manage with the only direct debit param being false" in {
-    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": false}, "body": "haha"}"""
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "false"}, "body": "haha"}"""
     val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     actualRequest.map(_.onlyCancelDirectDebit) should be(JsSuccess(false))
@@ -173,7 +173,7 @@ class DeserialiserTest extends FlatSpec with Matchers {
   }
 
   it should "manage with the only direct debit param being true" in {
-    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": true}, "body": "haha"}"""
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "true"}, "body": "haha"}"""
     val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     actualRequest.map(_.onlyCancelDirectDebit) should be(JsSuccess(true))

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -165,7 +165,7 @@ class DeserialiserTest extends FlatSpec with Matchers {
   }
 
   it should "manage with the only direct debit param being false" in {
-    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "false"}, "body": "haha"}"""
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": false}, "body": "haha"}"""
     val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     actualRequest.map(_.onlyCancelDirectDebit) should be(JsSuccess(false))
@@ -173,7 +173,7 @@ class DeserialiserTest extends FlatSpec with Matchers {
   }
 
   it should "manage with the only direct debit param being true" in {
-    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": "true"}, "body": "haha"}"""
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "onlyCancelDirectDebit": true}, "body": "haha"}"""
     val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     actualRequest.map(_.onlyCancelDirectDebit) should be(JsSuccess(true))


### PR DESCRIPTION
We are now auto cancelling everything at 28 days.  We would like to add a new trigger to cancel DD only at 21 days overdue.

We will use the same lambda for both triggers but we need to let the lambda decide whether to go ahead.

This PR adds a new parameter for the URL (optional) so you can add &onlyCancelDirectDebit=true to the url to get it to not cancel others.  This will be checked against the Account.PaymentMethod.Type parameter, if it's "BankTransfer" we know it's a DD and can be cancelled even in the constrained case.

Next step is to deploy to code and follow the steps in the google doc to test it.  Then we can add the body parameter in prod (this won't break the old lambda), deploy to PROD and then add the 21 day trigger.

@jacobwinch 