### PR TITLE
turn on auto cancel email from ET

### DIFF
--- a/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -43,7 +43,7 @@ object AutoCancelSteps extends Logging {
       acRequest <- deps.autoCancelFilter2(autoCancelCallout).withLogging(s"auto-cancellation filter for ${autoCancelCallout.accountId}")
       _ <- deps.autoCancel(acRequest).withLogging(s"auto-cancellation for ${autoCancelCallout.accountId}")
       request <- makeRequest(deps.etSendIds, autoCancelCallout)
-      _ <- deps.sendEmailRegardingAccount(autoCancelCallout.accountId, request) TODO add this back once the ET setup is done
+      _ <- deps.sendEmailRegardingAccount(autoCancelCallout.accountId, request)
     } yield ()
   }
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -43,7 +43,7 @@ object AutoCancelSteps extends Logging {
       acRequest <- deps.autoCancelFilter2(autoCancelCallout).withLogging(s"auto-cancellation filter for ${autoCancelCallout.accountId}")
       _ <- deps.autoCancel(acRequest).withLogging(s"auto-cancellation for ${autoCancelCallout.accountId}")
       request <- makeRequest(deps.etSendIds, autoCancelCallout)
-      //      _ <- deps.sendEmailRegardingAccount(autoCancelCallout.accountId, request) TODO add this back once the ET setup is done
+      _ <- deps.sendEmailRegardingAccount(autoCancelCallout.accountId, request) TODO add this back once the ET setup is done
     } yield ()
   }
 


### PR DESCRIPTION
This is to add a step to the auto cancel lambda to send emails from ET once we have auto cancelled someone.  It can go live once the email content has been finalised.

Then we can turn off the Zuora driven email @jacobwinch 😁 