### PR TITLE
Disable autoPay before cancelling the sub

### DIFF
--- a/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -16,8 +16,8 @@ object AutoCancel extends Logging {
     logger.info(s"Attempting to perform auto-cancellation on account: $accountId")
     val zuoraOp = for {
       _ <- Zuora.updateCancellationReason(subToCancel).withLogging("updateCancellationReason")
-      _ <- Zuora.cancelSubscription(subToCancel, cancellationDate).withLogging("cancelSubscription")
       _ <- Zuora.disableAutoPay(accountId).withLogging("disableAutoPay")
+      _ <- Zuora.cancelSubscription(subToCancel, cancellationDate).withLogging("cancelSubscription")
     } yield ()
     zuoraOp.run.run(zuoraDeps)
   }


### PR DESCRIPTION
AutoCancelDataCollection filter stops us from re-processing an account if the sub has already been cancelled.

However, this means that if we fail to disable autopay (i.e. we get as far as making the request, but it does not succeed) during the first attempt, we will never complete this step as part of a retry. 

Swapping the order of the requests in the for comprehension means that we don't attempt to cancel the sub until the other two requests (which are idempotent*) have succeeded.

_*I'm pretty sure this is true_