### PR TITLE
update ET email client local test to send all emails for all products

### DIFF
--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -26,7 +26,7 @@ object EmailClientSystemTest extends App {
           payment_method = "paymentMethodValue",
           card_type = "cardTypeValue",
           card_expiry_date = "cardExpiryValue",
-          first_name = s"$hint-firstNameValue",
+          first_name = s"${hint.replaceAll(" ", "-")}-firstNameValue",
           last_name = "lastNameValue",
           primaryKey = key, // must be unique otherwise the email won't arrive
           price = "49.0 GBP",
@@ -37,16 +37,14 @@ object EmailClientSystemTest extends App {
     )
   )
 
-  def five(a: ETSendIds, product: String) = {
-    val p = product.replaceAll(" ", "-")
+  def five(etSendIds: ETSendIds, product: String) =
     Seq(
-      a.pf1 -> message(s"${p}-pf1", PaymentId(s"paymentId$unique"), product),
-      a.pf2 -> message(s"${p}-pf2", PaymentId(s"paymentId$unique"), product),
-      a.pf3 -> message(s"${p}-pf3", PaymentId(s"paymentId$unique"), product),
-      a.pf4 -> message(s"${p}-pf4", PaymentId(s"paymentId$unique"), product),
-      a.cancelled -> message(s"${p}-overdue", InvoiceId(s"invoiceId$unique"), product)
+      etSendIds.pf1 -> message(s"$product-pf1", PaymentId(s"paymentId$unique"), product),
+      etSendIds.pf2 -> message(s"$product-pf2", PaymentId(s"paymentId$unique"), product),
+      etSendIds.pf3 -> message(s"$product-pf3", PaymentId(s"paymentId$unique"), product),
+      etSendIds.pf4 -> message(s"$product-pf4", PaymentId(s"paymentId$unique"), product),
+      etSendIds.cancelled -> message(s"$product-overdue", InvoiceId(s"invoiceId$unique"), product)
     )
-  }
 
   for {
     configAttempt <- Try {
@@ -54,7 +52,7 @@ object EmailClientSystemTest extends App {
     }
     config <- Config.parseConfig(configAttempt)
     deps = EmailSendStepsDeps.default(Stage("CODE"), RawEffects.createDefault.response, config.etConfig)
-    a = config.etConfig.etSendIDs
+    etSendIds = config.etConfig.etSendIDs
   } yield Seq(
     "Supporter",
     "Digital Pack",
@@ -64,7 +62,7 @@ object EmailClientSystemTest extends App {
     "Contributor",
     "Newspaper Voucher",
     "Newspaper Delivery"
-  ).flatMap(xxx => five(a, xxx)).foreach {
+  ).flatMap(product => five(etSendIds, product)).foreach {
       case (etSendId, index) =>
         val emailResult = EmailSendSteps(
           deps

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -63,14 +63,14 @@ object EmailClientSystemTest extends App {
     "Newspaper Voucher",
     "Newspaper Delivery"
   ).flatMap(product => five(etSendIds, product)).foreach {
-      case (etSendId, index) =>
-        val emailResult = EmailSendSteps(
-          deps
-        )(EmailRequest(
-          etSendId = etSendId,
-          message = index
-        ))
-        println(s"result for $etSendId:::::: $emailResult")
-    }
+    case (etSendId, index) =>
+      val emailResult = EmailSendSteps(
+        deps
+      )(EmailRequest(
+        etSendId = etSendId,
+        message = index
+      ))
+      println(s"result for $etSendId:::::: $emailResult")
+  }
 
 }

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -1,7 +1,7 @@
 package manualTest
 
 import com.gu.effects.RawEffects
-import com.gu.util.ETConfig.ETSendId
+import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.{ Config, Stage }
@@ -15,20 +15,20 @@ object EmailClientSystemTest extends App {
   private val recipient = "john.duffell@guardian.co.uk"
   private def unique = "pi123" + Random.nextInt
 
-  def message(number: Int) = Message(
+  def message(hint: String, key: PrimaryKey, product: String) = Message(
     To = ToDef(
       Address = recipient,
       SubscriberKey = recipient,
       ContactAttributes = ContactAttributesDef(
         SubscriberAttributes = SubscriberAttributesDef(
           subscriber_id = "subIdValue",
-          product = "Supporter",
+          product = product,
           payment_method = "paymentMethodValue",
           card_type = "cardTypeValue",
           card_expiry_date = "cardExpiryValue",
-          first_name = s"firstNameValue$number",
+          first_name = s"$hint-firstNameValue",
           last_name = "lastNameValue",
-          primaryKey = PaymentId(s"paymentId$unique"), // must be unique otherwise the email won't arrive
+          primaryKey = key, // must be unique otherwise the email won't arrive
           price = "49.0 GBP",
           serviceStartDate = "31 January 2016",
           serviceEndDate = "31 January 2017"
@@ -37,27 +37,16 @@ object EmailClientSystemTest extends App {
     )
   )
 
-  def overdueMessage = Message(
-    To = ToDef(
-      Address = recipient,
-      SubscriberKey = recipient,
-      ContactAttributes = ContactAttributesDef(
-        SubscriberAttributes = SubscriberAttributesDef(
-          subscriber_id = "subIdValue",
-          product = "Supporter",
-          payment_method = "paymentMethodValue",
-          card_type = "cardTypeValue",
-          card_expiry_date = "cardExpiryValue",
-          first_name = s"firstNameValue overdue",
-          last_name = "lastNameValue",
-          primaryKey = InvoiceId(s"invoiceId$unique"), // must be unique otherwise the email won't arrive
-          price = "49.0 GBP",
-          serviceStartDate = "31 January 2016",
-          serviceEndDate = "31 January 2017"
-        )
-      )
+  def five(a: ETSendIds, product: String) = {
+    val p = product.replaceAll(" ", "-")
+    Seq(
+      a.pf1 -> message(s"${p}-pf1", PaymentId(s"paymentId$unique"), product),
+      a.pf2 -> message(s"${p}-pf2", PaymentId(s"paymentId$unique"), product),
+      a.pf3 -> message(s"${p}-pf3", PaymentId(s"paymentId$unique"), product),
+      a.pf4 -> message(s"${p}-pf4", PaymentId(s"paymentId$unique"), product),
+      a.cancelled -> message(s"${p}-overdue", InvoiceId(s"invoiceId$unique"), product)
     )
-  )
+  }
 
   for {
     configAttempt <- Try {
@@ -66,15 +55,24 @@ object EmailClientSystemTest extends App {
     config <- Config.parseConfig(configAttempt)
     deps = EmailSendStepsDeps.default(Stage("CODE"), RawEffects.createDefault.response, config.etConfig)
     a = config.etConfig.etSendIDs
-  } yield Seq(a.pf1 -> message(1), a.pf2 -> message(2), a.pf3 -> message(3), a.pf4 -> message(4), a.cancelled -> overdueMessage).map {
-    case (etSendId, index) =>
-      val emailResult = EmailSendSteps(
-        deps
-      )(EmailRequest(
-        etSendId = etSendId,
-        message = index
-      ))
-      println(s"result for $etSendId:::::: $emailResult")
-  }
+  } yield Seq(
+    "Supporter",
+    "Digital Pack",
+    "Guardian Weekly Zone A",
+    "Guardian Weekly Zone B",
+    "Guardian Weekly Zone C",
+    "Contributor",
+    "Newspaper Voucher",
+    "Newspaper Delivery"
+  ).flatMap(xxx => five(a, xxx)).foreach {
+      case (etSendId, index) =>
+        val emailResult = EmailSendSteps(
+          deps
+        )(EmailRequest(
+          etSendId = etSendId,
+          message = index
+        ))
+        println(s"result for $etSendId:::::: $emailResult")
+    }
 
 }

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -1,7 +1,7 @@
 package manualTest
 
 import com.gu.effects.RawEffects
-import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
+import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.{ Config, Stage }
@@ -31,11 +31,7 @@ object EmailClientSystemTest extends App {
           primaryKey = key, // must be unique otherwise the email won't arrive
           price = "49.0 GBP",
           serviceStartDate = "31 January 2016",
-          serviceEndDate = "31 January 2017"
-        )
-      )
-    )
-  )
+          serviceEndDate = "31 January 2017"))))
 
   def five(etSendIds: ETSendIds, product: String) =
     Seq(
@@ -43,8 +39,7 @@ object EmailClientSystemTest extends App {
       etSendIds.pf2 -> message(s"$product-pf2", PaymentId(s"paymentId$unique"), product),
       etSendIds.pf3 -> message(s"$product-pf3", PaymentId(s"paymentId$unique"), product),
       etSendIds.pf4 -> message(s"$product-pf4", PaymentId(s"paymentId$unique"), product),
-      etSendIds.cancelled -> message(s"$product-overdue", InvoiceId(s"invoiceId$unique"), product)
-    )
+      etSendIds.cancelled -> message(s"$product-overdue", InvoiceId(s"invoiceId$unique"), product))
 
   for {
     configAttempt <- Try {
@@ -61,16 +56,13 @@ object EmailClientSystemTest extends App {
     "Guardian Weekly Zone C",
     "Contributor",
     "Newspaper Voucher",
-    "Newspaper Delivery"
-  ).flatMap(product => five(etSendIds, product)).foreach {
-    case (etSendId, index) =>
-      val emailResult = EmailSendSteps(
-        deps
-      )(EmailRequest(
-        etSendId = etSendId,
-        message = index
-      ))
-      println(s"result for $etSendId:::::: $emailResult")
-  }
+    "Newspaper Delivery").flatMap(product => five(etSendIds, product)).foreach {
+      case (etSendId, index) =>
+        val emailResult = EmailSendSteps(
+          deps)(EmailRequest(
+          etSendId = etSendId,
+          message = index))
+        println(s"result for $etSendId:::::: $emailResult")
+    }
 
 }


### PR DESCRIPTION
reliased I didn't push these changes.

Basically before the unique key on the emails was all payment id.  This was changed to be invoice id for the overdue email, because there's no actual payment for an overdue invoice.  There may be several.
The code was duplicated which was alright, but then I wanted to test over all the possible products, as ET will send different emails.  To avoid the duplication getting worse I just combined into one function and called that number of emails * number of products times, with the right parameters.

This is just a test you'd run locally, but it makes sense to have the latest version pushed.  It won't affect anythign that happens automatically.

@jacobwinch 