### PR TITLE
stripe card updated trigger to zuora

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -174,16 +174,16 @@ Resources:
         - ZuoraAutoCancelProxyResource
 
 
-    StripeCustomerUpdatedLambda:
+    StripeCustomerSourceUpdatedLambda:
         Type: AWS::Lambda::Function
         Properties:
             Description: Handles auto-cancellations for membership and subscriptions
             FunctionName:
-                !Sub stripe-customer-updated-${Stage}
+                !Sub stripe-customer-source-updated-${Stage}
             Code:
                 S3Bucket: zuora-auto-cancel-dist
                 S3Key: !Sub membership/${Stage}/zuora-auto-cancel/zuora-auto-cancel.jar
-            Handler: com.gu.stripeCustomerUpdated.Lambda::apply
+            Handler: com.gu.stripeCustomerSourceUpdated.Lambda::apply
             Environment:
                 Variables:
                   Stage: !Ref Stage
@@ -197,39 +197,39 @@ Resources:
         DependsOn:
         - ZuoraAutoCancelRole
 
-    StripeCustomerUpdatedAPIPermission:
+    StripeCustomerSourceUpdatedAPIPermission:
         Type: AWS::Lambda::Permission
         Properties:
             Action: lambda:invokeFunction
-            FunctionName: !Sub stripe-customer-updated-${Stage}
+            FunctionName: !Sub stripe-customer-source-updated-${Stage}
             Principal: apigateway.amazonaws.com
-        DependsOn: StripeCustomerUpdatedLambda
+        DependsOn: StripeCustomerSourceUpdatedLambda
 
-    StripeCustomerUpdatedProxyResource:
+    StripeCustomerSourceUpdatedProxyResource:
         Type: AWS::ApiGateway::Resource
         Properties:
             RestApiId: !Ref ZuoraAutoCancelAPI
             ParentId: !GetAtt [ZuoraAutoCancelAPI, RootResourceId]
-            PathPart: stripe-customer-updated
+            PathPart: stripe-customer-source-updated
         DependsOn: ZuoraAutoCancelAPI
 
-    StripeCustomerUpdatedMethod:
+    StripeCustomerSourceUpdatedMethod:
         Type: AWS::ApiGateway::Method
         Properties:
             AuthorizationType: NONE
             RestApiId: !Ref ZuoraAutoCancelAPI
-            ResourceId: !Ref StripeCustomerUpdatedProxyResource
+            ResourceId: !Ref StripeCustomerSourceUpdatedProxyResource
             HttpMethod: POST
             RequestParameters:
               method.request.header.stripe-signature: true
             Integration:
               Type: AWS_PROXY
               IntegrationHttpMethod: POST
-              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StripeCustomerUpdatedLambda.Arn}/invocations
+              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StripeCustomerSourceUpdatedLambda.Arn}/invocations
         DependsOn:
         - ZuoraAutoCancelAPI
-        - StripeCustomerUpdatedLambda
-        - StripeCustomerUpdatedProxyResource
+        - StripeCustomerSourceUpdatedLambda
+        - StripeCustomerSourceUpdatedProxyResource
 
 
     ZuoraAutoCancelAPI:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -221,7 +221,7 @@ Resources:
             ResourceId: !Ref StripeCustomerSourceUpdatedProxyResource
             HttpMethod: POST
             RequestParameters:
-              method.request.header.stripe-signature: true
+              method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
               IntegrationHttpMethod: POST

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Handles auto-cancellations for membership and subscriptions, using API Gateway and Lambda
+Description: Handles auto-cancellations for membership and subscriptions, using API Gateway and Lambda, plus stripe PM updates
 
 Parameters:
     Stage:
@@ -119,12 +119,6 @@ Resources:
             Principal: apigateway.amazonaws.com
         DependsOn: PaymentFailureLambda
 
-    ZuoraAutoCancelAPI:
-        Type: "AWS::ApiGateway::RestApi"
-        Properties:
-            Description: Zuora sends a callout to this endpoint to initiate an auto-cancellation on an overdue subscription
-            Name: !Sub ${ApiName}
-
     ZuoraAutoCancelProxyResource:
         Type: AWS::ApiGateway::Resource
         Properties:
@@ -178,6 +172,71 @@ Resources:
         - ZuoraAutoCancelAPI
         - ZuoraAutoCancelLambda
         - ZuoraAutoCancelProxyResource
+
+
+    StripeCustomerUpdatedLambda:
+        Type: AWS::Lambda::Function
+        Properties:
+            Description: Handles auto-cancellations for membership and subscriptions
+            FunctionName:
+                !Sub stripe-customer-updated-${Stage}
+            Code:
+                S3Bucket: zuora-auto-cancel-dist
+                S3Key: !Sub membership/${Stage}/zuora-auto-cancel/zuora-auto-cancel.jar
+            Handler: com.gu.stripeCustomerUpdated.Lambda::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+            Role:
+                Fn::GetAtt:
+                - ZuoraAutoCancelRole
+                - Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - ZuoraAutoCancelRole
+
+    StripeCustomerUpdatedAPIPermission:
+        Type: AWS::Lambda::Permission
+        Properties:
+            Action: lambda:invokeFunction
+            FunctionName: !Sub stripe-customer-updated-${Stage}
+            Principal: apigateway.amazonaws.com
+        DependsOn: StripeCustomerUpdatedLambda
+
+    StripeCustomerUpdatedProxyResource:
+        Type: AWS::ApiGateway::Resource
+        Properties:
+            RestApiId: !Ref ZuoraAutoCancelAPI
+            ParentId: !GetAtt [ZuoraAutoCancelAPI, RootResourceId]
+            PathPart: stripe-customer-updated
+        DependsOn: ZuoraAutoCancelAPI
+
+    StripeCustomerUpdatedMethod:
+        Type: AWS::ApiGateway::Method
+        Properties:
+            AuthorizationType: NONE
+            RestApiId: !Ref ZuoraAutoCancelAPI
+            ResourceId: !Ref StripeCustomerUpdatedProxyResource
+            HttpMethod: POST
+            RequestParameters:
+              method.request.header.stripe-signature: true
+            Integration:
+              Type: AWS_PROXY
+              IntegrationHttpMethod: POST
+              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StripeCustomerUpdatedLambda.Arn}/invocations
+        DependsOn:
+        - ZuoraAutoCancelAPI
+        - StripeCustomerUpdatedLambda
+        - StripeCustomerUpdatedProxyResource
+
+
+    ZuoraAutoCancelAPI:
+        Type: "AWS::ApiGateway::RestApi"
+        Properties:
+            Description: Zuora sends a callout to this endpoint to initiate an auto-cancellation on an overdue subscription
+            Name: !Sub ${ApiName}
 
     ZuoraAutoCancelAPIStage:
         Type: AWS::ApiGateway::Stage

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,3 +12,4 @@ deployments:
       functionNames:
       - zuora-auto-cancel-
       - payment-failure-
+      - stripe-customer-source-updated-

--- a/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -3,7 +3,7 @@ package com.gu.autoCancel
 import com.gu.util.Logging
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraModels.SubscriptionId
-import com.gu.util.zuora.{ Zuora, ZuoraDeps }
+import com.gu.util.zuora._
 import org.joda.time.LocalDate
 
 object AutoCancel extends Logging {
@@ -14,9 +14,9 @@ object AutoCancel extends Logging {
     val AutoCancelRequest(accountId, subToCancel, cancellationDate) = acRequest
     logger.info(s"Attempting to perform auto-cancellation on account: $accountId")
     val zuoraOp = for {
-      _ <- Zuora.updateCancellationReason(subToCancel).withLogging("updateCancellationReason")
-      _ <- Zuora.cancelSubscription(subToCancel, cancellationDate).withLogging("cancelSubscription")
-      _ <- Zuora.disableAutoPay(accountId).withLogging("disableAutoPay")
+      _ <- ZuoraUpdateCancellationReason(subToCancel).withLogging("updateCancellationReason")
+      _ <- ZuoraCancelSubscription(subToCancel, cancellationDate).withLogging("cancelSubscription")
+      _ <- ZuoraDisableAutoPay(accountId).withLogging("disableAutoPay")
     } yield ()
     zuoraOp.run.run(zuoraDeps)
   }

--- a/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -2,9 +2,8 @@ package com.gu.autoCancel
 
 import com.gu.util.Logging
 import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.Zuora
-import com.gu.util.zuora.Zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraModels.SubscriptionId
+import com.gu.util.zuora.{ Zuora, ZuoraDeps }
 import org.joda.time.LocalDate
 
 object AutoCancel extends Logging {

--- a/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -4,8 +4,9 @@ import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
 import com.gu.util.reader.Types.{ FailableOp, _ }
-import com.gu.util.zuora.ZuoraModels.{ AccountSummary, Invoice, SubscriptionId }
-import com.gu.util.zuora.{ Zuora, ZuoraDeps }
+import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, Invoice }
+import com.gu.util.zuora.ZuoraModels.SubscriptionId
+import com.gu.util.zuora.{ ZuoraDeps, ZuoraGetAccountSummary }
 import com.gu.util.{ Logging, ZuoraRestConfig }
 import okhttp3.{ Request, Response }
 import org.joda.time.LocalDate
@@ -25,7 +26,7 @@ object AutoCancelDataCollectionFilter extends Logging {
     def default(now: LocalDate, response: Request => Response, config: ZuoraRestConfig): ACFilterDeps = {
       ACFilterDeps(
         now,
-        Zuora.getAccountSummary,
+        ZuoraGetAccountSummary.apply,
         response,
         config
       )

--- a/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -4,9 +4,8 @@ import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
 import com.gu.util.reader.Types.{ FailableOp, _ }
-import com.gu.util.zuora.Zuora
-import com.gu.util.zuora.Zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraModels.{ AccountSummary, Invoice, SubscriptionId }
+import com.gu.util.zuora.{ Zuora, ZuoraDeps }
 import com.gu.util.{ Logging, ZuoraRestConfig }
 import okhttp3.{ Request, Response }
 import org.joda.time.LocalDate

--- a/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -8,7 +8,7 @@ import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.exacttarget.EmailRequest
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.Zuora.ZuoraDeps
+import com.gu.util.zuora.ZuoraDeps
 import com.gu.util.{ Config, Logging }
 import okhttp3.{ Request, Response }
 import org.joda.time.LocalDate

--- a/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/src/main/scala/com/gu/effects/AwsS3.scala
@@ -13,7 +13,7 @@ object ConfigLoad extends Logging {
 
   // if you are updating the config, it's hard to test it in advance of deployment
   // with this, you can upload the new config with a new name
-  val version = "2"
+  val version = "3"
 
   def load(stage: Stage): Try[String] = {
     logger.info(s"Attempting to load config in $stage")

--- a/src/main/scala/com/gu/effects/Http.scala
+++ b/src/main/scala/com/gu/effects/Http.scala
@@ -18,7 +18,7 @@ object Http extends Logging {
       val buffer = new Buffer()
       requestBody.writeTo(buffer)
       val body = buffer.readString(UTF_8)
-      body.length
+      (body.length, body.take(500) + (if (body.length > 500) "..." else ""))
     }
 
     { request: Request =>

--- a/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -3,7 +3,7 @@ package com.gu.paymentFailure
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.ZuoraModels.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
+import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
 import org.joda.time.LocalDate
 
 import scalaz.\/

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -10,8 +10,8 @@ import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget.{ EmailRequest, EmailSendSteps }
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraModels.InvoiceTransactionSummary
-import com.gu.util.zuora.{ Zuora, ZuoraDeps }
+import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
+import com.gu.util.zuora.{ ZuoraDeps, ZuoraGetInvoiceTransactions }
 import okhttp3.{ Request, Response }
 import play.api.libs.json.Json
 
@@ -76,7 +76,7 @@ object ZuoraEmailSteps {
     def default(response: Request => Response, config: Config): ZuoraEmailStepsDeps = {
       ZuoraEmailStepsDeps(
         EmailSendSteps.apply(EmailSendStepsDeps.default(config.stage, response, config.etConfig)),
-        a => Zuora.getInvoiceTransactions(a).run.run(ZuoraDeps(response, config.zuoraRestConfig))
+        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.zuoraRestConfig))
       )
     }
   }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -10,9 +10,8 @@ import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget.{ EmailRequest, EmailSendSteps }
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.Zuora
-import com.gu.util.zuora.Zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraModels.InvoiceTransactionSummary
+import com.gu.util.zuora.{ Zuora, ZuoraDeps }
 import okhttp3.{ Request, Response }
 import play.api.libs.json.Json
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -1,0 +1,31 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import java.io.{ InputStream, OutputStream }
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.effects.RawEffects
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.Deps
+import com.gu.util.Config
+import com.gu.util.apigateway.ApiGatewayHandler
+import com.gu.util.apigateway.ApiGatewayHandler.HandlerDeps
+
+object Lambda {
+
+  case class LambdaDeps(handler: (InputStream, OutputStream, Context) => Unit)
+
+  def default(rawEffects: RawEffects) =
+    LambdaDeps(
+      ApiGatewayHandler(HandlerDeps.default(rawEffects.stage, rawEffects.s3Load, { config: Config =>
+        SourceUpdatedSteps(Deps.default(rawEffects.response, config))
+      }))
+    )
+
+  // this is the entry point
+  // it's referenced by the cloudformation so make sure you keep it in step
+  // it's the only part you can't test of the handler
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    val deps = default(RawEffects.createDefault)
+    deps.handler(inputStream, outputStream, context)
+  }
+
+}

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -1,17 +1,50 @@
 package com.gu.stripeCustomerSourceUpdated
 
-import play.api.libs.json.{ JsPath, Reads }
+import play.api.libs.json.{ JsPath, Json, Reads, Writes }
+import play.api.libs.functional.syntax._
 
-case class SourceUpdatedCallout( // add here based on the format stripe sends us TODO
-  id: StripeId
-)
-case class StripeId(value: String) extends AnyVal
+case class EventData(`object`: EventDataObject)
+case class EventDataObject(id: StripeSourceId, customer: StripeCustomerId, exp_month: Int, exp_year: Int, last4: String)
+case class SourceUpdatedCallout(id: StripeEventId, data: EventData)
+
+case class StripeEventId(value: String) extends AnyVal
+case class StripeCustomerId(value: String) extends AnyVal
+case class StripeSourceId(value: String) extends AnyVal
 
 object SourceUpdatedCallout {
 
-  implicit val jf: Reads[SourceUpdatedCallout] = {
-    (
-      (JsPath \ "id").read[String].map(StripeId.apply)
-    ).map(SourceUpdatedCallout.apply _)
+  implicit val stripeEventIdReads = Json.reads[StripeEventId]
+  implicit val stripeCustomerIdReads = Json.reads[StripeCustomerId]
+  implicit val stripeSourceIdReads = Json.reads[StripeSourceId]
+
+  implicit val stripeEventIdWrites = new Writes[StripeEventId] {
+    def writes(se: StripeEventId) = Json.toJson(se.value)
   }
+
+  implicit val stripeCustomerIdWrites = new Writes[StripeCustomerId] {
+    def writes(sc: StripeCustomerId) = Json.toJson(sc.value)
+  }
+
+  implicit val stripeSourceIdWrites = new Writes[StripeSourceId] {
+    def writes(sc: StripeSourceId) = Json.toJson(sc.value)
+  }
+
+  implicit val eventDataObjectReads: Reads[EventDataObject] = (
+    (JsPath \ "id").read[String].map(StripeSourceId.apply) and
+    (JsPath \ "customer").read[String].map(StripeCustomerId.apply) and
+    (JsPath \ "exp_month").read[Int] and
+    (JsPath \ "exp_year").read[Int] and
+    (JsPath \ "last4").read[String]
+  )(EventDataObject.apply _)
+
+  implicit val eventDataReads: Reads[EventData] = (JsPath \ "object").read[EventDataObject].map(EventData.apply _)
+
+  implicit val jf: Reads[SourceUpdatedCallout] = (
+    (JsPath \ "id").read[String].map(StripeEventId.apply) and
+    (JsPath \ "data").read[EventData]
+  )(SourceUpdatedCallout.apply _)
+
+  implicit val eventDataObjectWrites: Writes[EventDataObject] = Json.writes[EventDataObject]
+  implicit val eventDataWrites: Writes[EventData] = Json.writes[EventData]
+  implicit val jfWrites: Writes[SourceUpdatedCallout] = Json.writes[SourceUpdatedCallout]
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -1,0 +1,17 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import play.api.libs.json.{ JsPath, Reads }
+
+case class SourceUpdatedCallout( // add here based on the format stripe sends us TODO
+  id: StripeId
+)
+case class StripeId(value: String) extends AnyVal
+
+object SourceUpdatedCallout {
+
+  implicit val jf: Reads[SourceUpdatedCallout] = {
+    (
+      (JsPath \ "id").read[String].map(StripeId.apply)
+    ).map(SourceUpdatedCallout.apply _)
+  }
+}

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -4,7 +4,7 @@ import play.api.libs.json.{ JsPath, Json, Reads, Writes }
 import play.api.libs.functional.syntax._
 
 case class EventData(`object`: EventDataObject)
-case class EventDataObject(id: StripeSourceId, customer: StripeCustomerId, exp_month: Int, exp_year: Int, last4: String)
+case class EventDataObject(id: StripeSourceId, brand: String, country: String, customer: StripeCustomerId, exp_month: Int, exp_year: Int, last4: String)
 case class SourceUpdatedCallout(id: StripeEventId, data: EventData)
 
 case class StripeEventId(value: String) extends AnyVal
@@ -31,6 +31,8 @@ object SourceUpdatedCallout {
 
   implicit val eventDataObjectReads: Reads[EventDataObject] = (
     (JsPath \ "id").read[String].map(StripeSourceId.apply) and
+    (JsPath \ "brand").read[String] and
+    (JsPath \ "country").read[String] and
     (JsPath \ "customer").read[String].map(StripeCustomerId.apply) and
     (JsPath \ "exp_month").read[Int] and
     (JsPath \ "exp_year").read[Int] and

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -1,12 +1,12 @@
 package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.util._
-import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.CreatePaymentMethod.{CreateStripePaymentMethod, CreditCardType}
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.{AccountId, PaymentMethodId}
+import com.gu.util.zuora.CreatePaymentMethod.{ CreateStripePaymentMethod, CreditCardType }
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora._
-import okhttp3.{Request, Response}
+import okhttp3.{ Request, Response }
 import play.api.libs.json.Json
 
 import scalaz._
@@ -18,6 +18,7 @@ object SourceUpdatedSteps extends Logging {
   def apply(deps: Deps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     (for {
       sourceUpdatedCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("fromJson SourceUpdatedCallout").pure[WithDeps].toEitherT
+      _ = logger.info(s"from: ${apiGatewayRequest.queryStringParameters.map(_.stripeAccount)}")
       accountId <- getAccountToUpdate(sourceUpdatedCallout.data.`object`.customer, sourceUpdatedCallout.data.`object`.id)
       _ <- updatePaymentMethod(accountId, sourceUpdatedCallout.data.`object`)
     } yield ()).run.run(deps.zuoraDeps)

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -1,0 +1,27 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import com.gu.util._
+import com.gu.util.apigateway.ApiGatewayRequest
+import com.gu.util.reader.Types._
+import okhttp3.{ Request, Response }
+import play.api.libs.json.Json
+
+object SourceUpdatedSteps extends Logging {
+
+  def apply(deps: Deps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
+    for {
+      paymentFailureCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp
+      _ = logger.info(s"received $paymentFailureCallout")
+      // TODO... write to zuora
+    } yield ()
+  }
+
+  object Deps {
+    def default(response: Request => Response, config: Config): Deps = {
+      Deps()
+    }
+  }
+
+  case class Deps()
+
+}

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -1,10 +1,16 @@
 package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.util._
-import com.gu.util.apigateway.ApiGatewayRequest
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types._
-import okhttp3.{ Request, Response }
+import com.gu.util.zuora.{Zuora, ZuoraQueryPaymentMethod}
+import okhttp3.{Request, Response}
 import play.api.libs.json.Json
+import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraModels.PaymentMethod
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.PaymentMethodId
+
+import scalaz.{-\/, Kleisli, NonEmptyList, Reader, \/-}
 
 object SourceUpdatedSteps extends Logging {
 
@@ -14,12 +20,29 @@ object SourceUpdatedSteps extends Logging {
       _ = logger.info(s"received $paymentFailureCallout")
       // TODO... similar to AccountController.updateCard in members-data-api
       // query zuora for account and payment method given the token id
+      paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(paymentFailureCallout.data.`object`.customer)
+      account <- Zuora.getAccountSummary(paymentMethods.accountId.value)
       // make sure the tokens relate to the default payment method
-      // check that the account payment gateway matches the stripe payment gateway
-      // (clear default payment method and autopay off - may not be needed)
+      _ <- Reader(_ => skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds)).toEitherT
+      // check that the account payment gateway matches (which?) stripe payment gateway (do we even need to do this? if it's the default, it must be right)
+      //...
+      // (clear default payment method and autopay off not needed because we are not changing the payment gateway)
+      // would be nice to have to know which stripe called us, and check the gateway matches
+      //...
       // create payment method with accountid, cardid, customerid, last4, cardcountry, expiry, cardtype
+      //TODO similar to ZuoraService.createPaymentMethod only in REST api
       // set payment method as the default - update account defaultpaymentmethodid
     } yield ()
+  }
+
+  def skipIfNotDefault(defaultPaymentMethod: PaymentMethod, paymentMethodIds: NonEmptyList[PaymentMethodId]): FailableOp[Unit] = {
+    if (paymentMethodIds.list.contains(defaultPaymentMethod.id)) {
+      // this card update event relates to a the default payment method - continue
+      \/-(())
+    } else {
+      // the card is updating some NON default payment method - ignore (or should we update anyway but keep it in the background?)
+      -\/(ApiGatewayResponse.successfulExecution)
+    }
   }
 
   object Deps {
@@ -31,3 +54,4 @@ object SourceUpdatedSteps extends Logging {
   case class Deps()
 
 }
+

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -1,29 +1,31 @@
 package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.util._
-import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.{Zuora, ZuoraQueryPaymentMethod}
-import okhttp3.{Request, Response}
-import play.api.libs.json.Json
-import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraModels.PaymentMethod
+import com.gu.util.zuora.CreatePaymentMethod.{ CreateStripePaymentMethod, CreditCardType }
+import com.gu.util.zuora.ZuoraModels.AccountSummary
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.PaymentMethodId
+import com.gu.util.zuora._
+import okhttp3.{ Request, Response }
+import play.api.libs.json.Json
 
-import scalaz.{-\/, Kleisli, NonEmptyList, Reader, \/-}
+import scalaz._
+import scalaz.syntax.applicative._
+import scalaz.syntax.std.option._
 
 object SourceUpdatedSteps extends Logging {
 
   def apply(deps: Deps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
-    for {
-      paymentFailureCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp
+    (for {
+      paymentFailureCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.pure[WithDeps].toEitherT
       _ = logger.info(s"received $paymentFailureCallout")
       // TODO... similar to AccountController.updateCard in members-data-api
       // query zuora for account and payment method given the token id
       paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(paymentFailureCallout.data.`object`.customer)
       account <- Zuora.getAccountSummary(paymentMethods.accountId.value)
       // make sure the tokens relate to the default payment method
-      _ <- Reader(_ => skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds)).toEitherT
+      _ <- skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds).pure[WithDeps].toEitherT
       // check that the account payment gateway matches (which?) stripe payment gateway (do we even need to do this? if it's the default, it must be right)
       //...
       // (clear default payment method and autopay off not needed because we are not changing the payment gateway)
@@ -31,12 +33,38 @@ object SourceUpdatedSteps extends Logging {
       //...
       // create payment method with accountid, cardid, customerid, last4, cardcountry, expiry, cardtype
       //TODO similar to ZuoraService.createPaymentMethod only in REST api
+      paymentMethod <- createPaymentMethod(paymentFailureCallout, account)
       // set payment method as the default - update account defaultpaymentmethodid
-    } yield ()
+      _ <- SetDefaultPaymentMethod.setDefaultPaymentMethod(account.basicInfo.id, paymentMethod.id)
+    } yield ()).run.run(ZuoraDeps(deps.response, deps.config))
   }
 
-  def skipIfNotDefault(defaultPaymentMethod: PaymentMethod, paymentMethodIds: NonEmptyList[PaymentMethodId]): FailableOp[Unit] = {
-    if (paymentMethodIds.list.contains(defaultPaymentMethod.id)) {
+  import com.gu.util.reader.Types._
+
+  type WithDeps[A] = Reader[ZuoraDeps, A]
+
+  def createPaymentMethod(callout: SourceUpdatedCallout, account: AccountSummary): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethod.CreatePaymentMethodResult] = {
+    for {
+      creditCardType <- Some(callout.data.`object`.brand).collect {
+        case StripeBrand.Visa => CreditCardType.Visa
+        case StripeBrand.Discover => CreditCardType.Discover
+        case StripeBrand.MasterCard => CreditCardType.MasterCard
+        case StripeBrand.AmericanExpress => CreditCardType.AmericanExpress
+      }.toRightDisjunction(ApiGatewayResponse.internalServerError(s"not valid card type for zuora: ${callout.data.`object`.brand}")).pure[WithDeps].toEitherT
+      result <- CreatePaymentMethod.createPaymentMethod(CreateStripePaymentMethod(
+        account.basicInfo.id,
+        callout.data.`object`.id,
+        callout.data.`object`.customer,
+        callout.data.`object`.country,
+        callout.data.`object`.last4,
+        callout.data.`object`.expiry,
+        creditCardType
+      ))
+    } yield result
+  }
+
+  def skipIfNotDefault(defaultPaymentMethod: PaymentMethodId, paymentMethodIds: NonEmptyList[PaymentMethodId]): FailableOp[Unit] = {
+    if (paymentMethodIds.list.contains(defaultPaymentMethod)) {
       // this card update event relates to a the default payment method - continue
       \/-(())
     } else {
@@ -47,11 +75,11 @@ object SourceUpdatedSteps extends Logging {
 
   object Deps {
     def default(response: Request => Response, config: Config): Deps = {
-      Deps()
+      Deps(response, config.zuoraRestConfig)
     }
   }
 
-  case class Deps()
+  case class Deps(response: Request => Response, config: ZuoraRestConfig)
 
 }
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -1,13 +1,12 @@
 package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.util._
-import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.CreatePaymentMethod.{ CreateStripePaymentMethod, CreditCardType }
-import com.gu.util.zuora.ZuoraModels.AccountSummary
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.CreatePaymentMethod.{CreateStripePaymentMethod, CreditCardType}
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{AccountId, PaymentMethodId}
 import com.gu.util.zuora._
-import okhttp3.{ Request, Response }
+import okhttp3.{Request, Response}
 import play.api.libs.json.Json
 
 import scalaz._
@@ -18,33 +17,32 @@ object SourceUpdatedSteps extends Logging {
 
   def apply(deps: Deps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     (for {
-      sourceUpdatedCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.pure[WithDeps].toEitherT
-      _ = logger.info(s"received source updated: $sourceUpdatedCallout")
+      sourceUpdatedCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("fromJson SourceUpdatedCallout").pure[WithDeps].toEitherT
       accountId <- getAccountToUpdate(sourceUpdatedCallout.data.`object`.customer, sourceUpdatedCallout.data.`object`.id)
       _ <- updatePaymentMethod(accountId, sourceUpdatedCallout.data.`object`)
     } yield ()).run.run(deps.zuoraDeps)
   }
 
-  def updatePaymentMethod(accountId: AccountId, eventDataObject: EventDataObject) = {
+  def updatePaymentMethod(accountId: AccountId, eventDataObject: EventDataObject): WithDepsFailableOp[ZuoraDeps, Unit] = {
     for {
       // (clear default payment method and autopay off not needed because we are not changing the payment gateway)
       // would be nice to have to know which stripe called us, and check the gateway matches
       //...
       // create payment method with accountid, cardid, customerid, last4, cardcountry, expiry, cardtype
       // similar to ZuoraService.createPaymentMethod only in REST api
-      paymentMethod <- createPaymentMethod(eventDataObject, accountId)
+      paymentMethod <- createPaymentMethod(eventDataObject, accountId).withLogging("createPaymentMethod")
       // set payment method as the default - update account defaultpaymentmethodid
-      _ <- SetDefaultPaymentMethod.setDefaultPaymentMethod(accountId, paymentMethod.id)
+      _ <- SetDefaultPaymentMethod.setDefaultPaymentMethod(accountId, paymentMethod.id).withLogging("setDefaultPaymentMethod")
     } yield ()
   }
 
-  def getAccountToUpdate(customer: StripeCustomerId, source: StripeSourceId) = {
+  def getAccountToUpdate(customer: StripeCustomerId, source: StripeSourceId): WithDepsFailableOp[ZuoraDeps, AccountId] = {
     for { // similar to AccountController.updateCard in members-data-api
       // query zuora for account and payment method given the token id
-      paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(customer, source)
-      account <- Zuora.getAccountSummary(paymentMethods.accountId.value)
+      paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(customer, source).withLogging("getPaymentMethodForStripeCustomer")
+      account <- Zuora.getAccountSummary(paymentMethods.accountId.value).withLogging("getAccountSummary")
       // make sure the tokens relate to the default payment method
-      _ <- skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds).pure[WithDeps].toEitherT
+      _ <- skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds).withLogging("skipIfNotDefault").pure[WithDeps].toEitherT
       // check that the account payment gateway matches (which?) stripe payment gateway (do we even need to do this? if it's the default, it must be right)
       //...
     } yield account.basicInfo.id

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -12,7 +12,13 @@ object SourceUpdatedSteps extends Logging {
     for {
       paymentFailureCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp
       _ = logger.info(s"received $paymentFailureCallout")
-      // TODO... write to zuora
+      // TODO... similar to AccountController.updateCard in members-data-api
+      // query zuora for account and payment method given the token id
+      // make sure the tokens relate to the default payment method
+      // check that the account payment gateway matches the stripe payment gateway
+      // (clear default payment method and autopay off - may not be needed)
+      // create payment method with accountid, cardid, customerid, last4, cardcountry, expiry, cardtype
+      // set payment method as the default - update account defaultpaymentmethodid
     } yield ()
   }
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -5,7 +5,7 @@ import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.CreatePaymentMethod.{ CreateStripePaymentMethod, CreditCardType }
 import com.gu.util.zuora.ZuoraModels.AccountSummary
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.PaymentMethodId
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora._
 import okhttp3.{ Request, Response }
 import play.api.libs.json.Json
@@ -20,44 +20,55 @@ object SourceUpdatedSteps extends Logging {
     (for {
       paymentFailureCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.pure[WithDeps].toEitherT
       _ = logger.info(s"received $paymentFailureCallout")
-      // TODO... similar to AccountController.updateCard in members-data-api
+      accountId <- getAccountToUpdate(paymentFailureCallout.data.`object`.customer, paymentFailureCallout.data.`object`.id)
+      _ <- updatePaymentMethod(accountId, paymentFailureCallout.data.`object`)
+    } yield ()).run.run(deps.zuoraDeps)
+  }
+
+  def updatePaymentMethod(accountId: AccountId, eventDataObject: EventDataObject) = {
+    for {
+      // (clear default payment method and autopay off not needed because we are not changing the payment gateway)
+      // would be nice to have to know which stripe called us, and check the gateway matches
+      //...
+      // create payment method with accountid, cardid, customerid, last4, cardcountry, expiry, cardtype
+      // similar to ZuoraService.createPaymentMethod only in REST api
+      paymentMethod <- createPaymentMethod(eventDataObject, accountId)
+      // set payment method as the default - update account defaultpaymentmethodid
+      _ <- SetDefaultPaymentMethod.setDefaultPaymentMethod(accountId, paymentMethod.id)
+    } yield ()
+  }
+
+  def getAccountToUpdate(customer: StripeCustomerId, source: StripeSourceId) = {
+    for { // similar to AccountController.updateCard in members-data-api
       // query zuora for account and payment method given the token id
-      paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(paymentFailureCallout.data.`object`.customer)
+      paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(customer, source)
       account <- Zuora.getAccountSummary(paymentMethods.accountId.value)
       // make sure the tokens relate to the default payment method
       _ <- skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds).pure[WithDeps].toEitherT
       // check that the account payment gateway matches (which?) stripe payment gateway (do we even need to do this? if it's the default, it must be right)
       //...
-      // (clear default payment method and autopay off not needed because we are not changing the payment gateway)
-      // would be nice to have to know which stripe called us, and check the gateway matches
-      //...
-      // create payment method with accountid, cardid, customerid, last4, cardcountry, expiry, cardtype
-      //TODO similar to ZuoraService.createPaymentMethod only in REST api
-      paymentMethod <- createPaymentMethod(paymentFailureCallout, account)
-      // set payment method as the default - update account defaultpaymentmethodid
-      _ <- SetDefaultPaymentMethod.setDefaultPaymentMethod(account.basicInfo.id, paymentMethod.id)
-    } yield ()).run.run(ZuoraDeps(deps.response, deps.config))
+    } yield account.basicInfo.id
   }
 
   import com.gu.util.reader.Types._
 
   type WithDeps[A] = Reader[ZuoraDeps, A]
 
-  def createPaymentMethod(callout: SourceUpdatedCallout, account: AccountSummary): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethod.CreatePaymentMethodResult] = {
+  def createPaymentMethod(eventDataObject: EventDataObject, accountId: AccountId): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethod.CreatePaymentMethodResult] = {
     for {
-      creditCardType <- Some(callout.data.`object`.brand).collect {
+      creditCardType <- Some(eventDataObject.brand).collect {
         case StripeBrand.Visa => CreditCardType.Visa
         case StripeBrand.Discover => CreditCardType.Discover
         case StripeBrand.MasterCard => CreditCardType.MasterCard
         case StripeBrand.AmericanExpress => CreditCardType.AmericanExpress
-      }.toRightDisjunction(ApiGatewayResponse.internalServerError(s"not valid card type for zuora: ${callout.data.`object`.brand}")).pure[WithDeps].toEitherT
+      }.toRightDisjunction(ApiGatewayResponse.internalServerError(s"not valid card type for zuora: ${eventDataObject.brand}")).pure[WithDeps].toEitherT
       result <- CreatePaymentMethod.createPaymentMethod(CreateStripePaymentMethod(
-        account.basicInfo.id,
-        callout.data.`object`.id,
-        callout.data.`object`.customer,
-        callout.data.`object`.country,
-        callout.data.`object`.last4,
-        callout.data.`object`.expiry,
+        accountId,
+        eventDataObject.id,
+        eventDataObject.customer,
+        eventDataObject.country,
+        eventDataObject.last4,
+        eventDataObject.expiry,
         creditCardType
       ))
     } yield result
@@ -75,11 +86,11 @@ object SourceUpdatedSteps extends Logging {
 
   object Deps {
     def default(response: Request => Response, config: Config): Deps = {
-      Deps(response, config.zuoraRestConfig)
+      Deps(ZuoraDeps(response, config.zuoraRestConfig))
     }
   }
 
-  case class Deps(response: Request => Response, config: ZuoraRestConfig)
+  case class Deps(zuoraDeps: ZuoraDeps)
 
 }
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -41,7 +41,7 @@ object SourceUpdatedSteps extends Logging {
     for { // similar to AccountController.updateCard in members-data-api
       // query zuora for account and payment method given the token id
       paymentMethods <- ZuoraQueryPaymentMethod.getPaymentMethodForStripeCustomer(customer, source).withLogging("getPaymentMethodForStripeCustomer")
-      account <- Zuora.getAccountSummary(paymentMethods.accountId.value).withLogging("getAccountSummary")
+      account <- ZuoraGetAccountSummary(paymentMethods.accountId.value).withLogging("getAccountSummary")
       // make sure the tokens relate to the default payment method
       _ <- skipIfNotDefault(account.basicInfo.defaultPaymentMethod, paymentMethods.paymentMethodIds).withLogging("skipIfNotDefault").pure[WithDeps].toEitherT
       // check that the account payment gateway matches (which?) stripe payment gateway (do we even need to do this? if it's the default, it must be right)

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -18,10 +18,10 @@ object SourceUpdatedSteps extends Logging {
 
   def apply(deps: Deps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     (for {
-      paymentFailureCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.pure[WithDeps].toEitherT
-      _ = logger.info(s"received $paymentFailureCallout")
-      accountId <- getAccountToUpdate(paymentFailureCallout.data.`object`.customer, paymentFailureCallout.data.`object`.id)
-      _ <- updatePaymentMethod(accountId, paymentFailureCallout.data.`object`)
+      sourceUpdatedCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.pure[WithDeps].toEitherT
+      _ = logger.info(s"received source updated: $sourceUpdatedCallout")
+      accountId <- getAccountToUpdate(sourceUpdatedCallout.data.`object`.customer, sourceUpdatedCallout.data.`object`.id)
+      _ <- updatePaymentMethod(accountId, sourceUpdatedCallout.data.`object`)
     } yield ()).run.run(deps.zuoraDeps)
   }
 

--- a/src/main/scala/com/gu/util/Auth.scala
+++ b/src/main/scala/com/gu/util/Auth.scala
@@ -6,8 +6,7 @@ object Auth extends Logging {
 
   def credentialsAreValid(requestAuth: Option[RequestAuth], trustedApiConfig: TrustedApiConfig): Boolean =
     requestAuth.exists { requestAuth =>
-      requestAuth.apiClientId == trustedApiConfig.apiClientId &&
-        requestAuth.apiToken == trustedApiConfig.apiToken
+      requestAuth.apiToken == trustedApiConfig.apiToken
     }
 
   // Ensure that the correct Zuora environment is hitting the API

--- a/src/main/scala/com/gu/util/ConfigLoader.scala
+++ b/src/main/scala/com/gu/util/ConfigLoader.scala
@@ -57,11 +57,10 @@ object ETConfig {
   )(ETConfig.apply _)
 }
 
-case class TrustedApiConfig(apiClientId: String, apiToken: String, tenantId: String)
+case class TrustedApiConfig(apiToken: String, tenantId: String)
 
 object TrustedApiConfig {
   implicit val apiConfigReads: Reads[TrustedApiConfig] = (
-    (JsPath \ "apiClientId").read[String] and
     (JsPath \ "apiToken").read[String] and
     (JsPath \ "tenantId").read[String]
   )(TrustedApiConfig.apply _)

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -8,7 +8,6 @@ import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayResponse.{ outputForAPIGateway, successfulExecution, unauthorized }
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.reader.Types._
-import okhttp3.{ Request, Response }
 import play.api.libs.json.Json
 
 import scala.io.Source

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -22,7 +22,7 @@ case class URLParams(apiToken: Option[String], onlyCancelDirectDebit: Boolean, s
 /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
   header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
   */
-case class ApiGatewayRequest(queryStringParameters: Option[URLParams], body: String) {
+case class ApiGatewayRequest(queryStringParameters: Option[URLParams], body: String, headers: Option[Map[String, String]]) {
   def onlyCancelDirectDebit: Boolean = queryStringParameters.exists(_.onlyCancelDirectDebit)
   def requestAuth: Option[RequestAuth] =
     for {
@@ -34,8 +34,8 @@ case class ApiGatewayRequest(queryStringParameters: Option[URLParams], body: Str
 object URLParams {
   implicit val jf = (
     (JsPath \ "apiToken").readNullable[String] and
-      (JsPath \ "onlyCancelDirectDebit").readNullable[String].map(_.contains("true")) and
-      (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString))
+    (JsPath \ "onlyCancelDirectDebit").readNullable[String].map(_.contains("true")) and
+    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString))
   )(URLParams.apply _)
 }
 

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -1,15 +1,29 @@
 package com.gu.util.apigateway
 
-import play.api.libs.json.Json
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
 
 case class RequestAuth(apiToken: String)
-case class URLParams(apiToken: Option[String], onlyCancelDirectDebit: Option[String])
+
+sealed abstract class StripeAccount(val string: String)
+object StripeAccount {
+  case object GNM_Membership_AUS extends StripeAccount("GNM_Membership_AUS")
+  case object GNM_Membership extends StripeAccount("GNM_Membership")
+  val all = Seq(GNM_Membership, GNM_Membership_AUS)
+
+  def fromString(string: String): Option[StripeAccount] = {
+    all.find(_.string == string)
+  }
+
+  implicit val reads: Reads[StripeAccount] = JsPath.read[String].map(fromString(_).get)
+}
+case class URLParams(apiToken: Option[String], onlyCancelDirectDebit: Boolean, stripeAccount: Option[StripeAccount])
 
 /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
   header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
   */
 case class ApiGatewayRequest(queryStringParameters: Option[URLParams], body: String) {
-  def onlyCancelDirectDebit: Boolean = queryStringParameters.exists(_.onlyCancelDirectDebit.contains("true"))
+  def onlyCancelDirectDebit: Boolean = queryStringParameters.exists(_.onlyCancelDirectDebit)
   def requestAuth: Option[RequestAuth] =
     for {
       queryStringParameters <- queryStringParameters
@@ -18,7 +32,11 @@ case class ApiGatewayRequest(queryStringParameters: Option[URLParams], body: Str
 }
 
 object URLParams {
-  implicit val jf = Json.reads[URLParams]
+  implicit val jf = (
+    (JsPath \ "apiToken").readNullable[String] and
+      (JsPath \ "onlyCancelDirectDebit").readNullable[String].map(_.contains("true")) and
+      (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString))
+  )(URLParams.apply _)
 }
 
 object ApiGatewayRequest {

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -2,8 +2,8 @@ package com.gu.util.apigateway
 
 import play.api.libs.json.Json
 
-case class RequestAuth(apiClientId: String, apiToken: String)
-case class URLParams(apiClientId: Option[String], apiToken: Option[String], onlyCancelDirectDebit: Option[String])
+case class RequestAuth(apiToken: String)
+case class URLParams(apiToken: Option[String], onlyCancelDirectDebit: Option[String])
 
 /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
   header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
@@ -13,9 +13,8 @@ case class ApiGatewayRequest(queryStringParameters: Option[URLParams], body: Str
   def requestAuth: Option[RequestAuth] =
     for {
       queryStringParameters <- queryStringParameters
-      apiClientId <- queryStringParameters.apiClientId
       apiToken <- queryStringParameters.apiToken
-    } yield RequestAuth(apiClientId, apiToken)
+    } yield RequestAuth(apiToken)
 }
 
 object URLParams {

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -1,7 +1,7 @@
 package com.gu.util.apigateway
 
-import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
 case class RequestAuth(apiToken: String)
 

--- a/src/main/scala/com/gu/util/zuora/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/CreatePaymentMethod.scala
@@ -1,0 +1,53 @@
+package com.gu.util.zuora
+
+import com.gu.stripeCustomerSourceUpdated._
+import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraRestRequestMaker.post
+import play.api.libs.json.{ JsPath, Json, Reads, Writes }
+
+object CreatePaymentMethod {
+
+  case class CreateStripePaymentMethod(
+    accountId: AccountId,
+    cardId: StripeSourceId,
+    customerId: StripeCustomerId,
+    cardCountry: StripeCountry,
+    last4: StripeLast4,
+    expiration: StripeExpiry,
+    creditCardType: CreditCardType
+  )
+
+  sealed abstract class CreditCardType(val value: String)
+  object CreditCardType {
+
+    case object AmericanExpress extends CreditCardType("AmericanExpress")
+    case object Discover extends CreditCardType("Discover")
+    case object MasterCard extends CreditCardType("MasterCard")
+    case object Visa extends CreditCardType("Visa")
+
+  }
+
+  implicit val writes = new Writes[CreateStripePaymentMethod] {
+    def writes(command: CreateStripePaymentMethod) = Json.obj(
+      "AccountId" -> command.accountId.value,
+      "TokenId" -> command.cardId.value,
+      "SecondTokenId" -> command.customerId.value,
+      "CreditCardCountry" -> command.cardCountry.value,
+      "CreditCardNumber" -> command.last4.value,
+      "CreditCardExpirationYear" -> command.expiration.exp_month,
+      "CreditCardExpirationYear" -> command.expiration.exp_year,
+      "CreditCardType" -> command.creditCardType.value,
+      "Type" -> "CreditCardReferenceTransaction"
+    )
+  }
+
+  implicit val reads: Reads[CreatePaymentMethodResult] =
+    (JsPath \ "Id").read[PaymentMethodId].map(CreatePaymentMethodResult.apply _)
+
+  case class CreatePaymentMethodResult(id: PaymentMethodId)
+
+  def createPaymentMethod(request: CreateStripePaymentMethod): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethodResult] =
+    post[CreateStripePaymentMethod, CreatePaymentMethodResult](request, s"object/payment-method")
+
+}

--- a/src/main/scala/com/gu/util/zuora/SetDefaultPaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/SetDefaultPaymentMethod.scala
@@ -1,0 +1,22 @@
+package com.gu.util.zuora
+
+import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraReaders.unitReads
+import com.gu.util.zuora.ZuoraRestRequestMaker.put
+import play.api.libs.json.{ Json, Writes }
+
+object SetDefaultPaymentMethod {
+
+  case class SetDefaultPaymentMethod(paymentMethodId: PaymentMethodId)
+
+  implicit val writes = new Writes[SetDefaultPaymentMethod] {
+    def writes(subscriptionUpdate: SetDefaultPaymentMethod) = Json.obj(
+      "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId
+    )
+  }
+
+  def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId): WithDepsFailableOp[ZuoraDeps, Unit] =
+    put(SetDefaultPaymentMethod(paymentMethodId), s"object/account/${accountId.value}")
+
+}

--- a/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -110,7 +110,8 @@ object CreatePaymentMethod {
       "CreditCardNumber" -> command.last4.value,
       "CreditCardExpirationYear" -> command.expiration.exp_month,
       "CreditCardExpirationYear" -> command.expiration.exp_year,
-      "CreditCardType" -> command.creditCardType.value
+      "CreditCardType" -> command.creditCardType.value,
+      "Type" -> "CreditCardReferenceTransaction"
     )
   }
 

--- a/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -1,169 +1,138 @@
 package com.gu.util.zuora
 
-import com.gu.stripeCustomerSourceUpdated.{ StripeCustomerId, _ }
 import com.gu.util.ZuoraRestConfig
-import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.WithDepsFailableOp
-import com.gu.util.zuora.Zuora.Query
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora.ZuoraReaders._
-import com.gu.util.zuora.ZuoraWriters._
 import com.gu.util.zuora.ZuoraRestRequestMaker._
 import okhttp3.{ Request, Response }
 import org.joda.time.LocalDate
 import play.api.libs.functional.syntax._
-import play.api.libs.json._
-
-import scalaz.{ -\/, NonEmptyList, \/-, _ }
+import play.api.libs.json.{ JsPath, Json, Reads, Writes }
 
 case class ZuoraDeps(response: Request => Response, config: ZuoraRestConfig)
 
-object Zuora {
+object ZuoraGetAccountSummary {
 
-  def getAccountSummary(accountId: String): WithDepsFailableOp[ZuoraDeps, AccountSummary] =
+  case class BasicAccountInfo(id: AccountId, balance: Double, defaultPaymentMethod: PaymentMethodId)
+
+  case class SubscriptionSummary(id: SubscriptionId, subscriptionNumber: String, status: String)
+
+  case class Invoice(id: String, dueDate: LocalDate, balance: Double, status: String)
+
+  case class AccountSummary(basicInfo: BasicAccountInfo, subscriptions: List[SubscriptionSummary], invoices: List[Invoice])
+
+  implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
+    (JsPath \ "id").read[String].map(AccountId.apply) and
+    (JsPath \ "balance").read[Double] and
+    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId]
+  )(BasicAccountInfo.apply _)
+
+  implicit val invoiceReads: Reads[Invoice] = (
+    (JsPath \ "id").read[String] and
+    (JsPath \ "dueDate").read[LocalDate] and
+    (JsPath \ "balance").read[Double] and
+    (JsPath \ "status").read[String]
+  )(Invoice.apply _)
+
+  implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (
+    (JsPath \ "id").read[String].map(SubscriptionId.apply) and
+    (JsPath \ "subscriptionNumber").read[String] and
+    (JsPath \ "status").read[String]
+  )(SubscriptionSummary.apply _)
+
+  implicit val accountSummaryReads: Reads[AccountSummary] = (
+    (JsPath \ "basicInfo").read[BasicAccountInfo] and
+    (JsPath \ "subscriptions").read[List[SubscriptionSummary]] and
+    (JsPath \ "invoices").read[List[Invoice]]
+  )(AccountSummary.apply _)
+
+  def apply(accountId: String): WithDepsFailableOp[ZuoraDeps, AccountSummary] =
     get[AccountSummary](s"accounts/$accountId/summary")
 
-  def getInvoiceTransactions(accountId: String): WithDepsFailableOp[ZuoraDeps, InvoiceTransactionSummary] =
+}
+
+object ZuoraGetInvoiceTransactions {
+  case class InvoiceItem(id: String, subscriptionName: String, serviceStartDate: LocalDate, serviceEndDate: LocalDate, chargeAmount: Double, chargeName: String, productName: String)
+
+  case class ItemisedInvoice(id: String, invoiceDate: LocalDate, amount: Double, balance: Double, status: String, invoiceItems: List[InvoiceItem])
+
+  case class InvoiceTransactionSummary(invoices: List[ItemisedInvoice])
+
+  implicit val invoiceItemReads: Reads[InvoiceItem] = (
+    (JsPath \ "id").read[String] and
+    (JsPath \ "subscriptionName").read[String] and
+    (JsPath \ "serviceStartDate").read[LocalDate] and
+    (JsPath \ "serviceEndDate").read[LocalDate] and
+    (JsPath \ "chargeAmount").read[Double] and
+    (JsPath \ "chargeName").read[String] and
+    (JsPath \ "productName").read[String]
+  )(InvoiceItem.apply _)
+
+  implicit val itemisedInvoiceReads: Reads[ItemisedInvoice] = (
+    (JsPath \ "id").read[String] and
+    (JsPath \ "invoiceDate").read[LocalDate] and
+    (JsPath \ "amount").read[Double] and
+    (JsPath \ "balance").read[Double] and
+    (JsPath \ "status").read[String] and
+    (JsPath \ "invoiceItems").read[List[InvoiceItem]]
+  )(ItemisedInvoice.apply _)
+
+  implicit val invoiceTransactionSummaryReads: Reads[InvoiceTransactionSummary] =
+    (JsPath \ "invoices").read[List[ItemisedInvoice]].map {
+      invoices => InvoiceTransactionSummary(invoices)
+    }
+
+  def apply(accountId: String): WithDepsFailableOp[ZuoraDeps, InvoiceTransactionSummary] =
     get[InvoiceTransactionSummary](s"transactions/invoices/accounts/$accountId")
 
-  def cancelSubscription(subscription: SubscriptionId, cancellationDate: LocalDate): WithDepsFailableOp[ZuoraDeps, Unit] =
+}
+
+object ZuoraCancelSubscription {
+
+  case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
+
+  implicit val subscriptionCancellationWrites = new Writes[SubscriptionCancellation] {
+    def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
+      "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
+      "cancellationPolicy" -> "SpecificDate",
+      "invoiceCollect" -> false
+    )
+  }
+
+  def apply(subscription: SubscriptionId, cancellationDate: LocalDate): WithDepsFailableOp[ZuoraDeps, Unit] =
     put(SubscriptionCancellation(cancellationDate), s"subscriptions/${subscription.id}/cancel")
 
-  def updateCancellationReason(subscription: SubscriptionId): WithDepsFailableOp[ZuoraDeps, Unit] =
+}
+
+object ZuoraUpdateCancellationReason {
+
+  case class SubscriptionUpdate(cancellationReason: String)
+
+  implicit val subscriptionUpdateWrites = new Writes[SubscriptionUpdate] {
+    def writes(subscriptionUpdate: SubscriptionUpdate) = Json.obj(
+      "CancellationReason__c" -> subscriptionUpdate.cancellationReason
+    )
+  }
+
+  def apply(subscription: SubscriptionId): WithDepsFailableOp[ZuoraDeps, Unit] =
     put(SubscriptionUpdate("System AutoCancel"), s"subscriptions/${subscription.id}")
 
-  def disableAutoPay(accountId: String): WithDepsFailableOp[ZuoraDeps, Unit] =
+}
+
+object ZuoraDisableAutoPay {
+
+  case class AccountUpdate(autoPay: Boolean)
+
+  implicit val accountUpdateWrites = new Writes[AccountUpdate] {
+    def writes(accountUpdate: AccountUpdate) = Json.obj(
+      "autoPay" -> accountUpdate.autoPay
+    )
+  }
+
+  def apply(accountId: String): WithDepsFailableOp[ZuoraDeps, Unit] =
     put(AccountUpdate(autoPay = false), s"accounts/$accountId")
 
-  case class Query(queryString: String)
-
-  case class QueryLocator(value: String) extends AnyVal
-
-  case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
-
-  implicit val queryW: Writes[Query] = Json.writes[Query]
-
-  implicit val queryLocator: Format[QueryLocator] =
-    Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), Writes { (o: QueryLocator) => JsString(o.value) })
-
-  implicit def queryResultR[QUERYRECORD: Reads]: Reads[QueryResult[QUERYRECORD]] = (
-    (JsPath \ "records").read[List[QUERYRECORD]] and
-    (JsPath \ "size").read[Int] and
-    (JsPath \ "done").read[Boolean] and
-    (JsPath \ "queryLocator").readNullable[QueryLocator]
-  ).apply(QueryResult.apply[QUERYRECORD] _)
-
-  case class QueryMoreReq(queryLocator: QueryLocator)
-
-  implicit val wQueryMoreReq: Writes[QueryMoreReq] = Json.writes[QueryMoreReq]
-
-  // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
-  def query[QUERYRECORD: Reads](query: Query): WithDepsFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
-    post(query, s"action/query")
-
 }
 
-object SetDefaultPaymentMethod {
-
-  case class SetDefaultPaymentMethod(paymentMethodId: PaymentMethodId)
-
-  implicit val writes = new Writes[SetDefaultPaymentMethod] {
-    def writes(subscriptionUpdate: SetDefaultPaymentMethod) = Json.obj(
-      "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId
-    )
-  }
-
-  def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId): WithDepsFailableOp[ZuoraDeps, Unit] =
-    put(SetDefaultPaymentMethod(paymentMethodId), s"object/account/${accountId.value}")
-
-}
-
-object CreatePaymentMethod {
-
-  case class CreateStripePaymentMethod(
-    accountId: AccountId,
-    cardId: StripeSourceId,
-    customerId: StripeCustomerId,
-    cardCountry: StripeCountry,
-    last4: StripeLast4,
-    expiration: StripeExpiry,
-    creditCardType: CreditCardType
-  )
-
-  sealed abstract class CreditCardType(val value: String)
-  object CreditCardType {
-
-    case object AmericanExpress extends CreditCardType("AmericanExpress")
-    case object Discover extends CreditCardType("Discover")
-    case object MasterCard extends CreditCardType("MasterCard")
-    case object Visa extends CreditCardType("Visa")
-
-  }
-
-  implicit val writes = new Writes[CreateStripePaymentMethod] {
-    def writes(command: CreateStripePaymentMethod) = Json.obj(
-      "AccountId" -> command.accountId.value,
-      "TokenId" -> command.cardId.value,
-      "SecondTokenId" -> command.customerId.value,
-      "CreditCardCountry" -> command.cardCountry.value,
-      "CreditCardNumber" -> command.last4.value,
-      "CreditCardExpirationYear" -> command.expiration.exp_month,
-      "CreditCardExpirationYear" -> command.expiration.exp_year,
-      "CreditCardType" -> command.creditCardType.value,
-      "Type" -> "CreditCardReferenceTransaction"
-    )
-  }
-
-  implicit val reads: Reads[CreatePaymentMethodResult] =
-    (JsPath \ "Id").read[PaymentMethodId].map(CreatePaymentMethodResult.apply _)
-
-  case class CreatePaymentMethodResult(id: PaymentMethodId)
-
-  def createPaymentMethod(request: CreateStripePaymentMethod): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethodResult] =
-    post[CreateStripePaymentMethod, CreatePaymentMethodResult](request, s"object/payment-method")
-
-}
-
-object ZuoraQueryPaymentMethod {
-
-  case class SecondTokenId(value: String) extends AnyVal
-  case class PaymentMethodId(value: String) extends AnyVal
-  case class AccountId(value: String) extends AnyVal
-  case class CreditCardExpirationMonth(value: Int) extends AnyVal
-  case class CreditCardExpirationYear(value: Int) extends AnyVal
-  case class CreditCardMaskNumber(value: String) extends AnyVal
-  case class PaymentMethodFields(
-    Id: PaymentMethodId,
-    AccountId: AccountId
-  )
-  implicit val fPaymentMethodId: Format[PaymentMethodId] =
-    Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), Writes { (o: PaymentMethodId) => JsString(o.value) })
-
-  implicit val fAccountId: Format[AccountId] =
-    Format[AccountId](JsPath.read[String].map(AccountId.apply), Writes { (o: AccountId) => JsString(o.value) })
-
-  implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
-
-  case class AccountPaymentMethodIds(accountId: AccountId, paymentMethodIds: NonEmptyList[PaymentMethodId])
-
-  def getPaymentMethodForStripeCustomer(customerId: StripeCustomerId, sourceId: StripeSourceId): WithDepsFailableOp[ZuoraDeps, AccountPaymentMethodIds] = {
-    import com.gu.util.reader.Types._
-    val query =
-      s"""SELECT Id, AccountId
-         | FROM PaymentMethod
-         |  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = '${sourceId.value}' AND SecondTokenId = '${customerId.value}'""".stripMargin
-
-    Zuora.query[PaymentMethodFields](Query(query)).run.map(_.flatMap { result =>
-      result.records.groupBy(_.AccountId).toList match {
-        case (account, first :: rest) :: Nil =>
-          \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*).map(_.Id)))
-        case _ =>
-          logger.warn(s"wrong number of accounts using the customer token: $result")
-          -\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details"))
-      }
-    }).toEitherT
-
-  }
-
-}

--- a/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -1,26 +1,25 @@
 package com.gu.util.zuora
 
-import com.gu.stripeCustomerSourceUpdated.StripeCustomerId
+import com.gu.stripeCustomerSourceUpdated.{ StripeCustomerId, _ }
 import com.gu.util.ZuoraRestConfig
 import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.reader.Types.WithDepsFailableOp
 import com.gu.util.zuora.Zuora.Query
 import com.gu.util.zuora.ZuoraModels._
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.ZuoraWriters._
-import okhttp3.{Request, Response}
+import com.gu.util.zuora.ZuoraRestRequestMaker._
+import okhttp3.{ Request, Response }
 import org.joda.time.LocalDate
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-import scala.annotation.tailrec
-import scala.util.{Failure, Success, Try}
-import scalaz.{-\/, EitherT, NonEmptyList, \/-}
+import scalaz.{ -\/, NonEmptyList, \/-, _ }
+
+case class ZuoraDeps(response: Request => Response, config: ZuoraRestConfig)
+
 object Zuora {
-
-  import ZuoraRestRequestMaker._
-
-  case class ZuoraDeps(response: Request => Response, config: ZuoraRestConfig)
 
   def getAccountSummary(accountId: String): WithDepsFailableOp[ZuoraDeps, AccountSummary] =
     get[AccountSummary](s"accounts/$accountId/summary")
@@ -38,6 +37,7 @@ object Zuora {
     put(AccountUpdate(autoPay = false), s"accounts/$accountId")
 
   case class Query(queryString: String)
+
   case class QueryLocator(value: String) extends AnyVal
 
   case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
@@ -45,18 +45,82 @@ object Zuora {
   implicit val queryW: Writes[Query] = Json.writes[Query]
 
   implicit val queryLocator: Format[QueryLocator] =
-    Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), (o: QueryLocator) => JsString(o.value))
+    Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), Writes { (o: QueryLocator) => JsString(o.value) })
 
-  implicit def queryResultR[QUERYRECORD : Reads]: Reads[QueryResult[QUERYRECORD]] = Json.reads[QueryResult[QUERYRECORD]]
-
+  implicit def queryResultR[QUERYRECORD: Reads]: Reads[QueryResult[QUERYRECORD]] = (
+    (JsPath \ "records").read[List[QUERYRECORD]] and
+    (JsPath \ "size").read[Int] and
+    (JsPath \ "done").read[Boolean] and
+    (JsPath \ "queryLocator").readNullable[QueryLocator]
+  ).apply(QueryResult.apply[QUERYRECORD] _)
 
   case class QueryMoreReq(queryLocator: QueryLocator)
+
   implicit val wQueryMoreReq: Writes[QueryMoreReq] = Json.writes[QueryMoreReq]
 
   // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
-  def query[QUERYRECORD : Reads](query: Query): WithDepsFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
+  def query[QUERYRECORD: Reads](query: Query): WithDepsFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
     post(query, s"action/query")
 
+}
+
+object SetDefaultPaymentMethod {
+
+  case class SetDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId)
+
+  implicit val writes = new Writes[SetDefaultPaymentMethod] {
+    def writes(subscriptionUpdate: SetDefaultPaymentMethod) = Json.obj(
+      "SetDefaultPaymentMethod" -> subscriptionUpdate.paymentMethodId
+    )
+  }
+
+  def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId): WithDepsFailableOp[ZuoraDeps, Unit] =
+    put(SetDefaultPaymentMethod(accountId, paymentMethodId), s"object/account/${accountId.value}")
+
+}
+
+object CreatePaymentMethod {
+
+  case class CreateStripePaymentMethod(
+    accountId: AccountId,
+    cardId: StripeSourceId,
+    customerId: StripeCustomerId,
+    cardCountry: StripeCountry,
+    last4: StripeLast4,
+    expiration: StripeExpiry,
+    creditCardType: CreditCardType
+  )
+
+  sealed abstract class CreditCardType(val value: String)
+  object CreditCardType {
+
+    case object AmericanExpress extends CreditCardType("AmericanExpress")
+    case object Discover extends CreditCardType("Discover")
+    case object MasterCard extends CreditCardType("MasterCard")
+    case object Visa extends CreditCardType("Visa")
+
+  }
+
+  implicit val writes = new Writes[CreateStripePaymentMethod] {
+    def writes(command: CreateStripePaymentMethod) = Json.obj(
+      "AccountId" -> command.accountId.value,
+      "TokenId" -> command.cardId.value,
+      "SecondTokenId" -> command.customerId.value,
+      "CreditCardCountry" -> command.cardCountry.value,
+      "CreditCardNumber" -> command.last4.value,
+      "CreditCardExpirationYear" -> command.expiration.exp_month,
+      "CreditCardExpirationYear" -> command.expiration.exp_year,
+      "CreditCardType" -> command.creditCardType.value
+    )
+  }
+
+  implicit val reads: Reads[CreatePaymentMethodResult] =
+    (JsPath \ "id").read[PaymentMethodId].map(CreatePaymentMethodResult.apply _)
+
+  case class CreatePaymentMethodResult(id: PaymentMethodId)
+
+  def createPaymentMethod(request: CreateStripePaymentMethod): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethodResult] =
+    post[CreateStripePaymentMethod, CreatePaymentMethodResult](request, s"object/payment-method")
 
 }
 
@@ -73,30 +137,30 @@ object ZuoraQueryPaymentMethod {
     AccountId: AccountId
   )
   implicit val fPaymentMethodId: Format[PaymentMethodId] =
-    Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), (o: PaymentMethodId) => JsString(o.value))
+    Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), Writes { (o: PaymentMethodId) => JsString(o.value) })
 
   implicit val fAccountId: Format[AccountId] =
-    Format[AccountId](JsPath.read[String].map(AccountId.apply), (o: AccountId) => JsString(o.value))
+    Format[AccountId](JsPath.read[String].map(AccountId.apply), Writes { (o: AccountId) => JsString(o.value) })
 
   implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
 
   case class AccountPaymentMethodIds(accountId: AccountId, paymentMethodIds: NonEmptyList[PaymentMethodId])
 
-  def getPaymentMethodForStripeCustomer(customerId: StripeCustomerId): WithDepsFailableOp[Zuora.ZuoraDeps, AccountPaymentMethodIds] = {
-
+  def getPaymentMethodForStripeCustomer(customerId: StripeCustomerId): WithDepsFailableOp[ZuoraDeps, AccountPaymentMethodIds] = {
+    import com.gu.util.reader.Types._
     val query =
       s"""SELECT Id, AccountId
          | FROM PaymentMethod
          |  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'TokenId' AND SecondTokenId = '${customerId.value}'""".stripMargin
 
-    EitherT(Zuora.query[PaymentMethodFields](Query(query)).run.map(_.flatMap { result =>
+    Zuora.query[PaymentMethodFields](Query(query)).run.map(_.flatMap { result =>
       result.records.groupBy(_.AccountId).toList match {
         case (account, first :: rest) :: Nil =>
           \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*).map(_.Id)))
         case _ =>
           -\/(ApiGatewayResponse.internalServerError(s"no results for the customer token: $result"))
       }
-    }))
+    }).toEitherT
 
   }
 

--- a/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -1,12 +1,21 @@
 package com.gu.util.zuora
 
+import com.gu.stripeCustomerSourceUpdated.StripeCustomerId
 import com.gu.util.ZuoraRestConfig
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.zuora.Zuora.Query
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.ZuoraWriters._
-import okhttp3.{ Request, Response }
+import okhttp3.{Request, Response}
 import org.joda.time.LocalDate
+import play.api.libs.json._
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+import scalaz.{-\/, EitherT, NonEmptyList, \/-}
 object Zuora {
 
   import ZuoraRestRequestMaker._
@@ -28,5 +37,67 @@ object Zuora {
   def disableAutoPay(accountId: String): WithDepsFailableOp[ZuoraDeps, Unit] =
     put(AccountUpdate(autoPay = false), s"accounts/$accountId")
 
+  case class Query(queryString: String)
+  case class QueryLocator(value: String) extends AnyVal
+
+  case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
+
+  implicit val queryW: Writes[Query] = Json.writes[Query]
+
+  implicit val queryLocator: Format[QueryLocator] =
+    Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), (o: QueryLocator) => JsString(o.value))
+
+  implicit def queryResultR[QUERYRECORD : Reads]: Reads[QueryResult[QUERYRECORD]] = Json.reads[QueryResult[QUERYRECORD]]
+
+
+  case class QueryMoreReq(queryLocator: QueryLocator)
+  implicit val wQueryMoreReq: Writes[QueryMoreReq] = Json.writes[QueryMoreReq]
+
+  // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
+  def query[QUERYRECORD : Reads](query: Query): WithDepsFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
+    post(query, s"action/query")
+
+
 }
 
+object ZuoraQueryPaymentMethod {
+
+  case class SecondTokenId(value: String) extends AnyVal
+  case class PaymentMethodId(value: String) extends AnyVal
+  case class AccountId(value: String) extends AnyVal
+  case class CreditCardExpirationMonth(value: Int) extends AnyVal
+  case class CreditCardExpirationYear(value: Int) extends AnyVal
+  case class CreditCardMaskNumber(value: String) extends AnyVal
+  case class PaymentMethodFields(
+    Id: PaymentMethodId,
+    AccountId: AccountId
+  )
+  implicit val fPaymentMethodId: Format[PaymentMethodId] =
+    Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), (o: PaymentMethodId) => JsString(o.value))
+
+  implicit val fAccountId: Format[AccountId] =
+    Format[AccountId](JsPath.read[String].map(AccountId.apply), (o: AccountId) => JsString(o.value))
+
+  implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
+
+  case class AccountPaymentMethodIds(accountId: AccountId, paymentMethodIds: NonEmptyList[PaymentMethodId])
+
+  def getPaymentMethodForStripeCustomer(customerId: StripeCustomerId): WithDepsFailableOp[Zuora.ZuoraDeps, AccountPaymentMethodIds] = {
+
+    val query =
+      s"""SELECT Id, AccountId
+         | FROM PaymentMethod
+         |  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'TokenId' AND SecondTokenId = '${customerId.value}'""".stripMargin
+
+    EitherT(Zuora.query[PaymentMethodFields](Query(query)).run.map(_.flatMap { result =>
+      result.records.groupBy(_.AccountId).toList match {
+        case (account, first :: rest) :: Nil =>
+          \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*).map(_.Id)))
+        case _ =>
+          -\/(ApiGatewayResponse.internalServerError(s"no results for the customer token: $result"))
+      }
+    }))
+
+  }
+
+}

--- a/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -159,7 +159,8 @@ object ZuoraQueryPaymentMethod {
         case (account, first :: rest) :: Nil =>
           \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*).map(_.Id)))
         case _ =>
-          -\/(ApiGatewayResponse.internalServerError(s"no results for the customer token: $result"))
+          logger.warn(s"wrong number of accounts using the customer token: $result")
+          -\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details"))
       }
     }).toEitherT
 

--- a/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
@@ -1,16 +1,14 @@
 package com.gu.util.zuora
 
 import com.gu.util.zuora.ZuoraModels._
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.PaymentMethodId
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import org.joda.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 object ZuoraModels {
 
-  case class BasicAccountInfo(id: String, balance: Double, defaultPaymentMethod: PaymentMethod)
-
-  case class PaymentMethod(id: PaymentMethodId)
+  case class BasicAccountInfo(id: AccountId, balance: Double, defaultPaymentMethod: PaymentMethodId)
 
   case class SubscriptionSummary(id: SubscriptionId, subscriptionNumber: String, status: String)
 
@@ -38,10 +36,13 @@ object ZuoraModels {
 
 object ZuoraReaders {
 
+  implicit val paymentMethodIdReads: Reads[PaymentMethodId] =
+    (JsPath \ "id").read[String].map(PaymentMethodId.apply)
+
   implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
-    (JsPath \ "id").read[String] and
+    (JsPath \ "id").read[String].map(AccountId.apply) and
     (JsPath \ "balance").read[Double] and
-      (JsPath \ "defaultPaymentMethod").read[PaymentMethod]
+    (JsPath \ "defaultPaymentMethod").read[PaymentMethodId]
   )(BasicAccountInfo.apply _)
 
   implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (
@@ -86,9 +87,6 @@ object ZuoraReaders {
     (JsPath \ "invoices").read[List[ItemisedInvoice]].map {
       invoices => InvoiceTransactionSummary(invoices)
     }
-
-  implicit val paymentMethodIdReads: Reads[PaymentMethodId] =
-    (JsPath \ "id").read[String].map(PaymentMethodId.apply)
 
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))

--- a/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
@@ -1,13 +1,16 @@
 package com.gu.util.zuora
 
 import com.gu.util.zuora.ZuoraModels._
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.PaymentMethodId
 import org.joda.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 object ZuoraModels {
 
-  case class BasicAccountInfo(id: String, balance: Double)
+  case class BasicAccountInfo(id: String, balance: Double, defaultPaymentMethod: PaymentMethod)
+
+  case class PaymentMethod(id: PaymentMethodId)
 
   case class SubscriptionSummary(id: SubscriptionId, subscriptionNumber: String, status: String)
 
@@ -37,7 +40,8 @@ object ZuoraReaders {
 
   implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
     (JsPath \ "id").read[String] and
-    (JsPath \ "balance").read[Double]
+    (JsPath \ "balance").read[Double] and
+      (JsPath \ "defaultPaymentMethod").read[PaymentMethod]
   )(BasicAccountInfo.apply _)
 
   implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (
@@ -82,6 +86,9 @@ object ZuoraReaders {
     (JsPath \ "invoices").read[List[ItemisedInvoice]].map {
       invoices => InvoiceTransactionSummary(invoices)
     }
+
+  implicit val paymentMethodIdReads: Reads[PaymentMethodId] =
+    (JsPath \ "id").read[String].map(PaymentMethodId.apply)
 
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))

--- a/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
@@ -1,89 +1,17 @@
 package com.gu.util.zuora
 
 import com.gu.util.zuora.ZuoraModels._
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
-import org.joda.time.LocalDate
-import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 object ZuoraModels {
 
-  case class BasicAccountInfo(id: AccountId, balance: Double, defaultPaymentMethod: PaymentMethodId)
-
-  case class SubscriptionSummary(id: SubscriptionId, subscriptionNumber: String, status: String)
-
   case class SubscriptionId(id: String) extends AnyVal
-
-  case class Invoice(id: String, dueDate: LocalDate, balance: Double, status: String)
-
-  case class AccountSummary(basicInfo: BasicAccountInfo, subscriptions: List[SubscriptionSummary], invoices: List[Invoice])
-
-  case class InvoiceItem(id: String, subscriptionName: String, serviceStartDate: LocalDate, serviceEndDate: LocalDate, chargeAmount: Double, chargeName: String, productName: String)
-
-  case class ItemisedInvoice(id: String, invoiceDate: LocalDate, amount: Double, balance: Double, status: String, invoiceItems: List[InvoiceItem])
-
-  case class InvoiceTransactionSummary(invoices: List[ItemisedInvoice])
-
-  case class SubscriptionCancellation(cancellationEffectiveDate: LocalDate)
-
-  case class SubscriptionUpdate(cancellationReason: String)
-
-  case class AccountUpdate(autoPay: Boolean)
 
   case class ZuoraCommonFields(success: Boolean)
 
 }
 
 object ZuoraReaders {
-
-  implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
-    (JsPath \ "id").read[String].map(AccountId.apply) and
-    (JsPath \ "balance").read[Double] and
-    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId]
-  )(BasicAccountInfo.apply _)
-
-  implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (
-    (JsPath \ "id").read[String].map(SubscriptionId.apply) and
-    (JsPath \ "subscriptionNumber").read[String] and
-    (JsPath \ "status").read[String]
-  )(SubscriptionSummary.apply _)
-
-  implicit val invoiceReads: Reads[Invoice] = (
-    (JsPath \ "id").read[String] and
-    (JsPath \ "dueDate").read[LocalDate] and
-    (JsPath \ "balance").read[Double] and
-    (JsPath \ "status").read[String]
-  )(Invoice.apply _)
-
-  implicit val accountSummaryReads: Reads[AccountSummary] = (
-    (JsPath \ "basicInfo").read[BasicAccountInfo] and
-    (JsPath \ "subscriptions").read[List[SubscriptionSummary]] and
-    (JsPath \ "invoices").read[List[Invoice]]
-  )(AccountSummary.apply _)
-
-  implicit val invoiceItemReads: Reads[InvoiceItem] = (
-    (JsPath \ "id").read[String] and
-    (JsPath \ "subscriptionName").read[String] and
-    (JsPath \ "serviceStartDate").read[LocalDate] and
-    (JsPath \ "serviceEndDate").read[LocalDate] and
-    (JsPath \ "chargeAmount").read[Double] and
-    (JsPath \ "chargeName").read[String] and
-    (JsPath \ "productName").read[String]
-  )(InvoiceItem.apply _)
-
-  implicit val itemisedInvoiceReads: Reads[ItemisedInvoice] = (
-    (JsPath \ "id").read[String] and
-    (JsPath \ "invoiceDate").read[LocalDate] and
-    (JsPath \ "amount").read[Double] and
-    (JsPath \ "balance").read[Double] and
-    (JsPath \ "status").read[String] and
-    (JsPath \ "invoiceItems").read[List[InvoiceItem]]
-  )(ItemisedInvoice.apply _)
-
-  implicit val invoiceTransactionSummaryReads: Reads[InvoiceTransactionSummary] =
-    (JsPath \ "invoices").read[List[ItemisedInvoice]].map {
-      invoices => InvoiceTransactionSummary(invoices)
-    }
 
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
@@ -94,29 +22,5 @@ object ZuoraReaders {
       .map {
         success => ZuoraCommonFields(success)
       }
-
-}
-
-object ZuoraWriters {
-
-  implicit val subscriptionCancellationWrites = new Writes[SubscriptionCancellation] {
-    def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
-      "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
-      "cancellationPolicy" -> "SpecificDate",
-      "invoiceCollect" -> false
-    )
-  }
-
-  implicit val subscriptionUpdateWrites = new Writes[SubscriptionUpdate] {
-    def writes(subscriptionUpdate: SubscriptionUpdate) = Json.obj(
-      "CancellationReason__c" -> subscriptionUpdate.cancellationReason
-    )
-  }
-
-  implicit val accountUpdateWrites = new Writes[AccountUpdate] {
-    def writes(accountUpdate: AccountUpdate) = Json.obj(
-      "autoPay" -> accountUpdate.autoPay
-    )
-  }
 
 }

--- a/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
@@ -88,9 +88,12 @@ object ZuoraReaders {
   implicit val unitReads: Reads[Unit] =
     Reads(_ => JsSuccess(()))
 
-  implicit val zuoraCommonFieldsReads: Reads[ZuoraCommonFields] = (JsPath \ "success").read[Boolean].map {
-    success => ZuoraCommonFields(success)
-  }
+  implicit val zuoraCommonFieldsReads: Reads[ZuoraCommonFields] =
+    (JsPath \ "success").read[Boolean]
+      .orElse((JsPath \ "Success").read[Boolean]) // rest object api seems to use title case....!!
+      .map {
+        success => ZuoraCommonFields(success)
+      }
 
 }
 

--- a/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
@@ -39,7 +39,7 @@ object ZuoraReaders {
   implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
     (JsPath \ "id").read[String].map(AccountId.apply) and
     (JsPath \ "balance").read[Double] and
-    (JsPath \ "defaultPaymentMethod").read[PaymentMethodId]
+    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId]
   )(BasicAccountInfo.apply _)
 
   implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (

--- a/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraObjects.scala
@@ -36,9 +36,6 @@ object ZuoraModels {
 
 object ZuoraReaders {
 
-  implicit val paymentMethodIdReads: Reads[PaymentMethodId] =
-    (JsPath \ "id").read[String].map(PaymentMethodId.apply)
-
   implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
     (JsPath \ "id").read[String].map(AccountId.apply) and
     (JsPath \ "balance").read[Double] and

--- a/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,0 +1,36 @@
+package com.gu.util.zuora
+
+import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.zuora.ZuoraRestRequestMaker.post
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+object ZuoraQuery {
+
+  case class Query(queryString: String)
+
+  case class QueryLocator(value: String) extends AnyVal
+
+  case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
+
+  implicit val queryW: Writes[Query] = Json.writes[Query]
+
+  implicit val queryLocator: Format[QueryLocator] =
+    Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), Writes { (o: QueryLocator) => JsString(o.value) })
+
+  implicit def queryResultR[QUERYRECORD: Reads]: Reads[QueryResult[QUERYRECORD]] = (
+    (JsPath \ "records").read[List[QUERYRECORD]] and
+    (JsPath \ "size").read[Int] and
+    (JsPath \ "done").read[Boolean] and
+    (JsPath \ "queryLocator").readNullable[QueryLocator]
+  ).apply(QueryResult.apply[QUERYRECORD] _)
+
+  case class QueryMoreReq(queryLocator: QueryLocator)
+
+  implicit val wQueryMoreReq: Writes[QueryMoreReq] = Json.writes[QueryMoreReq]
+
+  // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
+  def query[QUERYRECORD: Reads](query: Query): WithDepsFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
+    post(query, s"action/query")
+
+}

--- a/src/main/scala/com/gu/util/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraQueryPaymentMethod.scala
@@ -1,0 +1,53 @@
+package com.gu.util.zuora
+
+import com.gu.stripeCustomerSourceUpdated.{ StripeCustomerId, StripeSourceId }
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.zuora.ZuoraQuery.Query
+import com.gu.util.zuora.ZuoraRestRequestMaker.logger
+import play.api.libs.json._
+
+import scalaz.{ -\/, NonEmptyList, \/- }
+
+object ZuoraQueryPaymentMethod {
+
+  case class SecondTokenId(value: String) extends AnyVal
+  case class PaymentMethodId(value: String) extends AnyVal
+  case class AccountId(value: String) extends AnyVal
+  case class CreditCardExpirationMonth(value: Int) extends AnyVal
+  case class CreditCardExpirationYear(value: Int) extends AnyVal
+  case class CreditCardMaskNumber(value: String) extends AnyVal
+  case class PaymentMethodFields(
+    Id: PaymentMethodId,
+    AccountId: AccountId
+  )
+  implicit val fPaymentMethodId: Format[PaymentMethodId] =
+    Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), Writes { (o: PaymentMethodId) => JsString(o.value) })
+
+  implicit val fAccountId: Format[AccountId] =
+    Format[AccountId](JsPath.read[String].map(AccountId.apply), Writes { (o: AccountId) => JsString(o.value) })
+
+  implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
+
+  case class AccountPaymentMethodIds(accountId: AccountId, paymentMethodIds: NonEmptyList[PaymentMethodId])
+
+  def getPaymentMethodForStripeCustomer(customerId: StripeCustomerId, sourceId: StripeSourceId): WithDepsFailableOp[ZuoraDeps, AccountPaymentMethodIds] = {
+    import com.gu.util.reader.Types._
+    val query =
+      s"""SELECT Id, AccountId
+         | FROM PaymentMethod
+         |  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = '${sourceId.value}' AND SecondTokenId = '${customerId.value}'""".stripMargin
+
+    ZuoraQuery.query[PaymentMethodFields](Query(query)).run.map(_.flatMap { result =>
+      result.records.groupBy(_.AccountId).toList match {
+        case (account, first :: rest) :: Nil =>
+          \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*).map(_.Id)))
+        case _ =>
+          logger.warn(s"wrong number of accounts using the customer token: $result")
+          -\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details"))
+      }
+    }).toEitherT
+
+  }
+
+}

--- a/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -37,7 +37,9 @@ object ZuoraRestRequestMaker extends Logging {
     if (response.isSuccessful) {
       ().right
     } else {
-      logger.error(s"Request to Zuora was unsuccessful, the response was: \n $response")
+      val body = response.body.string
+      val truncated = body.take(500) + (if (body.length > 500) "..." else "")
+      logger.error(s"Request to Zuora was unsuccessful, the response was: \n $response\n$truncated")
       internalServerError("Request to Zuora was unsuccessful").left
     }
   }

--- a/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -3,7 +3,6 @@ package com.gu.util.zuora
 import com.gu.util.apigateway.ApiGatewayResponse._
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.Zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.{ Logging, ZuoraRestConfig }
@@ -12,7 +11,6 @@ import play.api.libs.json._
 
 import scalaz.Scalaz._
 import scalaz.{ Reader, \/ }
-import scalaz.syntax.std.boolean._
 
 object ZuoraRestRequestMaker extends Logging {
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -29,7 +29,7 @@ object TestData extends Matchers {
   val basicInvoiceTransactionSummary = InvoiceTransactionSummary(List(itemisedInvoice(49, List(invoiceItemA))))
   val weirdInvoiceTransactionSummary = InvoiceTransactionSummary(List(itemisedInvoice(0, List(invoiceItemA)), itemisedInvoice(49, List(invoiceItemB, invoiceItemA, invoiceItemC))))
 
-  val fakeApiConfig = TrustedApiConfig("validApiClientId", "validApiToken", "testEnvTenantId")
+  val fakeApiConfig = TrustedApiConfig("validApiToken", "testEnvTenantId")
   val fakeZuoraConfig = ZuoraRestConfig("https://ddd", "fakeUser", "fakePass")
   val fakeETSendIds = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can"))
   val fakeETConfig = ETConfig(etSendIDs = fakeETSendIds, "fakeClientId", "fakeClientSecret")

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -6,7 +6,7 @@ import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.HandlerDeps
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.Types.{ FailableOp, WithDepsFailableOp, _ }
-import com.gu.util.zuora.Zuora.ZuoraDeps
+import com.gu.util.zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraModels.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
 import okhttp3._
 import org.joda.time.LocalDate

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -8,7 +8,7 @@ import com.gu.util.apigateway.ApiGatewayHandler.HandlerDeps
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.Types.{ FailableOp, WithDepsFailableOp, _ }
 import com.gu.util.zuora.ZuoraDeps
-import com.gu.util.zuora.ZuoraModels.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
+import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
 import okhttp3._
 import okhttp3.internal.Util.UTF_8
 import okio.Buffer

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -37,8 +37,13 @@ object TestData extends Matchers {
   val fakeETSendIds = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can"))
   val fakeETConfig = ETConfig(etSendIDs = fakeETSendIds, "fakeClientId", "fakeClientSecret")
 
-  val fakeConfig = Config(Stage("DEV"), fakeApiConfig, zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
-    etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"))
+  val fakeConfig = Config(
+    stage = Stage("DEV"),
+    trustedApiConfig = fakeApiConfig,
+    zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
+    etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"),
+    stripeConfig = StripeConfig(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def"))
+  )
 
   val missingCredentialsResponse = """{"statusCode":"401","headers":{"Content-Type":"application/json"},"body":"Credentials are missing or invalid"}"""
   val successfulResponse = """{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}"""
@@ -67,6 +72,10 @@ object TestData extends Matchers {
       |    },
       |    "clientId": "jjj",
       |    "clientSecret": "kkk"
+      |  },
+      |  "stripe": {
+      |     "api.key.secret": "abc",
+      |     "au-membership.key.secret": "def"
       |  }
       |}
     """.stripMargin

--- a/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
@@ -2,6 +2,7 @@ package com.gu.autoCancel
 
 import com.gu.util.apigateway.ApiGatewayResponse._
 import com.gu.util.zuora.ZuoraModels._
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import org.joda.time.LocalDate
 import org.scalatest._
 
@@ -11,7 +12,7 @@ class AutoCancelDataCollectionFilterTest extends FlatSpec {
 
   import AutoCancelDataCollectionFilter._
 
-  val basicInfo = BasicAccountInfo("id123", 11.99)
+  val basicInfo = BasicAccountInfo(AccountId("id123"), 11.99, PaymentMethodId("pmid"))
   val subscription = SubscriptionSummary(SubscriptionId("id123"), "A-S123", "Active")
   val twoSubscriptions = List(SubscriptionSummary(SubscriptionId("id123"), "A-S123", "Active"), SubscriptionSummary(SubscriptionId("id321"), "A-S321", "Active"))
   val inactiveSubscriptions = List(SubscriptionSummary(SubscriptionId("id456"), "A-S123", "Cancelled"), SubscriptionSummary(SubscriptionId("id789"), "A-S321", "Expired"))

--- a/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
@@ -1,6 +1,7 @@
 package com.gu.autoCancel
 
 import com.gu.util.apigateway.ApiGatewayResponse._
+import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary }
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import org.joda.time.LocalDate

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -2,11 +2,11 @@ package com.gu.autoCancel
 
 import com.gu.util.TrustedApiConfig
 import com.gu.util.apigateway.ApiGatewayResponse._
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest, RequestAuth }
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, RequestAuth, StripeAccount}
 import org.scalatest._
-import play.api.libs.json.{ JsSuccess, Json }
+import play.api.libs.json.{JsSuccess, Json}
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 object AutoCancelHandlerTest {
 
   def fakeCallout(autoPay: Boolean) = {
@@ -83,7 +83,7 @@ class DeserialiserTest extends FlatSpec with Matchers {
     val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b"}, "body": "haha"}"""
     val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
-    actualRequest.map(_.queryStringParameters.flatMap(_.onlyCancelDirectDebit)) should be(JsSuccess(None))
+    actualRequest.map(_.queryStringParameters.map(_.onlyCancelDirectDebit)) should be(JsSuccess(Some(false)))
 
   }
 
@@ -100,6 +100,31 @@ class DeserialiserTest extends FlatSpec with Matchers {
     val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     actualRequest.map(_.onlyCancelDirectDebit) should be(JsSuccess(true))
+
+  }
+
+
+  "deserialise APIGatewayRequest" should "manage without the stripe param" in {
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b"}, "body": "haha"}"""
+    val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
+
+    actualRequest.map(_.queryStringParameters.flatMap(_.stripeAccount)) should be(JsSuccess(None))
+
+  }
+
+  "deserialise APIGatewayRequest" should "manage without a valid stripe param" in {
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "stripeAccount": "HAHAHAHAHAHA"}, "body": "haha"}"""
+    val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
+
+    actualRequest.map(_.queryStringParameters.flatMap(_.stripeAccount)) should be(JsSuccess(None))
+
+  }
+
+  it should "manage with the only stripe param set" in {
+    val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b", "stripeAccount": "GNM_Membership_AUS"}, "body": "haha"}"""
+    val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
+
+    actualRequest.map(_.queryStringParameters.flatMap(_.stripeAccount)) should be(JsSuccess(Some(StripeAccount.GNM_Membership_AUS)))
 
   }
 

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -64,7 +64,7 @@ class AutoCancelHandlerTest extends FlatSpec {
   }
 
   "authenticateCallout" should "return a left if the credentials are invalid" in {
-    val requestAuth = RequestAuth(apiToken = "tokpen")
+    val requestAuth = RequestAuth(apiToken = "incorrectRequestToken")
     val trustedApiConfig = TrustedApiConfig(apiToken = "token", tenantId = "tenant")
     assert(ApiGatewayHandler.authenticateCallout(Some(requestAuth), trustedApiConfig) == -\/(unauthorized))
   }

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -64,14 +64,14 @@ class AutoCancelHandlerTest extends FlatSpec {
   }
 
   "authenticateCallout" should "return a left if the credentials are invalid" in {
-    val requestAuth = RequestAuth(apiClientId = "correctId", apiToken = "token")
-    val trustedApiConfig = TrustedApiConfig(apiClientId = "wrongId", apiToken = "token", tenantId = "tenant")
+    val requestAuth = RequestAuth(apiToken = "tokpen")
+    val trustedApiConfig = TrustedApiConfig(apiToken = "token", tenantId = "tenant")
     assert(ApiGatewayHandler.authenticateCallout(Some(requestAuth), trustedApiConfig) == -\/(unauthorized))
   }
 
   "authenticateCallout" should "return a right if the credentials are valid" in {
-    val requestAuth = RequestAuth(apiClientId = "correctId", apiToken = "token")
-    val trustedApiConfig = TrustedApiConfig(apiClientId = "correctId", apiToken = "token", tenantId = "tenant")
+    val requestAuth = RequestAuth(apiToken = "token")
+    val trustedApiConfig = TrustedApiConfig(apiToken = "token", tenantId = "tenant")
     assert(ApiGatewayHandler.authenticateCallout(Some(requestAuth), trustedApiConfig) == \/-(()))
   }
 

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -2,11 +2,11 @@ package com.gu.autoCancel
 
 import com.gu.util.TrustedApiConfig
 import com.gu.util.apigateway.ApiGatewayResponse._
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, RequestAuth, StripeAccount}
+import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest, RequestAuth, StripeAccount }
 import org.scalatest._
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.{ JsSuccess, Json }
 
-import scalaz.{-\/, \/-}
+import scalaz.{ -\/, \/- }
 object AutoCancelHandlerTest {
 
   def fakeCallout(autoPay: Boolean) = {
@@ -102,7 +102,6 @@ class DeserialiserTest extends FlatSpec with Matchers {
     actualRequest.map(_.onlyCancelDirectDebit) should be(JsSuccess(true))
 
   }
-
 
   "deserialise APIGatewayRequest" should "manage without the stripe param" in {
     val json = """{"queryStringParameters": {"apiToken": "a", "apiClientId": "b"}, "body": "haha"}"""

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -1,13 +1,12 @@
 package com.gu.autoCancel
 
+import com.gu.TestingRawEffects.BasicResult
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.autoCancel.AutoCancelDataCollectionFilter.ACFilterDeps
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.{ TestData, TestingRawEffects, WithDependenciesFailableOp }
-import okhttp3.internal.Util.UTF_8
-import okio.Buffer
 import org.joda.time.LocalDate
 import org.scalatest._
 
@@ -37,15 +36,7 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
     val effects = new TestingRawEffects(false, 200)
     AutoCancel(effects.zuoraDeps)(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now))
 
-    val requests = effects.result.map { request =>
-      val buffer = new Buffer()
-      request.body().writeTo(buffer)
-      val body = buffer.readString(UTF_8)
-      val url = request.url
-      (request.method(), url.encodedPath(), body)
-    }
-
-    requests should contain(("PUT", "/accounts/AID", "{\"autoPay\":false}"))
+    effects.basicResults should contain(BasicResult("PUT", "/accounts/AID", "{\"autoPay\":false}"))
   }
 
   //  // todo need an ACSDeps so we don't need so many mock requests

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -4,6 +4,7 @@ import com.gu.TestingRawEffects.BasicResult
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.autoCancel.AutoCancelDataCollectionFilter.ACFilterDeps
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary }
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.{ TestData, TestingRawEffects, WithDependenciesFailableOp }

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -4,6 +4,7 @@ import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.autoCancel.AutoCancelDataCollectionFilter.ACFilterDeps
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraModels._
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.{ TestData, TestingRawEffects, WithDependenciesFailableOp }
 import okhttp3.internal.Util.UTF_8
 import okio.Buffer
@@ -14,7 +15,7 @@ import scalaz.\/-
 
 class AutoCancelStepsTest extends FlatSpec with Matchers {
 
-  val basicInfo = BasicAccountInfo("id123", 11.99)
+  val basicInfo = BasicAccountInfo(AccountId("id123"), 11.99, PaymentMethodId("pmid"))
   val subscription = SubscriptionSummary(SubscriptionId("sub123"), "A-S123", "Active")
   val singleOverdueInvoice = Invoice("inv123", LocalDate.now.minusDays(14), 11.99, "Posted")
 

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -11,6 +11,7 @@ import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest, ApiGateway
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.{ Config, Stage }
 import org.scalatest.{ FlatSpec, Matchers }

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -141,7 +141,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
-    effects.basicResults should be(List( expectedPOST))
+    effects.basicResults should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
 
@@ -164,7 +164,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
-    effects.basicResults should be(List( expectedPOST))
+    effects.basicResults should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
 

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -80,8 +80,8 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
   "SourceUpdatedSteps" should "updatePaymentMethod" in {
 
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/object/payment-method", (200, """{"success": true,"Id": "newPMID"}""")),
-      ("/object/account/fake", (200, """{"success": true,"Id": "fakeaccountid"}"""))
+      ("/object/payment-method", (200, """{"Success": true,"Id": "newPMID"}""")),
+      ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))
     ))
     val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
@@ -99,7 +99,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedPOST = BasicResult(
       "POST",
       "/object/payment-method",
-      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationYear":2020,"CreditCardType":"Visa"}"""
+      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction"}"""
     )
     val expectedPUT = BasicResult(
       "PUT",

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -1,0 +1,377 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import com.gu.TestingRawEffects
+import com.gu.TestingRawEffects.BasicResult
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.AccountId
+import okhttp3.Request
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scalaz.{ -\/, \/- }
+
+class SourceUpdatedStepsTest extends FlatSpec with Matchers {
+
+  "SourceUpdatedSteps" should "getAccountToUpdate non default pm" in {
+    val effects = new TestingRawEffects(false, 500, Map(
+      ("/action/query", (200, """{
+                                |  "records": [
+                                |    {
+                                |      "Id": "nondefaultPMID",
+                                |      "AccountId": "accid"
+                                |    }
+                                |  ],
+                                |  "size": 1,
+                                |  "done": true
+                                |}""".stripMargin)), //defaultPMID
+      ("/accounts/accid/summary", (200, accountSummaryJson))
+    ))
+    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+
+    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+
+    val expectedPOST = BasicResult(
+      "POST",
+      "/action/query",
+      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
+    val expectedGET = BasicResult(
+      "GET",
+      "/accounts/accid/summary",
+      ""
+    )
+
+    effects.basicResults should be(List(expectedGET, expectedPOST))
+    actual should be(-\/(ApiGatewayResponse.successfulExecution))
+  }
+
+  "SourceUpdatedSteps" should "getAccountToUpdate default pm" in {
+    val effects = new TestingRawEffects(false, 500, Map(
+      ("/action/query", (200, """{
+                                |  "records": [
+                                |    {
+                                |      "Id": "defaultPMID",
+                                |      "AccountId": "accid"
+                                |    }
+                                |  ],
+                                |  "size": 1,
+                                |  "done": true
+                                |}""".stripMargin)), //defaultPMID
+      ("/accounts/accid/summary", (200, accountSummaryJson))
+    ))
+    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+
+    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+
+    val expectedPOST = BasicResult(
+      "POST",
+      "/action/query",
+      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
+    val expectedGET = BasicResult(
+      "GET",
+      "/accounts/accid/summary",
+      ""
+    )
+
+    effects.basicResults should be(List(expectedGET, expectedPOST))
+    actual should be(\/-(AccountId("accountidfake")))
+  }
+
+  "SourceUpdatedSteps" should "updatePaymentMethod" in {
+
+    val effects = new TestingRawEffects(false, 500, Map(
+      ("/object/payment-method", (200, """{"success": true,"Id": "newPMID"}""")),
+      ("/object/account/fake", (200, """{"success": true,"Id": "fakeaccountid"}"""))
+    ))
+    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+
+    val eventData = EventDataObject(
+      id = StripeSourceId("card_def456"),
+      brand = StripeBrand.Visa,
+      country = StripeCountry("US"),
+      customer = StripeCustomerId("cus_ghi789"),
+      expiry = StripeExpiry(exp_month = 7, exp_year = 2020),
+      last4 = StripeLast4("1234")
+    )
+
+    val actual = SourceUpdatedSteps.updatePaymentMethod(AccountId("fake"), eventData).run.run(effects.zuoraDeps)
+
+    val expectedPOST = BasicResult(
+      "POST",
+      "/object/payment-method",
+      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationYear":2020,"CreditCardType":"Visa"}"""
+    )
+    val expectedPUT = BasicResult(
+      "PUT",
+      "/object/account/fake",
+      """{"DefaultPaymentMethodId":"newPMID"}"""
+    )
+
+    effects.basicResults should be(List(expectedPUT, expectedPOST))
+    actual should be(\/-(()))
+  }
+
+  val accountSummaryJson =
+    """{
+  "payments": [
+    {
+      "paidInvoices": [
+        {
+          "invoiceNumber": "INV00000159",
+          "appliedPaymentAmount": 5,
+          "invoiceId": "2c92a09539190dbe0139190f42780012"
+        },
+        {
+          "invoiceNumber": "INV00000323",
+          "appliedPaymentAmount": 139722.1,
+          "invoiceId": "2c92a0953a3fa95d013a407c10a60100"
+        },
+        {
+          "invoiceNumber": "INV00000160",
+          "appliedPaymentAmount": 10521,
+          "invoiceId": "2c92a09739190dc60139194bcf1b0098"
+        }
+      ],
+      "paymentNumber": "P-00000075",
+      "status": "Processed",
+      "effectiveDate": "2013-03-27",
+      "id": "2c92c8f83dabf9cf013daf3bfa0305a6",
+      "paymentType": "Electronic"
+    },
+    {
+      "paidInvoices": [
+        {
+          "invoiceNumber": "INV00000159",
+          "appliedPaymentAmount": 5,
+          "invoiceId": "2c92a09539190dbe0139190f42780012"
+        }
+      ],
+      "paymentNumber": "P-00000056",
+      "status": "Processed",
+      "effectiveDate": "2012-08-11",
+      "id": "2c92a0f9391832b101391922ad5f049d",
+      "paymentType": "Electronic"
+    }
+  ],
+  "invoices": [
+    {
+      "amount": 139722.1,
+      "status": "Posted",
+      "invoiceNumber": "INV00000323",
+      "invoiceDate": "2013-02-11",
+      "balance": 0,
+      "id": "2c92a0953a3fa95d013a407c10a60100",
+      "dueDate": "2013-02-11"
+    },
+    {
+      "amount": 10521,
+      "status": "Posted",
+      "invoiceNumber": "INV00000160",
+      "invoiceDate": "2012-08-11",
+      "balance": 0,
+      "id": "2c92a09739190dc60139194bcf1b0098",
+      "dueDate": "2012-08-11"
+    },
+    {
+      "amount": 10,
+      "status": "Posted",
+      "invoiceNumber": "INV00000159",
+      "invoiceDate": "2012-08-11",
+      "balance": 0,
+      "id": "2c92a09539190dbe0139190f42780012",
+      "dueDate": "2012-08-11"
+    }
+  ],
+  "usage": [
+    {
+      "unitOfMeasure": "UOM",
+      "quantity": 10,
+      "startDate": "2012-02"
+    },
+    {
+      "unitOfMeasure": "UOM",
+      "quantity": 10,
+      "startDate": "2012-01"
+    }
+  ],
+  "basicInfo": {
+    "defaultPaymentMethod": {
+      "creditCardNumber": "************1111",
+      "paymentMethodType": "CreditCard",
+      "creditCardExpirationMonth": 10,
+      "creditCardExpirationYear": 2020,
+      "creditCardType": "Visa",
+      "id": "defaultPMID"
+    },
+    "status": "Active",
+    "lastInvoiceDate": "2013-02-11",
+    "lastPaymentAmount": 150248.1,
+    "billCycleDay": 1,
+    "invoiceDeliveryPrefsPrint": false,
+    "invoiceDeliveryPrefsEmail": true,
+    "additionalEmailAddresses": [
+      "test1@test.com",
+      "test2@test.com"
+    ],
+    "name": "subscribeCallYan_1",
+    "balance": 0,
+    "accountNumber": "A00001115",
+    "id": "accountidfake",
+    "dfadsf__c": null,
+    "currency": "USD",
+    "lastPaymentDate": "2013-03-27"
+  },
+  "soldToContact": {
+    "fax": "",
+    "taxRegion": "",
+    "country": "United States",
+    "zipCode": "95135",
+    "county": "",
+    "lastName": "Cho",
+    "workEmail": "work_email@zbcloud.com",
+    "state": "California",
+    "address2": "",
+    "address1": "278 Bridgeton Circle",
+    "firstName": "Bill",
+    "id": "2c92a0f9391832b10139183e27940043",
+    "workPhone": "5555551212",
+    "city": "San Jose"
+  },
+  "success": true,
+  "subscriptions": [
+    {
+      "termEndDate": "2014-02-01",
+      "termStartDate": "2013-02-01",
+      "status": "Active",
+      "initialTerm": 12,
+      "autoRenew": true,
+      "subscriptionNumber": "A-S00001081",
+      "subscriptionStartDate": "2013-02-01",
+      "id": "2c92c8f83dc4f752013dc72c24ee016d",
+      "ratePlans": [
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "QSF_Tier"
+        }
+      ],
+      "termType": "TERMED",
+      "renewalTerm": 3
+    },
+    {
+      "termEndDate": "2014-02-01",
+      "termStartDate": "2013-02-01",
+      "status": "Active",
+      "initialTerm": 12,
+      "autoRenew": true,
+      "subscriptionNumber": "A-S00001080",
+      "subscriptionStartDate": "2013-02-01",
+      "id": "2c92c8f83dc4f752013dc72bb85c0127",
+      "ratePlans": [
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "QSF_Tier"
+        }
+      ],
+      "termType": "TERMED",
+      "renewalTerm": 3
+    },
+    {
+      "termEndDate": "2014-04-01",
+      "termStartDate": "2013-12-01",
+      "status": "Cancelled",
+      "initialTerm": 10,
+      "autoRenew": false,
+      "subscriptionNumber": "A-S00001079",
+      "subscriptionStartDate": "2013-02-01",
+      "id": "2c92c8f83dc4f752013dc723fdab00d4",
+      "ratePlans": [
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "QSF_Tier"
+        }
+      ],
+      "termType": "TERMED",
+      "renewalTerm": 4
+    },
+    {
+      "termEndDate": "2012-02-11",
+      "termStartDate": "2011-02-11",
+      "status": "Active",
+      "initialTerm": 12,
+      "autoRenew": false,
+      "subscriptionNumber": "A-S00001076",
+      "subscriptionStartDate": "2011-02-11",
+      "id": "2c92c8f83db0b4b4013db4717ad000ec",
+      "ratePlans": [
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "Month_PerUnit"
+        },
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "Month_PerUnit"
+        }
+      ],
+      "termType": "TERMED",
+      "renewalTerm": 3
+    },
+    {
+      "termEndDate": "2012-02-11",
+      "termStartDate": "2011-02-11",
+      "status": "Active",
+      "initialTerm": 12,
+      "autoRenew": false,
+      "subscriptionNumber": "A-S00001075",
+      "subscriptionStartDate": "2011-02-11",
+      "id": "2c92c8f83db0b4b4013db3ab6a4d00bc",
+      "ratePlans": [
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "Month_PerUnit"
+        },
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "Month_PerUnit"
+        }
+      ],
+      "termType": "TERMED",
+      "renewalTerm": 3
+    },
+    {
+      "termEndDate": "2012-02-11",
+      "termStartDate": "2011-02-11",
+      "status": "Active",
+      "initialTerm": 12,
+      "autoRenew": false,
+      "subscriptionNumber": "A-S00001074",
+      "subscriptionStartDate": "2011-02-11",
+      "id": "2c92c8f83db0b4b4013db3aa9fbd0090",
+      "ratePlans": [
+        {
+          "productName": "Recurring Charge",
+          "ratePlanName": "Month_PerUnit"
+        }
+      ],
+      "termType": "TERMED",
+      "renewalTerm": 3
+    }
+  ],
+  "billToContact": {
+    "fax": "",
+    "taxRegion": "",
+    "country": "United States",
+    "zipCode": "95135",
+    "county": "",
+    "lastName": "Zou",
+    "workEmail": "work_email@zbcloud.com",
+    "state": "California",
+    "address2": "",
+    "address1": "1400 Bridge Pkwy",
+    "firstName": "Cheng",
+    "id": "2c92a0f9391832b10139183e27940043",
+    "workPhone": "5555551212",
+    "city": "San Jose"
+  }
+}""".stripMargin
+
+}

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
@@ -1,0 +1,81 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import play.api.libs.json.{ JsResult, JsSuccess, Json }
+import SourceUpdatedCallout._
+
+class StripeCustomerUpdatedReadsTest extends FlatSpec {
+
+  "SourceUpdatedCallout" should "deserialise correctly from a valid event" in {
+
+    val validEventJson =
+      """
+        |{
+        |  "id": "evt_abc123",
+        |  "object": "event",
+        |  "api_version": "2017-08-15",
+        |  "created": 1513761863,
+        |  "data": {
+        |    "object": {
+        |      "id": "card_def456",
+        |      "object": "card",
+        |      "address_city": null,
+        |      "address_country": null,
+        |      "address_line1": null,
+        |      "address_line1_check": null,
+        |      "address_line2": null,
+        |      "address_state": null,
+        |      "address_zip": null,
+        |      "address_zip_check": null,
+        |      "brand": "Visa",
+        |      "country": "US",
+        |      "customer": "cus_ghi789",
+        |      "cvc_check": "unchecked",
+        |      "dynamic_last4": null,
+        |      "exp_month": 7,
+        |      "exp_year": 2020,
+        |      "fingerprint": "abab1212",
+        |      "funding": "credit",
+        |      "last4": "1234",
+        |      "metadata": {
+        |      },
+        |      "name": null,
+        |      "tokenization_method": null
+        |    },
+        |    "previous_attributes": {
+        |      "exp_month": 5,
+        |      "exp_year": 2018
+        |    }
+        |  },
+        |  "livemode": true,
+        |  "pending_webhooks": 1,
+        |  "request": {
+        |    "id": null,
+        |    "idempotency_key": null
+        |  },
+        |  "type": "customer.source.updated"
+        |}
+      """.stripMargin
+
+    val expected: JsResult[SourceUpdatedCallout] = JsSuccess(
+      SourceUpdatedCallout(
+        id = StripeEventId("evt_abc123"),
+        data = EventData(
+          `object` = EventDataObject(
+            id = StripeSourceId("card_def456"),
+            customer = StripeCustomerId("cus_ghi789"),
+            exp_month = 7,
+            exp_year = 2020,
+            last4 = "1234"
+          )
+        )
+      )
+    )
+
+    val event: JsResult[SourceUpdatedCallout] = Json.parse(validEventJson).validate[SourceUpdatedCallout]
+
+    event should be(expected)
+  }
+
+}

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
@@ -64,12 +64,11 @@ class StripeCustomerUpdatedReadsTest extends FlatSpec {
         data = EventData(
           `object` = EventDataObject(
             id = StripeSourceId("card_def456"),
-            brand = "Visa",
-            country = "US",
+            brand = StripeBrand.Visa,
+            country = StripeCountry("US"),
             customer = StripeCustomerId("cus_ghi789"),
-            exp_month = 7,
-            exp_year = 2020,
-            last4 = "1234"
+            expiry = StripeExpiry(exp_month = 7, exp_year = 2020),
+            last4 = StripeLast4("1234")
           )
         )
       )

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
@@ -64,6 +64,8 @@ class StripeCustomerUpdatedReadsTest extends FlatSpec {
         data = EventData(
           `object` = EventDataObject(
             id = StripeSourceId("card_def456"),
+            brand = "Visa",
+            country = "US",
             customer = StripeCustomerId("cus_ghi789"),
             exp_month = 7,
             exp_year = 2020,

--- a/src/test/scala/com/gu/util/ApiGatewayHandlerReadsTest.scala
+++ b/src/test/scala/com/gu/util/ApiGatewayHandlerReadsTest.scala
@@ -1,0 +1,77 @@
+package com.gu.util
+
+import com.gu.util.apigateway.ApiGatewayRequest
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import play.api.libs.json.{ JsResult, JsSuccess, Json }
+
+class ApiGatewayHandlerReadsTest extends FlatSpec {
+
+  "ApiGatewayHandler" should "deserialise the headers too when receiving a request from Stripe" in {
+
+    val eventBodySimple: String = "{\'hello\': \'it is some stripe event info but what exactly, I do not mind right now\'}"
+
+    val eventHeaders = Map(
+      "SomeHeader1" -> "testvalue",
+      "Content-Type" -> "application/json",
+      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
+    )
+    val validApiGatewayEventJson =
+      s"""
+        |{
+        |    "resource": "/stripe-customer-source-updated",
+        |    "path": "/stripe-customer-source-updated",
+        |    "httpMethod": "POST",
+        |    "headers": {
+        |        "SomeHeader1": "testvalue",
+        |        "Content-Type": "application/json",
+        |        "Stripe-Signature": "t=1513759648,v1=longAlphanumericString"
+        |    },
+        |    "queryStringParameters": null,
+        |    "pathParameters": null,
+        |    "stageVariables": null,
+        |    "requestContext": {
+        |        "requestTime": "20/Dec/2017:08:47:29 +0000",
+        |        "path": "/CODE/stripe-customer-source-updated",
+        |        "accountId": "865473395570",
+        |        "protocol": "HTTP/1.1",
+        |        "resourceId": "ki15f3",
+        |        "stage": "CODE",
+        |        "requestTimeEpoch": 1513759649023,
+        |        "requestId": "690ee95d-e562-11e7-9699-d79373eb6f8c",
+        |        "identity": {
+        |            "cognitoIdentityPoolId": null,
+        |            "accountId": null,
+        |            "cognitoIdentityId": null,
+        |            "caller": null,
+        |            "sourceIp": "54.187.174.169",
+        |            "accessKey": null,
+        |            "cognitoAuthenticationType": null,
+        |            "cognitoAuthenticationProvider": null,
+        |            "userArn": null,
+        |            "userAgent": "Stripe/1.0 (+https://stripe.com/docs/webhooks)",
+        |            "user": null
+        |        },
+        |        "resourcePath": "/stripe-customer-source-updated",
+        |        "httpMethod": "POST",
+        |        "apiId": "aefy0066u0"
+        |    },
+        |    "body": "$eventBodySimple",
+        |    "isBase64Encoded": false
+        |}
+      """.stripMargin
+
+    val expected: JsResult[ApiGatewayRequest] = JsSuccess(
+      ApiGatewayRequest(
+        queryStringParameters = None,
+        body = eventBodySimple,
+        headers = Some(eventHeaders)
+      )
+    )
+
+    val event: JsResult[ApiGatewayRequest] = Json.parse(validApiGatewayEventJson).validate[ApiGatewayRequest]
+
+    event should be(expected)
+  }
+
+}

--- a/src/test/scala/com/gu/util/AuthTest.scala
+++ b/src/test/scala/com/gu/util/AuthTest.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{ JsError, JsSuccess, JsValue, Json }
 
 class AuthTest extends FlatSpec {
 
-  val trustedApiConfig = TrustedApiConfig("validUser", "correctPassword", "tenant123")
+  val trustedApiConfig = TrustedApiConfig("correctPassword", "tenant123")
 
   def generateInputEvent(apiClientId: String, apiToken: String): JsValue = {
 
@@ -43,17 +43,12 @@ class AuthTest extends FlatSpec {
   }
 
   "credentialsAreValid" should "return true for correct credentials" in {
-    val requestAuth = Some(RequestAuth(apiClientId = "validUser", apiToken = "correctPassword"))
+    val requestAuth = Some(RequestAuth(apiToken = "correctPassword"))
     assert(credentialsAreValid(requestAuth, trustedApiConfig) == true)
   }
 
-  "credentialsAreValid" should "return false for an incorrect user" in {
-    val requestAuth = Some(RequestAuth(apiClientId = "invalidUser", apiToken = "correctPassword"))
-    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
-  }
-
   "credentialsAreValid" should "return false for an incorrect password" in {
-    val requestAuth = Some(RequestAuth(apiClientId = "validUser", apiToken = "ndjashjkhajshs"))
+    val requestAuth = Some(RequestAuth(apiToken = "ndjashjkhajshs"))
     assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
   }
 

--- a/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -12,8 +12,15 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
     //    val requestAuth = Some(RequestAuth(apiClientId = "validUser", apiToken = "ndjashjkhajshs"))
     //    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
     val prod = Config.parseConfig(TestData.codeConfig)
-    prod should be(Success(Config(Stage("DEV"), TrustedApiConfig("b", "c"), zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
-      etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"))))
+    prod should be(Success(
+      Config(
+        Stage("DEV"),
+        TrustedApiConfig("b", "c"),
+        zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
+        etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"),
+        stripeConfig = StripeConfig(StripeSecretKey("abc"), StripeSecretKey("def"))
+      )
+    ))
   }
 
 }

--- a/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -12,7 +12,7 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
     //    val requestAuth = Some(RequestAuth(apiClientId = "validUser", apiToken = "ndjashjkhajshs"))
     //    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
     val prod = Config.parseConfig(TestData.codeConfig)
-    prod should be(Success(Config(Stage("DEV"), TrustedApiConfig("a", "b", "c"), zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
+    prod should be(Success(Config(Stage("DEV"), TrustedApiConfig("b", "c"), zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
       etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"))))
   }
 

--- a/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -41,7 +41,7 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
   val validUpdateSubscriptionResult = Json.parse(
     """{
       |  "success": true,
-      |  "id": "id123", "balance": 1.2, "defaultPaymentMethod": "pmid"
+      |  "id": "id123", "balance": 1.2, "defaultPaymentMethod": {"id": "pmid"}
       |}""".stripMargin
   )
 

--- a/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -1,6 +1,7 @@
 package com.gu.util
 
 import com.gu.util.apigateway.ApiGatewayResponse._
+import com.gu.util.zuora.ZuoraGetAccountSummary.BasicAccountInfo
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora.ZuoraReaders._

--- a/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -2,6 +2,7 @@ package com.gu.util
 
 import com.gu.util.apigateway.ApiGatewayResponse._
 import com.gu.util.zuora.ZuoraModels._
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.ZuoraRestRequestMaker
 import okhttp3._
@@ -40,7 +41,7 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
   val validUpdateSubscriptionResult = Json.parse(
     """{
       |  "success": true,
-      |  "id": "id123", "balance": 1.2
+      |  "id": "id123", "balance": 1.2, "defaultPaymentMethod": "pmid"
       |}""".stripMargin
   )
 
@@ -97,13 +98,14 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
   it should "return a right[T] if the body of a successful response deserializes to T" in {
     val response = constructTestResponse(200, validUpdateSubscriptionResult)
     val either = ZuoraRestRequestMaker.convertResponseToCaseClass[BasicAccountInfo](response)
-    assert(either == \/-(BasicAccountInfo(id = "id123", balance = 1.2)))
+    val basicInfo = BasicAccountInfo(AccountId("id123"), 1.2, PaymentMethodId("pmid"))
+    either should be(\/-(basicInfo))
   }
 
   it should "return a right[Unit] if the body of a successful response deserializes to Unit" in {
     val response = constructTestResponse(200, validUpdateSubscriptionResult)
     val either = ZuoraRestRequestMaker.convertResponseToCaseClass[Unit](response)
-    assert(either == \/-(()))
+    either should be(\/-(()))
   }
 
   it should "return a left[String] if the body of a successful http response has a zuora failed in it" in {


### PR DESCRIPTION
This is needed so that when stripe cards are updated automcatically, we still have the information cached in zuora to say what the expiry and last4 are.  This is useful for display to the customer and for outbound calling for expired cards.

See https://stripe.com/blog/smarter-saved-cards

We can do the follow up changes in a later PR for checking signatures, while the backfill is going on.  This should be fine because the api token will be checked regardless.

The url would have to be of the form 
/CODE/stripe-customer-source-updated?apiToken=SUPERSECRET&stripeAccount=GNM_Membership_AUS

comments please @paulbrown1982 @jacobwinch @lmath 