### PR TITLE
Verify Stripe-Signature

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "com.github.nscala-time" % "nscala-time_2.12" % "2.16.0",
-  "org.apache.commons" % "commons-io" % "1.3.2"
+  "org.apache.commons" % "commons-io" % "1.3.2",
+  "com.stripe" % "stripe-java" % "5.28.0"
 )
 
 initialize := {

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -1,7 +1,10 @@
 package com.gu.stripeCustomerSourceUpdated
 
+import com.gu.util.StripeConfig
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+
+case class StripeDeps(config: StripeConfig)
 
 case class EventData(`object`: EventDataObject)
 case class EventDataObject(

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -4,8 +4,6 @@ import com.gu.util.StripeConfig
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class StripeDeps(config: StripeConfig)
-
 case class EventData(`object`: EventDataObject)
 case class EventDataObject(
   id: StripeSourceId,

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
@@ -1,0 +1,31 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.logger
+import com.gu.util.StripeConfig
+import com.stripe.exception.SignatureVerificationException
+import com.stripe.net.Webhook.Signature
+
+import scala.util.Try
+
+object StripeSignatureChecker {
+
+  def verifyStripeSignature(stripeConfig: StripeConfig, headers: Map[String, String], payload: String) =
+    verifyStripeSignatureForAccount(stripeConfig.ukStripeSecretKey.key, headers, payload) || verifyStripeSignatureForAccount(stripeConfig.auStripeSecretKey.key, headers, payload)
+
+  private def verifyStripeSignatureForAccount(secretKey: String, headers: Map[String, String], payload: String) = {
+    val signatureHeader: Option[String] = headers.get("Stripe-Signature")
+    val headerVerified: Try[Boolean] = Try(Signature.verifyHeader(payload, signatureHeader.get, secretKey, 1000l))
+
+    val falseIfNotSigned = headerVerified recover {
+      case e: SignatureVerificationException => {
+        logger.error(s"something went wrong with sig header: ${e.getSigHeader} D:< with message ${e.getMessage}")
+        false
+      }
+      case e: Throwable => {
+        logger.error(s"something went wrong with verifying the signature header D:< with message ${e.getMessage}")
+        false
+      }
+    }
+    falseIfNotSigned.get //because false if any throwable
+  }
+}

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
@@ -15,7 +15,7 @@ object StripeRequestSignatureChecker {
     val signatureHeader: Option[String] = headers.get("Stripe-Signature")
 
     stripeAccount.exists { account =>
-      val secretKey = if (account == StripeAccount.GNM_Membership_AUS) stripeDeps.config.auStripeSecretKey else stripeDeps.config.ukStripeSecretKey
+      val secretKey = if (account == StripeAccount.GNM_Membership_AUS) stripeDeps.config.customerSourceUpdatedWebhook.auStripeSecretKey else stripeDeps.config.customerSourceUpdatedWebhook.ukStripeSecretKey
       val headerVerified: Try[Boolean] = Try(stripeDeps.signatureChecker.verifySignature(secretKey, payload, signatureHeader, 10000l))
 
       headerVerified match {

--- a/src/main/scala/com/gu/util/ConfigLoader.scala
+++ b/src/main/scala/com/gu/util/ConfigLoader.scala
@@ -72,12 +72,17 @@ object StripeSecretKey {
   implicit val stripeSecretKeyReads = Json.reads[StripeSecretKey]
 }
 
-case class StripeConfig(ukStripeSecretKey: StripeSecretKey, auStripeSecretKey: StripeSecretKey)
-object StripeConfig {
-  implicit val apiConfigReads: Reads[StripeConfig] = (
+case class StripeWebhook(ukStripeSecretKey: StripeSecretKey, auStripeSecretKey: StripeSecretKey)
+object StripeWebhook {
+  implicit val stripeWebhookConfigReads: Reads[StripeWebhook] = (
     (JsPath \ "api.key.secret").read[String].map(StripeSecretKey.apply) and
     (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply)
-  )(StripeConfig.apply _)
+  )(StripeWebhook.apply _)
+}
+
+case class StripeConfig(customerSourceUpdatedWebhook: StripeWebhook)
+object StripeConfig {
+  implicit val stripeConfigReads = Json.reads[StripeConfig]
 }
 
 case class Config(

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -2,6 +2,7 @@ package com.gu
 
 import com.gu.TestingRawEffects.BasicResult
 import com.gu.effects.RawEffects
+import com.gu.stripeCustomerSourceUpdated.StripeDeps
 import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.HandlerDeps
@@ -36,6 +37,7 @@ object TestData extends Matchers {
   val fakeZuoraConfig = ZuoraRestConfig("https://ddd", "fakeUser", "fakePass")
   val fakeETSendIds = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can"))
   val fakeETConfig = ETConfig(etSendIDs = fakeETSendIds, "fakeClientId", "fakeClientSecret")
+  val fakeStripeConfig = StripeConfig(StripeSecretKey("ukStripeSecretKey"), StripeSecretKey("auStripeSecretKey"))
 
   val fakeConfig = Config(
     stage = Stage("DEV"),
@@ -102,7 +104,7 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
 
   val stage = Stage(if (isProd) "PROD" else "DEV")
 
-  def basicResults = result.map { request =>
+  def requestsAttempted = result.map { request =>
     val buffer = new Buffer()
     Option(request.body()).foreach(_.writeTo(buffer))
     val body = buffer.readString(UTF_8)
@@ -125,6 +127,7 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
 
   def handlerDeps(operation: Config => ApiGatewayRequest => FailableOp[Unit]) = HandlerDeps(() => Success(""), Stage("DEV"), _ => Success(TestData.fakeConfig), operation)
   val zuoraDeps = ZuoraDeps(response, TestData.fakeZuoraConfig)
+  val stripeDeps = StripeDeps(TestData.fakeStripeConfig)
 
 }
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -2,7 +2,7 @@ package com.gu
 
 import com.gu.TestingRawEffects.BasicResult
 import com.gu.effects.RawEffects
-import com.gu.stripeCustomerSourceUpdated.StripeDeps
+import com.gu.stripeCustomerSourceUpdated.{ StripeDeps, StripeSignatureChecker }
 import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.HandlerDeps
@@ -127,7 +127,7 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
 
   def handlerDeps(operation: Config => ApiGatewayRequest => FailableOp[Unit]) = HandlerDeps(() => Success(""), Stage("DEV"), _ => Success(TestData.fakeConfig), operation)
   val zuoraDeps = ZuoraDeps(response, TestData.fakeZuoraConfig)
-  val stripeDeps = StripeDeps(TestData.fakeStripeConfig)
+  val stripeDeps = StripeDeps(TestData.fakeStripeConfig, new StripeSignatureChecker)
 
 }
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -37,7 +37,7 @@ object TestData extends Matchers {
   val fakeZuoraConfig = ZuoraRestConfig("https://ddd", "fakeUser", "fakePass")
   val fakeETSendIds = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can"))
   val fakeETConfig = ETConfig(etSendIDs = fakeETSendIds, "fakeClientId", "fakeClientSecret")
-  val fakeStripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(StripeSecretKey("ukcustomerSourceUpdatedSecretKey"), StripeSecretKey("aucustomerSourceUpdatedStripeSecretKey")))
+  val fakeStripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(StripeSecretKey("ukCustomerSourceUpdatedSecretKey"), StripeSecretKey("auCustomerSourceUpdatedStripeSecretKey")))
 
   val fakeConfig = Config(
     stage = Stage("DEV"),

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -37,14 +37,14 @@ object TestData extends Matchers {
   val fakeZuoraConfig = ZuoraRestConfig("https://ddd", "fakeUser", "fakePass")
   val fakeETSendIds = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can"))
   val fakeETConfig = ETConfig(etSendIDs = fakeETSendIds, "fakeClientId", "fakeClientSecret")
-  val fakeStripeConfig = StripeConfig(StripeSecretKey("ukStripeSecretKey"), StripeSecretKey("auStripeSecretKey"))
+  val fakeStripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(StripeSecretKey("ukcustomerSourceUpdatedSecretKey"), StripeSecretKey("aucustomerSourceUpdatedStripeSecretKey")))
 
   val fakeConfig = Config(
     stage = Stage("DEV"),
     trustedApiConfig = fakeApiConfig,
     zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
     etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"),
-    stripeConfig = StripeConfig(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def"))
+    stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")))
   )
 
   val missingCredentialsResponse = """{"statusCode":"401","headers":{"Content-Type":"application/json"},"body":"Credentials are missing or invalid"}"""
@@ -76,8 +76,10 @@ object TestData extends Matchers {
       |    "clientSecret": "kkk"
       |  },
       |  "stripe": {
-      |     "api.key.secret": "abc",
-      |     "au-membership.key.secret": "def"
+      |     "customerSourceUpdatedWebhook": {
+      |       "api.key.secret": "abc",
+      |       "au-membership.key.secret": "def"
+      |     }
       |  }
       |}
     """.stripMargin

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -37,7 +37,7 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
     val effects = new TestingRawEffects(false, 200)
     AutoCancel(effects.zuoraDeps)(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now))
 
-    effects.basicResults should contain(BasicResult("PUT", "/accounts/AID", "{\"autoPay\":false}"))
+    effects.requestsAttempted should contain(BasicResult("PUT", "/accounts/AID", "{\"autoPay\":false}"))
   }
 
   //  // todo need an ACSDeps so we don't need so many mock requests

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -2,9 +2,8 @@ package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.TestingRawEffects
 import com.gu.TestingRawEffects.BasicResult
-import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.AccountId
-import okhttp3.Request
 import org.scalatest.{ FlatSpec, Matchers }
 
 import scalaz.{ -\/, \/- }
@@ -14,18 +13,17 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
   "SourceUpdatedSteps" should "getAccountToUpdate non default pm" in {
     val effects = new TestingRawEffects(false, 500, Map(
       ("/action/query", (200, """{
-                                |  "records": [
-                                |    {
-                                |      "Id": "nondefaultPMID",
-                                |      "AccountId": "accid"
-                                |    }
-                                |  ],
-                                |  "size": 1,
-                                |  "done": true
-                                |}""".stripMargin)), //defaultPMID
+                                  |  "records": [
+                                  |    {
+                                  |      "Id": "nondefaultPMID",
+                                  |      "AccountId": "accid"
+                                  |    }
+                                  |  ],
+                                  |  "size": 1,
+                                  |  "done": true
+                                  |}""".stripMargin)), //defaultPMID
       ("/accounts/accid/summary", (200, accountSummaryJson))
     ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
     val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -40,25 +38,24 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       ""
     )
 
-    effects.basicResults should be(List(expectedGET, expectedPOST))
+    effects.requestsAttempted should be(List(expectedGET, expectedPOST))
     actual should be(-\/(ApiGatewayResponse.successfulExecution))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate default pm" in {
     val effects = new TestingRawEffects(false, 500, Map(
       ("/action/query", (200, """{
-                                |  "records": [
-                                |    {
-                                |      "Id": "defaultPMID",
-                                |      "AccountId": "accid"
-                                |    }
-                                |  ],
-                                |  "size": 1,
-                                |  "done": true
-                                |}""".stripMargin)), //defaultPMID
+                                  |  "records": [
+                                  |    {
+                                  |      "Id": "defaultPMID",
+                                  |      "AccountId": "accid"
+                                  |    }
+                                  |  ],
+                                  |  "size": 1,
+                                  |  "done": true
+                                  |}""".stripMargin)), //defaultPMID
       ("/accounts/accid/summary", (200, accountSummaryJson))
     ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
     val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -73,29 +70,28 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       ""
     )
 
-    effects.basicResults should be(List(expectedGET, expectedPOST))
+    effects.requestsAttempted should be(List(expectedGET, expectedPOST))
     actual should be(\/-(AccountId("accountidfake")))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate default pm with multiple on the same account" in {
     val effects = new TestingRawEffects(false, 500, Map(
       ("/action/query", (200, """{
-                                |  "records": [
-                                |    {
-                                |      "Id": "defaultPMID",
-                                |      "AccountId": "accountidfake"
-                                |    },
-                                |    {
-                                |      "Id": "anotherPM",
-                                |      "AccountId": "accountidfake"
-                                |    }
-                                |  ],
-                                |  "size": 2,
-                                |  "done": true
-                                |}""".stripMargin)), //defaultPMID
+                                  |  "records": [
+                                  |    {
+                                  |      "Id": "defaultPMID",
+                                  |      "AccountId": "accountidfake"
+                                  |    },
+                                  |    {
+                                  |      "Id": "anotherPM",
+                                  |      "AccountId": "accountidfake"
+                                  |    }
+                                  |  ],
+                                  |  "size": 2,
+                                  |  "done": true
+                                  |}""".stripMargin)), //defaultPMID
       ("/accounts/accountidfake/summary", (200, accountSummaryJson))
     ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
     val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -110,29 +106,28 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       ""
     )
 
-    effects.basicResults should be(List(expectedGET, expectedPOST))
+    effects.requestsAttempted should be(List(expectedGET, expectedPOST))
     actual should be(\/-(AccountId("accountidfake")))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account" in {
     val effects = new TestingRawEffects(false, 500, Map(
       ("/action/query", (200, """{
-                                |  "records": [
-                                |    {
-                                |      "Id": "defaultPMID",
-                                |      "AccountId": "accountidfake"
-                                |    },
-                                |    {
-                                |      "Id": "anotherPM",
-                                |      "AccountId": "accountidANOTHER"
-                                |    }
-                                |  ],
-                                |  "size": 2,
-                                |  "done": true
-                                |}""".stripMargin)), //defaultPMID
+                                  |  "records": [
+                                  |    {
+                                  |      "Id": "defaultPMID",
+                                  |      "AccountId": "accountidfake"
+                                  |    },
+                                  |    {
+                                  |      "Id": "anotherPM",
+                                  |      "AccountId": "accountidANOTHER"
+                                  |    }
+                                  |  ],
+                                  |  "size": 2,
+                                  |  "done": true
+                                  |}""".stripMargin)), //defaultPMID
       ("/accounts/accountidfake/summary", (200, accountSummaryJson))
     ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
     val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -141,21 +136,20 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
-    effects.basicResults should be(List(expectedPOST))
+    effects.requestsAttempted should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate no payment methods at all" in {
     val effects = new TestingRawEffects(false, 500, Map(
       ("/action/query", (200, """{
-                                |  "records": [
-                                |  ],
-                                |  "size": 0,
-                                |  "done": true
-                                |}""".stripMargin)), //defaultPMID
+                                  |  "records": [
+                                  |  ],
+                                  |  "size": 0,
+                                  |  "done": true
+                                  |}""".stripMargin)), //defaultPMID
       ("/accounts/accountidfake/summary", (200, accountSummaryJson))
     ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
     val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -164,7 +158,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
-    effects.basicResults should be(List(expectedPOST))
+    effects.requestsAttempted should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
 
@@ -176,7 +170,6 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       ("/object/payment-method", (200, """{"Success": true,"Id": "newPMID"}""")),
       ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))
     ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
     val eventData = EventDataObject(
       id = StripeSourceId("card_def456"),
@@ -200,8 +193,56 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       """{"DefaultPaymentMethodId":"newPMID"}"""
     )
 
-    effects.basicResults should be(List(expectedPUT, expectedPOST))
+    effects.requestsAttempted should be(List(expectedPUT, expectedPOST))
     actual should be(\/-(()))
+  }
+
+  "SourceUpdatedSteps" should "fail with unauthorised if the Stripe Signature header check fails" in {
+    val effects = new TestingRawEffects(false, 500)
+    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps, effects.stripeDeps)
+
+    val badHeaders = Map(
+      "SomeHeader1" -> "testvalue",
+      "Content-Type" -> "application/json",
+      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
+    )
+
+    val someBody =
+      """
+        |{
+        |  "id": "evt_lettersAndNumbers",
+        |  "data": {
+        |    "object": {
+        |      "id": "card_lettersAndNumbers",
+        |      "object": "card",
+        |      "brand": "Visa",
+        |      "country": "US",
+        |      "customer": "cus_lettersAndNumbers",
+        |      "exp_month": 7,
+        |      "exp_year": 2020,
+        |      "fingerprint": "lettersAndNumbers",
+        |      "funding": "credit",
+        |      "last4": "1234",
+        |      "name": null,
+        |      "tokenization_method": null
+        |    }
+        |  },
+        |  "livemode": true,
+        |  "pending_webhooks": 1,
+        |  "request": {
+        |    "id": null,
+        |    "idempotency_key": null
+        |  },
+        |  "type": "customer.source.updated"
+        |}
+      """.stripMargin
+
+    val testGatewayRequest = ApiGatewayRequest(None, someBody.toString, Some(badHeaders))
+
+    val actual = SourceUpdatedSteps.apply(sourceUpdatedSteps)(testGatewayRequest)
+
+    effects.requestsAttempted should be(Nil)
+    actual.leftMap(_.statusCode) should be(-\/("401"))
   }
 
   val accountSummaryJson =

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
@@ -84,9 +84,9 @@ class StripeRequestSignatureCheckerTest extends FlatSpec {
     override def verifySignature(secretKey: StripeSecretKey, payload: String, signatureHeader: Option[String], tolerance: Long): Boolean = {
       val signatureHeaderWithoutTimestamp = signatureHeader map { header => header.split("v1=")(1) }
       (secretKey, payload, signatureHeaderWithoutTimestamp, tolerance) match {
-        case (TestData.fakeStripeConfig.auStripeSecretKey, _, Some("longAlphanumericString"), _) => false
-        case (TestData.fakeStripeConfig.ukStripeSecretKey, _, Some("test signature"), _) => true
-        case (TestData.fakeStripeConfig.auStripeSecretKey, _, Some("test signature"), _) => true
+        case (TestData.fakeStripeConfig.customerSourceUpdatedWebhook.auStripeSecretKey, _, Some("longAlphanumericString"), _) => false
+        case (TestData.fakeStripeConfig.customerSourceUpdatedWebhook.ukStripeSecretKey, _, Some("test signature"), _) => true
+        case (TestData.fakeStripeConfig.customerSourceUpdatedWebhook.auStripeSecretKey, _, Some("test signature"), _) => true
         case (_, _, _, _) => false
       }
     }

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
@@ -1,0 +1,96 @@
+package com.gu.stripeCustomerSourceUpdated
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import StripeSignatureChecker._
+import com.gu.TestData
+import org.joda.time.DateTime
+
+class StripeSignatureCheckerTest extends FlatSpec {
+
+  "verifySignature" should "fail if the signature is nonsense" in {
+    val badHeaders = headersWithStripeSignature("1513759648", "longAlphanumericString")
+
+    //when
+    val signatureCheckPassed = verifyStripeSignature(stripeConfig = TestData.fakeStripeConfig, headers = badHeaders, payload = someBody)
+
+    signatureCheckPassed shouldBe (false)
+  }
+
+  it should "succeed if the secret key is correct" in {
+    val nowInSeconds = (DateTime.now().getMillis / 1000).toString
+
+    val sigJava = makeExpectedSignature(nowInSeconds, someBody, TestData.fakeStripeConfig.ukStripeSecretKey.key)
+    val headers = headersWithStripeSignature(nowInSeconds, sigJava)
+
+    //when
+    val signatureCheckPassed = verifyStripeSignature(stripeConfig = TestData.fakeStripeConfig, headers = headers, payload = someBody)
+
+    signatureCheckPassed shouldBe (true)
+  }
+
+  it should "still work if signature made using AU secret key" in {
+    val nowInSeconds = (DateTime.now().getMillis / 1000).toString
+
+    val sigJava = makeExpectedSignature(nowInSeconds, someBody, TestData.fakeStripeConfig.auStripeSecretKey.key)
+    val headers = headersWithStripeSignature(nowInSeconds, sigJava)
+
+    //when
+    val signatureCheckPassed = verifyStripeSignature(stripeConfig = TestData.fakeStripeConfig, headers = headers, payload = someBody)
+
+    signatureCheckPassed shouldBe (true)
+  }
+
+  val someBody =
+    """
+      |{
+      |  "id": "evt_lettersAndNumbers",
+      |  "data": {
+      |    "object": {
+      |      "id": "card_lettersAndNumbers",
+      |      "object": "card",
+      |      "brand": "Visa",
+      |      "country": "US",
+      |      "customer": "cus_lettersAndNumbers",
+      |      "exp_month": 7,
+      |      "exp_year": 2020,
+      |      "fingerprint": "lettersAndNumbers",
+      |      "funding": "credit",
+      |      "last4": "1234",
+      |      "name": null,
+      |      "tokenization_method": null
+      |    }
+      |  },
+      |  "livemode": true,
+      |  "pending_webhooks": 1,
+      |  "request": {
+      |    "id": null,
+      |    "idempotency_key": null
+      |  },
+      |  "type": "customer.source.updated"
+      |}
+    """.stripMargin
+
+  def headersWithStripeSignature(timestamp: String, signature: String) = Map(
+    "SomeHeader1" -> "testvalue",
+    "Content-Type" -> "application/json",
+    "Stripe-Signature" -> s"t=$timestamp,v1=$signature"
+  )
+
+  def makeExpectedSignature(timestamp: String, payload: String, secretKey: String) = {
+    val signedPayload = s"$timestamp.$payload"
+
+    val hasher = Mac.getInstance("HmacSHA256")
+    hasher.init(new SecretKeySpec(secretKey.getBytes("UTF8"), "HmacSHA256"))
+    val hash: Array[Byte] = hasher.doFinal(signedPayload.getBytes("UTF8"))
+
+    var result = ""
+    for (b <- hash) {
+      result += Integer.toString((b & 0xff) + 0x100, 16).substring(1)
+    }
+    result
+  }
+}

--- a/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -18,7 +18,7 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
         TrustedApiConfig("b", "c"),
         zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
         etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"),
-        stripeConfig = StripeConfig(StripeSecretKey("abc"), StripeSecretKey("def"))
+        stripeConfig = StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")))
       )
     ))
   }


### PR DESCRIPTION
In the Stripe Customer Source Updated lambda, we receive events customer.source.updated events from Stripe. Stripe [signs](https://stripe.com/docs/webhooks#signatures) these requests. Here, we check the signature and verify that the requests are coming from Stripe. 