### PR TITLE
dont take payment for outstanding invoices when stripe expiry update comes in

### DIFF
--- a/src/main/scala/com/gu/util/zuora/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/CreatePaymentMethod.scala
@@ -2,7 +2,7 @@ package com.gu.util.zuora
 
 import com.gu.stripeCustomerSourceUpdated._
 import com.gu.util.reader.Types.WithDepsFailableOp
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, NumConsecutiveFailures, PaymentMethodId }
 import com.gu.util.zuora.ZuoraRestRequestMaker.post
 import play.api.libs.json.{ JsPath, Json, Reads, Writes }
 
@@ -15,7 +15,8 @@ object CreatePaymentMethod {
     cardCountry: StripeCountry,
     last4: StripeLast4,
     expiration: StripeExpiry,
-    creditCardType: CreditCardType
+    creditCardType: CreditCardType,
+    numConsecutiveFailures: NumConsecutiveFailures
   )
 
   sealed abstract class CreditCardType(val value: String)
@@ -38,7 +39,8 @@ object CreatePaymentMethod {
       "CreditCardExpirationMonth" -> command.expiration.exp_month,
       "CreditCardExpirationYear" -> command.expiration.exp_year,
       "CreditCardType" -> command.creditCardType.value,
-      "Type" -> "CreditCardReferenceTransaction"
+      "Type" -> "CreditCardReferenceTransaction",
+      "NumConsecutiveFailures" -> command.numConsecutiveFailures
     )
   }
 

--- a/src/main/scala/com/gu/util/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraQueryPaymentMethod.scala
@@ -14,12 +14,14 @@ object ZuoraQueryPaymentMethod {
   case class SecondTokenId(value: String) extends AnyVal
   case class PaymentMethodId(value: String) extends AnyVal
   case class AccountId(value: String) extends AnyVal
+  case class NumConsecutiveFailures(value: Int) extends AnyVal
   case class CreditCardExpirationMonth(value: Int) extends AnyVal
   case class CreditCardExpirationYear(value: Int) extends AnyVal
   case class CreditCardMaskNumber(value: String) extends AnyVal
   case class PaymentMethodFields(
     Id: PaymentMethodId,
-    AccountId: AccountId
+    AccountId: AccountId,
+    NumConsecutiveFailures: NumConsecutiveFailures
   )
   implicit val fPaymentMethodId: Format[PaymentMethodId] =
     Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), Writes { (o: PaymentMethodId) => JsString(o.value) })
@@ -27,21 +29,24 @@ object ZuoraQueryPaymentMethod {
   implicit val fAccountId: Format[AccountId] =
     Format[AccountId](JsPath.read[String].map(AccountId.apply), Writes { (o: AccountId) => JsString(o.value) })
 
+  implicit val fNumConsecutiveFailures: Format[NumConsecutiveFailures] =
+    Format[NumConsecutiveFailures](JsPath.read[Int].map(NumConsecutiveFailures.apply), Writes { (o: NumConsecutiveFailures) => JsNumber(o.value) })
+
   implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
 
-  case class AccountPaymentMethodIds(accountId: AccountId, paymentMethodIds: NonEmptyList[PaymentMethodId])
+  case class AccountPaymentMethodIds(accountId: AccountId, paymentMethods: NonEmptyList[PaymentMethodFields])
 
   def getPaymentMethodForStripeCustomer(customerId: StripeCustomerId, sourceId: StripeSourceId): WithDepsFailableOp[ZuoraDeps, AccountPaymentMethodIds] = {
     import com.gu.util.reader.Types._
     val query =
-      s"""SELECT Id, AccountId
+      s"""SELECT Id, AccountId, NumConsecutiveFailures
          | FROM PaymentMethod
          |  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = '${sourceId.value}' AND SecondTokenId = '${customerId.value}'""".stripMargin
 
     ZuoraQuery.query[PaymentMethodFields](Query(query)).run.map(_.flatMap { result =>
       result.records.groupBy(_.AccountId).toList match {
         case (account, first :: rest) :: Nil =>
-          \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*).map(_.Id)))
+          \/-(AccountPaymentMethodIds(account, NonEmptyList(first, rest: _*)))
         case _ =>
           logger.warn(s"wrong number of accounts using the customer token: $result")
           -\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details"))

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -3,7 +3,7 @@ package com.gu.stripeCustomerSourceUpdated
 import com.gu.TestingRawEffects
 import com.gu.TestingRawEffects.BasicResult
 import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.zuora.ZuoraQueryPaymentMethod.AccountId
+import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, NumConsecutiveFailures, PaymentMethodFields, PaymentMethodId }
 import okhttp3.Request
 import org.scalatest.{ FlatSpec, Matchers }
 
@@ -17,7 +17,8 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "records": [
                                 |    {
                                 |      "Id": "nondefaultPMID",
-                                |      "AccountId": "accid"
+                                |      "AccountId": "accid",
+                                |      "NumConsecutiveFailures": 3
                                 |    }
                                 |  ],
                                 |  "size": 1,
@@ -32,7 +33,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET = BasicResult(
       "GET",
@@ -50,7 +51,8 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "records": [
                                 |    {
                                 |      "Id": "defaultPMID",
-                                |      "AccountId": "accid"
+                                |      "AccountId": "accid",
+                                |      "NumConsecutiveFailures": 3
                                 |    }
                                 |  ],
                                 |  "size": 1,
@@ -65,7 +67,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET = BasicResult(
       "GET",
@@ -74,7 +76,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     )
 
     effects.basicResults should be(List(expectedGET, expectedPOST))
-    actual should be(\/-(AccountId("accountidfake")))
+    actual should be(\/-(PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accid"), NumConsecutiveFailures(3))))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate default pm with multiple on the same account" in {
@@ -83,11 +85,13 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "records": [
                                 |    {
                                 |      "Id": "defaultPMID",
-                                |      "AccountId": "accountidfake"
+                                |      "AccountId": "accountidfake",
+                                |      "NumConsecutiveFailures": 2
                                 |    },
                                 |    {
                                 |      "Id": "anotherPM",
-                                |      "AccountId": "accountidfake"
+                                |      "AccountId": "accountidfake",
+                                |      "NumConsecutiveFailures": 4
                                 |    }
                                 |  ],
                                 |  "size": 2,
@@ -102,7 +106,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET = BasicResult(
       "GET",
@@ -111,7 +115,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     )
 
     effects.basicResults should be(List(expectedGET, expectedPOST))
-    actual should be(\/-(AccountId("accountidfake")))
+    actual should be(\/-(PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2))))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account" in {
@@ -120,11 +124,13 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "records": [
                                 |    {
                                 |      "Id": "defaultPMID",
-                                |      "AccountId": "accountidfake"
+                                |      "AccountId": "accountidfake",
+                                |      "NumConsecutiveFailures": 2
                                 |    },
                                 |    {
                                 |      "Id": "anotherPM",
-                                |      "AccountId": "accountidANOTHER"
+                                |      "AccountId": "accountidANOTHER",
+                                |      "NumConsecutiveFailures": 4
                                 |    }
                                 |  ],
                                 |  "size": 2,
@@ -139,7 +145,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     effects.basicResults should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
@@ -162,7 +168,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     effects.basicResults should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
@@ -187,12 +193,12 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       last4 = StripeLast4("1234")
     )
 
-    val actual = SourceUpdatedSteps.updatePaymentMethod(AccountId("fake"), eventData).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.updatePaymentMethod(PaymentMethodFields(PaymentMethodId("PMID"), AccountId("fake"), NumConsecutiveFailures(1)), eventData).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/object/payment-method",
-      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction"}"""
+      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction","NumConsecutiveFailures":1}"""
     )
     val expectedPUT = BasicResult(
       "PUT",

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -28,7 +28,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     ))
     val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
-    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.getPaymentMethodToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
@@ -62,7 +62,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     ))
     val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
-    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.getPaymentMethodToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
@@ -101,7 +101,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     ))
     val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
-    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.getPaymentMethodToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
@@ -140,7 +140,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     ))
     val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
-    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.getPaymentMethodToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
@@ -163,7 +163,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     ))
     val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
 
-    val actual = SourceUpdatedSteps.getAccountToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.getPaymentMethodToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
@@ -193,7 +193,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       last4 = StripeLast4("1234")
     )
 
-    val actual = SourceUpdatedSteps.updatePaymentMethod(PaymentMethodFields(PaymentMethodId("PMID"), AccountId("fake"), NumConsecutiveFailures(1)), eventData).run.run(effects.zuoraDeps)
+    val actual = SourceUpdatedSteps.createUpdatedDefaultPaymentMethod(PaymentMethodFields(PaymentMethodId("PMID"), AccountId("fake"), NumConsecutiveFailures(1)), eventData).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",


### PR DESCRIPTION
So I realised that by creating a fresh payment method with the same stripe ids, this would reset the payment failure count for the default payment method back to zero.
This could cause zuora to resume trying to charge any outstanding invoices where auto pay is left on.

Since we are not sure how many people this would affect, I have changed it to copy the payment failure count to the new payment method object in zuora.  This should prevent the user being charged too many times, although it would bring forward the next retry to the next day, rather than waiting a week between payment attempts.  This may actually not be a bad idea.

Thanks for the help @jacobwinch 
cc @paulbrown1982 @lmath 