### PR TITLE
update dependencies to the latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,6 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.18",
   "com.typesafe.play" %% "play-json" % "2.6.8",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "org.apache.commons" % "commons-io" % "1.3.2",
   "com.stripe" % "stripe-java" % "5.28.0"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "zuora-auto-cancel"
 description:= "Handles auto-cancellations for membership and subscriptions"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.4"
 version      := "0.0.1"
 organization := "com.gu"
 
@@ -34,17 +34,13 @@ addCommandAlias("dist", ";riffRaffArtifact")
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.163",
-  "com.amazonaws" % "aws-java-sdk-kms" % "1.11.86",
-  "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.95",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.265",
   "log4j" % "log4j" % "1.2.17",
-  "com.squareup.okhttp3" % "okhttp" % "3.4.1",
-  "org.scalaz" %% "scalaz-core" % "7.1.3",
-  "com.typesafe.play" %% "play-json" % "2.4.6",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
+  "org.scalaz" %% "scalaz-core" % "7.2.18",
+  "com.typesafe.play" %% "play-json" % "2.6.8",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "org.mockito" % "mockito-core" % "1.9.5" % "test",
-  "com.github.nscala-time" % "nscala-time_2.12" % "2.16.0",
   "org.apache.commons" % "commons-io" % "1.3.2"
 )
 

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 
 resolvers += Resolver.typesafeRepo("releases")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")

--- a/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -4,7 +4,7 @@ import com.gu.util.Logging
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraModels.SubscriptionId
 import com.gu.util.zuora._
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 object AutoCancel extends Logging {
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -3,18 +3,17 @@ package com.gu.autoCancel
 import play.api.libs.json.Json
 
 case class AutoCancelCallout(
-    accountId: String,
-    autoPay: String,
-    email: String,
-    firstName: String,
-    lastName: String,
-    paymentMethodType: String,
-    creditCardType: String,
-    creditCardExpirationMonth: String,
-    creditCardExpirationYear: String,
-    invoiceId: String,
-    currency: String
-) {
+  accountId: String,
+  autoPay: String,
+  email: String,
+  firstName: String,
+  lastName: String,
+  paymentMethodType: String,
+  creditCardType: String,
+  creditCardExpirationMonth: String,
+  creditCardExpirationYear: String,
+  invoiceId: String,
+  currency: String) {
   def isAutoPay = autoPay == "true"
   def nonDirectDebit = paymentMethodType != "BankTransfer"
 }

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -17,8 +17,7 @@ object AutoCancelHandler extends App with Logging {
     ACDeps(
       ApiGatewayHandler(HandlerDeps.default(rawEffects.stage, rawEffects.s3Load, { config: Config =>
         AutoCancelSteps(AutoCancelStepsDeps.default(rawEffects.now(), rawEffects.response, config))
-      }))
-    )
+      })))
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step

--- a/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/src/main/scala/com/gu/effects/AwsS3.scala
@@ -58,7 +58,6 @@ object aws {
     new SystemPropertiesCredentialsProvider,
     new ProfileCredentialsProvider(ProfileName),
     new InstanceProfileCredentialsProvider(false),
-    new EC2ContainerCredentialsProviderWrapper
-  )
+    new EC2ContainerCredentialsProviderWrapper)
 
 }

--- a/src/main/scala/com/gu/effects/RawEffects.scala
+++ b/src/main/scala/com/gu/effects/RawEffects.scala
@@ -2,11 +2,15 @@ package com.gu.effects
 
 import com.gu.util.Stage
 import okhttp3.{ Request, Response }
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 import scala.util.Try
 
-case class RawEffects(response: Request => Response, stage: Stage, s3Load: Stage => Try[String], now: () => LocalDate)
+case class RawEffects(
+  response: Request => Response,
+  stage: Stage,
+  s3Load: Stage => Try[String],
+  now: () => LocalDate)
 
 object RawEffects {
 

--- a/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -4,7 +4,7 @@ import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 import scalaz.\/
 import scalaz.syntax.std.option._

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -17,8 +17,7 @@ object Lambda {
     LambdaDeps(
       ApiGatewayHandler(HandlerDeps.default(rawEffects.stage, rawEffects.s3Load, { config: Config =>
         PaymentFailureSteps(PFDeps.default(rawEffects.response, config))
-      }))
-    )
+      })))
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
@@ -1,6 +1,5 @@
 package com.gu.paymentFailure
 
-import play.api.data.validation.ValidationError
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -18,8 +17,7 @@ case class PaymentFailureCallout(
   creditCardExpirationYear: String,
   paymentId: String,
   currency: String,
-  tenantId: String
-)
+  tenantId: String)
 
 object PaymentFailureCallout {
 
@@ -27,7 +25,7 @@ object PaymentFailureCallout {
     (
       (JsPath \ "accountId").read[String] and
       (JsPath \ "email").read[String] and
-      (JsPath \ "failureNumber").read[String].map(str => Try { Integer.parseInt(str) }).collect(ValidationError("int wasn't parsable"))({ case scala.util.Success(num) => num }) and
+      (JsPath \ "failureNumber").read[String].map(str => Try { Integer.parseInt(str) }).collect(JsonValidationError("int wasn't parsable"))({ case scala.util.Success(num) => num }) and
       (JsPath \ "firstName").read[String] and
       (JsPath \ "lastName").read[String] and
       (JsPath \ "paymentMethodType").read[String] and
@@ -36,7 +34,6 @@ object PaymentFailureCallout {
       (JsPath \ "creditCardExpirationYear").read[String] and
       (JsPath \ "paymentId").read[String] and
       (JsPath \ "currency").read[String] and
-      (JsPath \ "tenantId").read[String]
-    ).apply(PaymentFailureCallout.apply _)
+      (JsPath \ "tenantId").read[String]).apply(PaymentFailureCallout.apply _)
   }
 }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -48,16 +48,14 @@ object PaymentFailureSteps extends Logging {
       PFDeps(
         ZuoraEmailSteps.sendEmailRegardingAccount(ZuoraEmailStepsDeps.default(response, config)),
         config.etConfig.etSendIDs,
-        config.trustedApiConfig
-      )
+        config.trustedApiConfig)
     }
   }
 
   case class PFDeps(
     sendEmailRegardingAccount: (String, PaymentFailureInformation => EmailRequest) => FailableOp[Unit],
     etSendIDs: ETSendIds,
-    trustedApiConfig: TrustedApiConfig
-  )
+    trustedApiConfig: TrustedApiConfig)
 
 }
 
@@ -76,14 +74,12 @@ object ZuoraEmailSteps {
     def default(response: Request => Response, config: Config): ZuoraEmailStepsDeps = {
       ZuoraEmailStepsDeps(
         EmailSendSteps.apply(EmailSendStepsDeps.default(config.stage, response, config.etConfig)),
-        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.zuoraRestConfig))
-      )
+        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.zuoraRestConfig)))
     }
   }
 
   case class ZuoraEmailStepsDeps(
     sendEmail: EmailRequest => FailableOp[Unit],
-    getInvoiceTransactions: String => FailableOp[InvoiceTransactionSummary]
-  )
+    getInvoiceTransactions: String => FailableOp[InvoiceTransactionSummary])
 
 }

--- a/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -5,7 +5,8 @@ import java.text.DecimalFormat
 import com.gu.autoCancel.AutoCancelCallout
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.util.exacttarget._
-import org.joda.time.LocalDate
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 import scala.math.BigDecimal.decimal
 
@@ -27,11 +28,7 @@ object ToMessage {
           primaryKey = PaymentId(paymentFailureCallout.paymentId),
           price = price(paymentFailureInformation.amount, paymentFailureCallout.currency),
           serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
-          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)
-        )
-      )
-    )
-  )
+          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)))))
 
   def apply(callout: AutoCancelCallout, paymentFailureInformation: PaymentFailureInformation) = Message(
     To = ToDef(
@@ -49,11 +46,7 @@ object ToMessage {
           primaryKey = InvoiceId(callout.invoiceId),
           price = price(paymentFailureInformation.amount, callout.currency),
           serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
-          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)
-        )
-      )
-    )
-  )
+          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)))))
 
   val currencySymbol = Map("GBP" -> "£", "AUD" -> "$", "EUR" -> "€", "USD" -> "$", "CAD" -> "$", "NZD" -> "$")
 
@@ -66,6 +59,6 @@ object ToMessage {
     symbol + formattedAmount
   }
 
-  def serviceDateFormat(d: LocalDate) = d.toString("dd MMMM yyyy")
+  def serviceDateFormat(d: LocalDate) = d.format(DateTimeFormatter.ofPattern("dd MMMM yyyy"))
 
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -17,8 +17,7 @@ object Lambda {
     LambdaDeps(
       ApiGatewayHandler(HandlerDeps.default(rawEffects.stage, rawEffects.s3Load, { config: Config =>
         SourceUpdatedSteps(Deps.default(rawEffects.response, config))
-      }))
-    )
+      })))
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -10,8 +10,7 @@ case class EventDataObject(
   country: StripeCountry,
   customer: StripeCustomerId,
   expiry: StripeExpiry,
-  last4: StripeLast4
-)
+  last4: StripeLast4)
 case class SourceUpdatedCallout(id: StripeEventId, data: EventData)
 
 case class StripeEventId(value: String) extends AnyVal
@@ -79,16 +78,13 @@ object SourceUpdatedCallout {
     (JsPath \ "customer").read[String].map(StripeCustomerId.apply) and
     (
       (JsPath \ "exp_month").read[Int] and
-      (JsPath \ "exp_year").read[Int]
-    )(StripeExpiry.apply _) and
-      (JsPath \ "last4").read[String].map(StripeLast4.apply)
-  )(EventDataObject.apply _)
+      (JsPath \ "exp_year").read[Int])(StripeExpiry.apply _) and
+      (JsPath \ "last4").read[String].map(StripeLast4.apply))(EventDataObject.apply _)
 
   implicit val eventDataReads: Reads[EventData] = (JsPath \ "object").read[EventDataObject].map(EventData.apply _)
 
   implicit val jf: Reads[SourceUpdatedCallout] = (
     (JsPath \ "id").read[String].map(StripeEventId.apply) and
-    (JsPath \ "data").read[EventData]
-  )(SourceUpdatedCallout.apply _)
+    (JsPath \ "data").read[EventData])(SourceUpdatedCallout.apply _)
 
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -1,6 +1,5 @@
 package com.gu.stripeCustomerSourceUpdated
 
-import com.gu.util.StripeConfig
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -70,8 +70,7 @@ object SourceUpdatedSteps extends Logging {
         eventDataObject.last4,
         eventDataObject.expiry,
         creditCardType,
-        paymentMethodFields.NumConsecutiveFailures
-      ))
+        paymentMethodFields.NumConsecutiveFailures))
     } yield result
   }
 

--- a/src/main/scala/com/gu/util/ConfigLoader.scala
+++ b/src/main/scala/com/gu/util/ConfigLoader.scala
@@ -9,21 +9,18 @@ import scala.util.{ Failure, Success, Try }
 case class ZuoraRestConfig(
   baseUrl: String,
   username: String,
-  password: String
-)
+  password: String)
 
 case class ETConfig(
   etSendIDs: ETSendIds,
   clientId: String,
-  clientSecret: String
-)
+  clientSecret: String)
 
 object ZuoraRestConfig {
   implicit val zuoraConfigReads: Reads[ZuoraRestConfig] = (
     (JsPath \ "baseUrl").read[String] and
     (JsPath \ "username").read[String] and
-    (JsPath \ "password").read[String]
-  )(ZuoraRestConfig.apply _)
+    (JsPath \ "password").read[String])(ZuoraRestConfig.apply _)
 }
 
 object ETConfig {
@@ -34,12 +31,11 @@ object ETConfig {
 
   case class ETSendId(id: String) extends AnyVal
   case class ETSendIds(
-      pf1: ETSendId,
-      pf2: ETSendId,
-      pf3: ETSendId,
-      pf4: ETSendId,
-      cancelled: ETSendId
-  ) {
+    pf1: ETSendId,
+    pf2: ETSendId,
+    pf3: ETSendId,
+    pf4: ETSendId,
+    cancelled: ETSendId) {
     def find(attempt: Int): Option[ETSendId] = Some(attempt match {
       case 1 => pf1
       case 2 => pf2
@@ -53,8 +49,7 @@ object ETConfig {
   implicit val zuoraConfigReads: Reads[ETConfig] = (
     (JsPath \ "etSendIDs").read[ETSendIds] and
     (JsPath \ "clientId").read[String] and
-    (JsPath \ "clientSecret").read[String]
-  )(ETConfig.apply _)
+    (JsPath \ "clientSecret").read[String])(ETConfig.apply _)
 }
 
 case class TrustedApiConfig(apiToken: String, tenantId: String)
@@ -62,8 +57,7 @@ case class TrustedApiConfig(apiToken: String, tenantId: String)
 object TrustedApiConfig {
   implicit val apiConfigReads: Reads[TrustedApiConfig] = (
     (JsPath \ "apiToken").read[String] and
-    (JsPath \ "tenantId").read[String]
-  )(TrustedApiConfig.apply _)
+    (JsPath \ "tenantId").read[String])(TrustedApiConfig.apply _)
 }
 
 case class StripeSecretKey(key: String) extends AnyVal
@@ -76,8 +70,7 @@ case class StripeConfig(ukStripeSecretKey: StripeSecretKey, auStripeSecretKey: S
 object StripeConfig {
   implicit val apiConfigReads: Reads[StripeConfig] = (
     (JsPath \ "api.key.secret").read[String].map(StripeSecretKey.apply) and
-    (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply)
-  )(StripeConfig.apply _)
+    (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply))(StripeConfig.apply _)
 }
 
 case class Config(
@@ -85,8 +78,7 @@ case class Config(
   trustedApiConfig: TrustedApiConfig,
   zuoraRestConfig: ZuoraRestConfig,
   etConfig: ETConfig,
-  stripeConfig: StripeConfig
-)
+  stripeConfig: StripeConfig)
 
 case class Stage(value: String) extends AnyVal {
   def isProd: Boolean = value == "PROD"
@@ -99,8 +91,7 @@ object Config extends Logging {
     (JsPath \ "trustedApiConfig").read[TrustedApiConfig] and
     (JsPath \ "zuoraRestConfig").read[ZuoraRestConfig] and
     (JsPath \ "etConfig").read[ETConfig] and
-    (JsPath \ "stripe").read[StripeConfig]
-  )(Config.apply _)
+    (JsPath \ "stripe").read[StripeConfig])(Config.apply _)
 
   def parseConfig(jsonConfig: String): Try[Config] = {
     Json.fromJson[Config](Json.parse(jsonConfig)) match {

--- a/src/main/scala/com/gu/util/ConfigLoader.scala
+++ b/src/main/scala/com/gu/util/ConfigLoader.scala
@@ -73,9 +73,13 @@ object StripeWebhook {
     (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply))(StripeWebhook.apply _)
 }
 
-case class StripeConfig(customerSourceUpdatedWebhook: StripeWebhook)
+case class StripeConfig(
+  customerSourceUpdatedWebhook: StripeWebhook,
+  signatureChecking: Boolean)
 object StripeConfig {
-  implicit val stripeConfigReads = Json.reads[StripeConfig]
+  implicit val stripeConfigReads: Reads[StripeConfig] = (
+    (JsPath \ "customerSourceUpdatedWebhook").read[StripeWebhook] and
+    (JsPath \ "signatureChecking").readNullable[String].map(!_.contains("false")))(StripeConfig.apply _)
 }
 
 case class Config(

--- a/src/main/scala/com/gu/util/ConfigLoader.scala
+++ b/src/main/scala/com/gu/util/ConfigLoader.scala
@@ -70,8 +70,7 @@ case class StripeWebhook(ukStripeSecretKey: StripeSecretKey, auStripeSecretKey: 
 object StripeWebhook {
   implicit val stripeWebhookConfigReads: Reads[StripeWebhook] = (
     (JsPath \ "api.key.secret").read[String].map(StripeSecretKey.apply) and
-    (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply)
-  )(StripeWebhook.apply _)
+    (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply))(StripeWebhook.apply _)
 }
 
 case class StripeConfig(customerSourceUpdatedWebhook: StripeWebhook)

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -21,8 +21,7 @@ object ApiGatewayHandler extends Logging {
     s3Load: () => Try[String],
     stage: Stage,
     parseConfig: String => Try[Config],
-    operation: Config => ApiGatewayRequest => FailableOp[Unit]
-  )
+    operation: Config => ApiGatewayRequest => FailableOp[Unit])
 
   object HandlerDeps {
     def default(stage: Stage, s3Load: Stage => Try[String], operation: Config => ApiGatewayRequest => FailableOp[Unit]): HandlerDeps =
@@ -30,8 +29,7 @@ object ApiGatewayHandler extends Logging {
         () => s3Load(stage),
         stage,
         Config.parseConfig,
-        operation
-      )
+        operation)
   }
 
   def apply(deps: HandlerDeps)(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -35,8 +35,7 @@ object URLParams {
   implicit val jf = (
     (JsPath \ "apiToken").readNullable[String] and
     (JsPath \ "onlyCancelDirectDebit").readNullable[String].map(_.contains("true")) and
-    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString))
-  )(URLParams.apply _)
+    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString)))(URLParams.apply _)
 }
 
 object ApiGatewayRequest {

--- a/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -19,16 +19,14 @@ object ResponseWriters {
 
   implicit val headersWrites = new Writes[Headers] {
     def writes(headers: Headers) = Json.obj(
-      "Content-Type" -> headers.contentType
-    )
+      "Content-Type" -> headers.contentType)
   }
 
   implicit val responseWrites = new Writes[ApiResponse] {
     def writes(response: ApiResponse) = Json.obj(
       "statusCode" -> response.statusCode,
       "headers" -> response.headers,
-      "body" -> response.body
-    )
+      "body" -> response.body)
   }
 
 }

--- a/src/main/scala/com/gu/util/exacttarget/EmailSendSteps.scala
+++ b/src/main/scala/com/gu/util/exacttarget/EmailSendSteps.scala
@@ -25,8 +25,7 @@ case class SubscriberAttributesDef(
   primaryKey: PrimaryKey,
   price: String,
   serviceStartDate: String,
-  serviceEndDate: String
-)
+  serviceEndDate: String)
 
 sealed trait PrimaryKey {
   // ET will filter out multiple emails with the same payment id for PF1,2,3,4
@@ -60,9 +59,7 @@ object SubscriberAttributesDef {
           },
           "price" -> JsString(o.price),
           "serviceStartDate" -> JsString(o.serviceStartDate),
-          "serviceEndDate" -> JsString(o.serviceEndDate)
-        )
-      )
+          "serviceEndDate" -> JsString(o.serviceEndDate)))
 
   }
 
@@ -84,8 +81,7 @@ object EmailSendSteps extends Logging {
 
   case class EmailSendStepsDeps(
     sendEmail: EmailRequest => FailableOp[Unit],
-    filterEmail: EmailRequest => FailableOp[Unit]
-  )
+    filterEmail: EmailRequest => FailableOp[Unit])
 
   object EmailSendStepsDeps {
     def default(stage: Stage, response: Request => Response, etConfig: ETConfig): EmailSendStepsDeps = {
@@ -106,8 +102,7 @@ object ETClient {
 
   case class ETClientDeps(
     response: (Request => Response),
-    etConfig: ETConfig
-  )
+    etConfig: ETConfig)
 
   def sendEmail(eTClientDeps: ETClientDeps)(emailRequest: EmailRequest): FailableOp[Unit] = {
     for {

--- a/src/main/scala/com/gu/util/exacttarget/SalesforceAuthenticate.scala
+++ b/src/main/scala/com/gu/util/exacttarget/SalesforceAuthenticate.scala
@@ -20,8 +20,7 @@ object SalesforceAuthenticate extends Logging {
 
     implicit val salesforceAuthReads: Reads[SalesforceAuth] = (
       (JsPath \ "accessToken").read[String] and
-      (JsPath \ "expiresIn").read[Int]
-    )(SalesforceAuth.apply _)
+      (JsPath \ "expiresIn").read[Int])(SalesforceAuth.apply _)
 
   }
 

--- a/src/main/scala/com/gu/util/zuora/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/CreatePaymentMethod.scala
@@ -16,8 +16,7 @@ object CreatePaymentMethod {
     last4: StripeLast4,
     expiration: StripeExpiry,
     creditCardType: CreditCardType,
-    numConsecutiveFailures: NumConsecutiveFailures
-  )
+    numConsecutiveFailures: NumConsecutiveFailures)
 
   sealed abstract class CreditCardType(val value: String)
   object CreditCardType {
@@ -40,8 +39,7 @@ object CreatePaymentMethod {
       "CreditCardExpirationYear" -> command.expiration.exp_year,
       "CreditCardType" -> command.creditCardType.value,
       "Type" -> "CreditCardReferenceTransaction",
-      "NumConsecutiveFailures" -> command.numConsecutiveFailures
-    )
+      "NumConsecutiveFailures" -> command.numConsecutiveFailures)
   }
 
   implicit val reads: Reads[CreatePaymentMethodResult] =

--- a/src/main/scala/com/gu/util/zuora/SetDefaultPaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/SetDefaultPaymentMethod.scala
@@ -12,8 +12,7 @@ object SetDefaultPaymentMethod {
 
   implicit val writes = new Writes[SetDefaultPaymentMethod] {
     def writes(subscriptionUpdate: SetDefaultPaymentMethod) = Json.obj(
-      "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId
-    )
+      "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId)
   }
 
   def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId): WithDepsFailableOp[ZuoraDeps, Unit] =

--- a/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -7,7 +7,7 @@ import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.ZuoraRestRequestMaker._
 import okhttp3.{ Request, Response }
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{ JsPath, Json, Reads, Writes }
 
@@ -26,27 +26,23 @@ object ZuoraGetAccountSummary {
   implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
     (JsPath \ "id").read[String].map(AccountId.apply) and
     (JsPath \ "balance").read[Double] and
-    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId]
-  )(BasicAccountInfo.apply _)
+    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId])(BasicAccountInfo.apply _)
 
   implicit val invoiceReads: Reads[Invoice] = (
     (JsPath \ "id").read[String] and
     (JsPath \ "dueDate").read[LocalDate] and
     (JsPath \ "balance").read[Double] and
-    (JsPath \ "status").read[String]
-  )(Invoice.apply _)
+    (JsPath \ "status").read[String])(Invoice.apply _)
 
   implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (
     (JsPath \ "id").read[String].map(SubscriptionId.apply) and
     (JsPath \ "subscriptionNumber").read[String] and
-    (JsPath \ "status").read[String]
-  )(SubscriptionSummary.apply _)
+    (JsPath \ "status").read[String])(SubscriptionSummary.apply _)
 
   implicit val accountSummaryReads: Reads[AccountSummary] = (
     (JsPath \ "basicInfo").read[BasicAccountInfo] and
     (JsPath \ "subscriptions").read[List[SubscriptionSummary]] and
-    (JsPath \ "invoices").read[List[Invoice]]
-  )(AccountSummary.apply _)
+    (JsPath \ "invoices").read[List[Invoice]])(AccountSummary.apply _)
 
   def apply(accountId: String): WithDepsFailableOp[ZuoraDeps, AccountSummary] =
     get[AccountSummary](s"accounts/$accountId/summary")
@@ -67,8 +63,7 @@ object ZuoraGetInvoiceTransactions {
     (JsPath \ "serviceEndDate").read[LocalDate] and
     (JsPath \ "chargeAmount").read[Double] and
     (JsPath \ "chargeName").read[String] and
-    (JsPath \ "productName").read[String]
-  )(InvoiceItem.apply _)
+    (JsPath \ "productName").read[String])(InvoiceItem.apply _)
 
   implicit val itemisedInvoiceReads: Reads[ItemisedInvoice] = (
     (JsPath \ "id").read[String] and
@@ -76,8 +71,7 @@ object ZuoraGetInvoiceTransactions {
     (JsPath \ "amount").read[Double] and
     (JsPath \ "balance").read[Double] and
     (JsPath \ "status").read[String] and
-    (JsPath \ "invoiceItems").read[List[InvoiceItem]]
-  )(ItemisedInvoice.apply _)
+    (JsPath \ "invoiceItems").read[List[InvoiceItem]])(ItemisedInvoice.apply _)
 
   implicit val invoiceTransactionSummaryReads: Reads[InvoiceTransactionSummary] =
     (JsPath \ "invoices").read[List[ItemisedInvoice]].map {
@@ -97,8 +91,7 @@ object ZuoraCancelSubscription {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
       "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
       "cancellationPolicy" -> "SpecificDate",
-      "invoiceCollect" -> false
-    )
+      "invoiceCollect" -> false)
   }
 
   def apply(subscription: SubscriptionId, cancellationDate: LocalDate): WithDepsFailableOp[ZuoraDeps, Unit] =
@@ -112,8 +105,7 @@ object ZuoraUpdateCancellationReason {
 
   implicit val subscriptionUpdateWrites = new Writes[SubscriptionUpdate] {
     def writes(subscriptionUpdate: SubscriptionUpdate) = Json.obj(
-      "CancellationReason__c" -> subscriptionUpdate.cancellationReason
-    )
+      "CancellationReason__c" -> subscriptionUpdate.cancellationReason)
   }
 
   def apply(subscription: SubscriptionId): WithDepsFailableOp[ZuoraDeps, Unit] =
@@ -127,8 +119,7 @@ object ZuoraDisableAutoPay {
 
   implicit val accountUpdateWrites = new Writes[AccountUpdate] {
     def writes(accountUpdate: AccountUpdate) = Json.obj(
-      "autoPay" -> accountUpdate.autoPay
-    )
+      "autoPay" -> accountUpdate.autoPay)
   }
 
   def apply(accountId: String): WithDepsFailableOp[ZuoraDeps, Unit] =

--- a/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -22,8 +22,7 @@ object ZuoraQuery {
     (JsPath \ "records").read[List[QUERYRECORD]] and
     (JsPath \ "size").read[Int] and
     (JsPath \ "done").read[Boolean] and
-    (JsPath \ "queryLocator").readNullable[QueryLocator]
-  ).apply(QueryResult.apply[QUERYRECORD] _)
+    (JsPath \ "queryLocator").readNullable[QueryLocator]).apply(QueryResult.apply[QUERYRECORD] _)
 
   case class QueryMoreReq(queryLocator: QueryLocator)
 

--- a/src/main/scala/com/gu/util/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/util/zuora/ZuoraQueryPaymentMethod.scala
@@ -21,8 +21,7 @@ object ZuoraQueryPaymentMethod {
   case class PaymentMethodFields(
     Id: PaymentMethodId,
     AccountId: AccountId,
-    NumConsecutiveFailures: NumConsecutiveFailures
-  )
+    NumConsecutiveFailures: NumConsecutiveFailures)
   implicit val fPaymentMethodId: Format[PaymentMethodId] =
     Format[PaymentMethodId](JsPath.read[String].map(PaymentMethodId.apply), Writes { (o: PaymentMethodId) => JsString(o.value) })
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -37,20 +37,19 @@ object TestData extends Matchers {
   val fakeZuoraConfig = ZuoraRestConfig("https://ddd", "fakeUser", "fakePass")
   val fakeETSendIds = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can"))
   val fakeETConfig = ETConfig(etSendIDs = fakeETSendIds, "fakeClientId", "fakeClientSecret")
-  val fakeStripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(StripeSecretKey("ukCustomerSourceUpdatedSecretKey"), StripeSecretKey("auCustomerSourceUpdatedStripeSecretKey")))
+  val fakeStripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(StripeSecretKey("ukCustomerSourceUpdatedSecretKey"), StripeSecretKey("auCustomerSourceUpdatedStripeSecretKey")), true)
 
   val fakeConfig = Config(
     stage = Stage("DEV"),
     trustedApiConfig = fakeApiConfig,
     zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
     etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"),
-    stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")))
-  )
+    stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")), true))
 
   val missingCredentialsResponse = """{"statusCode":"401","headers":{"Content-Type":"application/json"},"body":"Credentials are missing or invalid"}"""
   val successfulResponse = """{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}"""
 
-  val codeConfig =
+  val codeConfig: String =
     """
       |{ "stage": "DEV",
       |  "trustedApiConfig": {

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -12,7 +12,7 @@ import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTrans
 import okhttp3._
 import okhttp3.internal.Util.UTF_8
 import okio.Buffer
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import org.scalatest.Matchers
 import play.api.libs.json.Json
 
@@ -21,7 +21,7 @@ import scalaz.{ Reader, \/ }
 
 object TestData extends Matchers {
 
-  val today = new LocalDate(2016, 11, 21)
+  val today = LocalDate.of(2016, 11, 21)
   val accountId = "accountId"
   val invoiceItemA = InvoiceItem("invitem123", "A-S123", today, today.plusMonths(1), 49.21, "Non founder - annual", "Supporter")
   val invoiceItemB = InvoiceItem("invitem122", "A-S123", today, today.plusMonths(1), 0, "Friends", "Friend")
@@ -42,8 +42,7 @@ object TestData extends Matchers {
     trustedApiConfig = fakeApiConfig,
     zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
     etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"),
-    stripeConfig = StripeConfig(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def"))
-  )
+    stripeConfig = StripeConfig(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")))
 
   val missingCredentialsResponse = """{"statusCode":"401","headers":{"Content-Type":"application/json"},"body":"Credentials are missing or invalid"}"""
   val successfulResponse = """{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}"""
@@ -115,10 +114,16 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
       result = req :: result
       val (code, response) = responses.getOrElse(req.url().encodedPath(), (defaultCode, """{"success": true}"""))
       println(s"request for: ${req.url().encodedPath()} so returning $response")
-      new Response.Builder().request(req).protocol(Protocol.HTTP_1_1).code(code).body(ResponseBody.create(MediaType.parse("text/plain"), response)).build()
+      new Response.Builder()
+        .request(req)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .body(ResponseBody.create(MediaType.parse("text/plain"), response))
+        .message("message??")
+        .build()
   }
 
-  val rawEffects = RawEffects(response, stage, _ => Success(TestData.codeConfig), () => new LocalDate(2017, 11, 19))
+  val rawEffects = RawEffects(response, stage, _ => Success(TestData.codeConfig), () => LocalDate.of(2017, 11, 19))
 
   //  val fakeConfig = Config(stage, TrustedApiConfig("a", "b", "c"), zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
   //    etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"))

--- a/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
@@ -4,7 +4,7 @@ import com.gu.util.apigateway.ApiGatewayResponse._
 import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary }
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import org.scalatest._
 
 import scalaz.{ -\/, \/- }

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -1,14 +1,16 @@
 package com.gu.autoCancel
 
+import java.time.LocalDate
+
 import com.gu.TestingRawEffects.BasicResult
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.autoCancel.AutoCancelDataCollectionFilter.ACFilterDeps
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary }
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.{ TestData, TestingRawEffects, WithDependenciesFailableOp }
-import org.joda.time.LocalDate
 import org.scalatest._
 
 import scalaz.\/-
@@ -24,9 +26,9 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
     val aCDeps = ACFilterDeps(
       now = LocalDate.now,
       getAccountSummary = _ => WithDependenciesFailableOp.liftT(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice))),
-      a.response,
-      TestData.fakeZuoraConfig
-    )
+      ZuoraDeps(
+        a.response,
+        TestData.fakeZuoraConfig))
     val autoCancelCallout = AutoCancelHandlerTest.fakeCallout(true)
     val cancel: FailableOp[AutoCancelRequest] = AutoCancelDataCollectionFilter(aCDeps)(autoCancelCallout)
 

--- a/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -30,8 +30,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
 
     config.result.map(req => (req.method, req.url.encodedPath) -> Option(req.body).map(body)).toMap
       .get(("POST", "/messaging/v1/messageDefinitionSends/111/send")) should be(
-        Some(Some(EndToEndData.expectedEmailSend))
-      ) // TODO check the body too
+        Some(Some(EndToEndData.expectedEmailSend))) // TODO check the body too
 
     val responseString = new String(os.toByteArray(), "UTF-8")
 
@@ -49,8 +48,7 @@ object EndToEndData {
   def responses: Map[String, (Int, String)] = Map(
     ("/transactions/invoices/accounts/2c92c0f85fc90734015fca884c3f04cf", (200, invoices)),
     ("/v1/requestToken", (200, """{"accessToken":"", "expiresIn":1}""")),
-    ("/messaging/v1/messageDefinitionSends/111/send", (202, ""))
-  )
+    ("/messaging/v1/messageDefinitionSends/111/send", (202, "")))
 
   val expectedEmailSend =
     """{"To":{"Address":"john.duffell@guardian.co.uk","SubscriberKey":"john.duffell@guardian.co.uk","ContactAttributes":{"SubscriberAttributes":{"subscriber_id":"A-S00071536","product":"Supporter","payment_method":"CreditCardReferenceTransaction","card_type":"Visa","card_expiry_date":"12/2019","first_name":"eSAFaBwm4WJZNg5xhIc","last_name":"eSAFaBwm4WJZNg5xhIc","paymentId":"2c92c0f95fc912eb015fcb2a481720e6","price":"$49.00","serviceStartDate":"17 November 2017","serviceEndDate":"16 November 2018"}}}}"""

--- a/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
@@ -24,11 +24,7 @@ class MessageWritesTest extends FlatSpec {
             primaryKey = PaymentId("paymentId"),
             price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
-            serviceEndDate = "31 January 2017"
-          )
-        )
-      )
-    )
+            serviceEndDate = "31 January 2017"))))
 
     val expectedJson =
       """
@@ -75,11 +71,7 @@ class MessageWritesTest extends FlatSpec {
             primaryKey = InvoiceId("paymentId"),
             price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
-            serviceEndDate = "31 January 2017"
-          )
-        )
-      )
-    )
+            serviceEndDate = "31 January 2017"))))
 
     val expectedJson =
       """

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -4,7 +4,6 @@ import com.gu.TestingRawEffects
 import com.gu.TestingRawEffects.BasicResult
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, NumConsecutiveFailures, PaymentMethodFields, PaymentMethodId }
-import okhttp3.Request
 import org.scalatest.{ FlatSpec, Matchers }
 
 import scalaz.{ -\/, \/- }
@@ -24,22 +23,18 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 1,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     val expectedGET = BasicResult(
       "GET",
       "/accounts/accid/summary",
-      ""
-    )
+      "")
 
     effects.basicResults should be(List(expectedGET, expectedPOST))
     actual should be(\/-(List()))
@@ -58,22 +53,18 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 1,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     val expectedGET = BasicResult(
       "GET",
       "/accounts/accid/summary",
-      ""
-    )
+      "")
 
     effects.basicResults should be(List(expectedGET, expectedPOST))
     actual should be(\/-(List(PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accid"), NumConsecutiveFailures(3)))))
@@ -97,22 +88,18 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 2,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     val expectedGET = BasicResult(
       "GET",
       "/accounts/accountidfake/summary",
-      ""
-    )
+      "")
 
     effects.basicResults should be(List(expectedGET, expectedPOST))
     actual should be(\/-(List(PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)))))
@@ -143,38 +130,31 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |}""".stripMargin)),
       ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson)),
       ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM"))),
-      ("/accounts/accountidANOTHERONE/summary", (200, accountSummaryJson("anotherPMAGAIN")))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accountidANOTHERONE/summary", (200, accountSummaryJson("anotherPMAGAIN")))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     val expectedGET1 = BasicResult(
       "GET",
       "/accounts/accountidfake/summary",
-      ""
-    )
+      "")
     val expectedGET2 = BasicResult(
       "GET",
       "/accounts/accountidANOTHER/summary",
-      ""
-    )
+      "")
     val expectedGET3 = BasicResult(
       "GET",
       "/accounts/accountidANOTHERONE/summary",
-      ""
-    )
+      "")
     effects.basicResults.toSet should be(Set(expectedGET1, expectedGET2, expectedGET3, expectedPOST))
     actual.map(_.toSet) should be(\/-(Set(
       PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)),
       PaymentMethodFields(PaymentMethodId("anotherPM"), AccountId("accountidANOTHER"), NumConsecutiveFailures(4)),
-      PaymentMethodFields(PaymentMethodId("anotherPMAGAIN"), AccountId("accountidANOTHERONE"), NumConsecutiveFailures(4))
-    )))
+      PaymentMethodFields(PaymentMethodId("anotherPMAGAIN"), AccountId("accountidANOTHERONE"), NumConsecutiveFailures(4)))))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account two of them but only one is default PM" in {
@@ -196,31 +176,25 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "done": true
                                 |}""".stripMargin)),
       ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson)),
-      ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM")))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM")))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     val expectedGET1 = BasicResult(
       "GET",
       "/accounts/accountidfake/summary",
-      ""
-    )
+      "")
     val expectedGET2 = BasicResult(
       "GET",
       "/accounts/accountidANOTHER/summary",
-      ""
-    )
+      "")
     effects.basicResults.toSet should be(Set(expectedGET1, expectedGET2, expectedPOST))
     actual.map(_.toSet) should be(\/-(Set(
-      PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2))
-    )))
+      PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)))))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account more than three" in {
@@ -251,17 +225,14 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 4,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     effects.basicResults should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
@@ -274,17 +245,14 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 0,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     effects.basicResults should be(List(expectedPOST))
     actual should be(\/-(List()))
   }
@@ -295,9 +263,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
 
     val effects = new TestingRawEffects(false, 500, Map(
       ("/object/payment-method", (200, """{"Success": true,"Id": "newPMID"}""")),
-      ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))
-    ))
-    val sourceUpdatedSteps = SourceUpdatedSteps.Deps(effects.zuoraDeps)
+      ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))))
 
     val eventData = EventDataObject(
       id = StripeSourceId("card_def456"),
@@ -305,21 +271,18 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
       country = StripeCountry("US"),
       customer = StripeCustomerId("cus_ghi789"),
       expiry = StripeExpiry(exp_month = 7, exp_year = 2020),
-      last4 = StripeLast4("1234")
-    )
+      last4 = StripeLast4("1234"))
 
     val actual = SourceUpdatedSteps.createUpdatedDefaultPaymentMethod(PaymentMethodFields(PaymentMethodId("PMID"), AccountId("fake"), NumConsecutiveFailures(1)), eventData).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/object/payment-method",
-      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction","NumConsecutiveFailures":1}"""
-    )
+      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction","NumConsecutiveFailures":1}""")
     val expectedPUT = BasicResult(
       "PUT",
       "/object/account/fake",
-      """{"DefaultPaymentMethodId":"newPMID"}"""
-    )
+      """{"DefaultPaymentMethodId":"newPMID"}""")
 
     effects.basicResults should be(List(expectedPUT, expectedPOST))
     actual should be(\/-(()))

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -53,8 +53,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 1,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))
-    ))
+      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -150,8 +149,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedGET3 = BasicResult(
       "GET",
       "/accounts/accountidANOTHERONE/summary",
-      ""
-    )
+      "")
     effects.requestsAttempted.toSet should be(Set(expectedGET1, expectedGET2, expectedGET3, expectedPOST))
     actual.map(_.toSet) should be(\/-(Set(
       PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)),
@@ -178,8 +176,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "done": true
                                 |}""".stripMargin)),
       ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson)),
-      ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM")))
-    ))
+      ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM")))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
@@ -194,8 +191,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val expectedGET2 = BasicResult(
       "GET",
       "/accounts/accountidANOTHER/summary",
-      ""
-    )
+      "")
     effects.requestsAttempted.toSet should be(Set(expectedGET1, expectedGET2, expectedPOST))
     actual.map(_.toSet) should be(\/-(Set(
       PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)))))
@@ -229,16 +225,14 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 4,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))
-    ))
+      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     effects.requestsAttempted should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
@@ -251,16 +245,14 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
                                 |  "size": 0,
                                 |  "done": true
                                 |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))
-    ))
+      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(effects.zuoraDeps)
 
     val expectedPOST = BasicResult(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
-    )
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
     effects.requestsAttempted should be(List(expectedPOST))
     actual should be(\/-(List()))
   }
@@ -271,8 +263,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
 
     val effects = new TestingRawEffects(false, 500, Map(
       ("/object/payment-method", (200, """{"Success": true,"Id": "newPMID"}""")),
-      ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))
-    ))
+      ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))))
 
     val eventData = EventDataObject(
       id = StripeSourceId("card_def456"),
@@ -304,8 +295,7 @@ class SourceUpdatedStepsTest extends FlatSpec with Matchers {
     val badHeaders = Map(
       "SomeHeader1" -> "testvalue",
       "Content-Type" -> "application/json",
-      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
-    )
+      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString")
 
     val someBody =
       """

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
@@ -68,11 +68,7 @@ class StripeCustomerUpdatedReadsTest extends FlatSpec {
             country = StripeCountry("US"),
             customer = StripeCustomerId("cus_ghi789"),
             expiry = StripeExpiry(exp_month = 7, exp_year = 2020),
-            last4 = StripeLast4("1234")
-          )
-        )
-      )
-    )
+            last4 = StripeLast4("1234")))))
 
     val event: JsResult[SourceUpdatedCallout] = Json.parse(validEventJson).validate[SourceUpdatedCallout]
 

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
@@ -77,8 +77,7 @@ class StripeRequestSignatureCheckerTest extends FlatSpec {
     """.stripMargin
 
   def headersWithStripeSignature(timestamp: String, signature: String) = Map(
-    "Stripe-Signature" -> s"t=$timestamp,v1=$signature"
-  )
+    "Stripe-Signature" -> s"t=$timestamp,v1=$signature")
 
   class FakeStripeSignatureChecker(stripeConfig: StripeConfig) extends SignatureChecker {
     override def verifySignature(secretKey: StripeSecretKey, payload: String, signatureHeader: Option[String], tolerance: Long): Boolean = {

--- a/src/test/scala/com/gu/util/ApiGatewayHandlerReadsTest.scala
+++ b/src/test/scala/com/gu/util/ApiGatewayHandlerReadsTest.scala
@@ -14,8 +14,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
     val eventHeaders = Map(
       "SomeHeader1" -> "testvalue",
       "Content-Type" -> "application/json",
-      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
-    )
+      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString")
     val validApiGatewayEventJson =
       s"""
         |{
@@ -65,9 +64,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
       ApiGatewayRequest(
         queryStringParameters = None,
         body = eventBodySimple,
-        headers = Some(eventHeaders)
-      )
-    )
+        headers = Some(eventHeaders)))
 
     val event: JsResult[ApiGatewayRequest] = Json.parse(validApiGatewayEventJson).validate[ApiGatewayRequest]
 

--- a/src/test/scala/com/gu/util/AuthTest.scala
+++ b/src/test/scala/com/gu/util/AuthTest.scala
@@ -13,18 +13,15 @@ class AuthTest extends FlatSpec {
 
     def constructQueryStrings(apiClientId: String, apiToken: String) = Json.obj(
       "apiClientId" -> apiClientId,
-      "apiToken" -> apiToken
-    )
+      "apiToken" -> apiToken)
     val headers = Json.obj(
-      "Content-Type" -> "text/xml"
-    )
+      "Content-Type" -> "text/xml")
     val sampleJson = Json.obj(
       "resource" -> "test-resource",
       "path" -> "/test-path",
       "httpMethod" -> "POST",
       "headers" -> headers,
-      "queryStringParameters" -> constructQueryStrings(apiClientId, apiToken)
-    )
+      "queryStringParameters" -> constructQueryStrings(apiClientId, apiToken))
     sampleJson
   }
 
@@ -33,8 +30,7 @@ class AuthTest extends FlatSpec {
       "resource" -> "test-resource",
       "path" -> "/test-path",
       "httpMethod" -> "POST",
-      "body" -> ""
-    )
+      "body" -> "")
     sampleJson.validate[ApiGatewayRequest] match {
       case JsError(e) => fail(s"couldn't parse with $e")
       case JsSuccess(req, _) =>

--- a/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -18,9 +18,7 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
         TrustedApiConfig("b", "c"),
         zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
         etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"),
-        stripeConfig = StripeConfig(StripeSecretKey("abc"), StripeSecretKey("def"))
-      )
-    ))
+        stripeConfig = StripeConfig(StripeSecretKey("abc"), StripeSecretKey("def")))))
   }
 
 }

--- a/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -1,26 +1,74 @@
 package com.gu.util
 
 import com.gu.TestData
-import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
-import org.scalatest.{ FlatSpec, Matchers }
+import com.gu.util.ETConfig.{ETSendId, ETSendIds}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsSuccess, Json}
 
 import scala.util.Success
 
 class ConfigLoaderTest extends FlatSpec with Matchers {
 
   "loader" should "be able to load config successfully" in {
-    //    val requestAuth = Some(RequestAuth(apiClientId = "validUser", apiToken = "ndjashjkhajshs"))
-    //    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
-    val prod = Config.parseConfig(TestData.codeConfig)
-    prod should be(Success(
+    val actualConfigObject = Config.parseConfig(TestData.codeConfig)
+    actualConfigObject should be(Success(
       Config(
         Stage("DEV"),
         TrustedApiConfig("b", "c"),
         zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
         etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"),
-        stripeConfig = StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")))
-      )
-    ))
+        stripeConfig = StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true))))
+  }
+
+  "loader" should "the sig verified status is on by default" in {
+    val configString = """{
+                         |     "customerSourceUpdatedWebhook": {
+                         |       "api.key.secret": "abc",
+                         |       "au-membership.key.secret": "def"
+                         |     }
+                         |  }""".stripMargin
+    val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
+    actualConfigObject should be(JsSuccess(
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)))
+  }
+
+  "loader" should "sig verifying is on if we ask for it to be on" in {
+    val configString = """{
+                         |     "customerSourceUpdatedWebhook": {
+                         |       "api.key.secret": "abc",
+                         |       "au-membership.key.secret": "def"
+                         |     },
+                         |     "signatureChecking": "true"
+                         |  }""".stripMargin
+    val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
+    actualConfigObject should be(JsSuccess(
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)))
+  }
+
+  "loader" should "sig verifying is still on if we ask for sdjfkhgsdf" in {
+    val configString = """{
+                         |     "customerSourceUpdatedWebhook": {
+                         |       "api.key.secret": "abc",
+                         |       "au-membership.key.secret": "def"
+                         |     },
+                         |     "signatureChecking": "sdfjhgsdf"
+                         |  }""".stripMargin
+    val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
+    actualConfigObject should be(JsSuccess(
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)))
+  }
+
+  "loader" should "sig verifying is ONLY off if we ask for false" in {
+    val configString = """{
+                         |     "customerSourceUpdatedWebhook": {
+                         |       "api.key.secret": "abc",
+                         |       "au-membership.key.secret": "def"
+                         |     },
+                         |     "signatureChecking": "false"
+                         |  }""".stripMargin
+    val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
+    actualConfigObject should be(JsSuccess(
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), false)))
   }
 
 }

--- a/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -2,7 +2,6 @@ package com.gu.util
 
 import com.gu.util.apigateway.ApiGatewayResponse._
 import com.gu.util.zuora.ZuoraGetAccountSummary.BasicAccountInfo
-import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraQueryPaymentMethod.{ AccountId, PaymentMethodId }
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.ZuoraRestRequestMaker
@@ -36,28 +35,24 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
   val dummyJson = Json.parse(
     """{
       |  "body": "test"
-      |}""".stripMargin
-  )
+      |}""".stripMargin)
 
   val validUpdateSubscriptionResult = Json.parse(
     """{
       |  "success": true,
       |  "id": "id123", "balance": 1.2, "defaultPaymentMethod": {"id": "pmid"}
-      |}""".stripMargin
-  )
+      |}""".stripMargin)
 
   val validFailedUpdateSubscriptionResult = Json.parse(
     """{
       |  "success": false,
       |  "subscriptionId": "id123"
-      |}""".stripMargin
-  )
+      |}""".stripMargin)
 
   val validZuoraNoOtherFields = Json.parse(
     """{
       |  "success": true
-      |}""".stripMargin
-  )
+      |}""".stripMargin)
 
   def constructTestRequest(json: JsValue = dummyJson): Request = {
     val body = RequestBody.create(MediaType.parse("application/json"), json.toString)
@@ -74,6 +69,7 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
       .request(constructTestRequest())
       .protocol(Protocol.HTTP_1_1)
       .body(ResponseBody.create(MediaType.parse("application/json"), json.toString))
+      .message("message?")
       .build()
     response
   }

--- a/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
+++ b/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
@@ -26,11 +26,7 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
             primaryKey = PaymentId("paymentId"),
             price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
-            serviceEndDate = "31 January 2017"
-          )
-        )
-      )
-    )
+            serviceEndDate = "31 January 2017"))))
   }
 
   private val guardian = "john.duffell@guardian.co.uk"
@@ -40,8 +36,7 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
 
     val req = EmailRequest(
       etSendId = ETSendId("etSendId"),
-      makeMessage(email)
-    )
+      makeMessage(email))
 
     val stage = Stage(if (isProd) "PROD" else "CODE")
 
@@ -49,11 +44,10 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
 
     val deps = EmailSendStepsDeps(
       sendEmail = req => {
-      varAttempted = true
-      \/-(()) // always success
-    },
-      filterEmail = FilterEmail.apply(stage) _
-    )
+        varAttempted = true
+        \/-(()) // always success
+      },
+      filterEmail = FilterEmail.apply(stage) _)
 
     EmailSendSteps(deps)(req)
 

--- a/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
+++ b/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
@@ -1,11 +1,11 @@
 package manualTest
 
 import com.gu.effects.ConfigLoad
-import com.gu.util.{ Config, Stage }
-import org.scalatest.{ FlatSpec, Ignore, Matchers }
+import com.gu.util.{Config, Stage}
+import org.scalatest.{FlatSpec, Ignore, Matchers}
 
 import scala.io.Source
-import scala.util.{ Success, Try }
+import scala.util.{Success, Try}
 
 // this test checks the actual config in S3 so it needs credentials.  this means you can only run it manually
 // however it does stop you deploying a new version without updating the config first
@@ -14,15 +14,15 @@ class ConfigLoaderSystemTest extends FlatSpec with Matchers {
 
   "loader" should "be able to load the prod config successfully" in {
     val prod = ConfigLoad.load(Stage("PROD"))
-    validate(prod)
+    validate(prod, Some(true))
   }
 
   it should "be able to load the code config successfully" in {
     val code: Try[String] = ConfigLoad.load(Stage("CODE"))
-    validate(code)
+    validate(code, None)
   }
 
-  def validate(configAttemp: Try[String]) = {
+  def validate(configAttemp: Try[String], verificationStatus: Option[Boolean]) = {
     val con = for {
       a <- configAttemp
       b <- Config.parseConfig(a)
@@ -30,13 +30,16 @@ class ConfigLoaderSystemTest extends FlatSpec with Matchers {
     val loadedOK = con.map(config => ())
     withClue(configAttemp) {
       loadedOK should be(Success(()))
+      verificationStatus.foreach {
+        expected => con.get.stripeConfig.signatureChecking should be(expected)
+      }
     }
   }
 
   it should "be able to load the local test config successfully" in {
     val configAttempt = Try { Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString }
 
-    validate(configAttempt)
+    validate(configAttempt, None)
   }
 
 }

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -1,7 +1,6 @@
 package manualTest
 
 import com.gu.effects.RawEffects
-import com.gu.util.ETConfig.ETSendId
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.{ Config, Stage }
@@ -31,11 +30,7 @@ object EmailClientSystemTest extends App {
           primaryKey = PaymentId(s"paymentId$unique"), // must be unique otherwise the email won't arrive
           price = "49.0 GBP",
           serviceStartDate = "31 January 2016",
-          serviceEndDate = "31 January 2017"
-        )
-      )
-    )
-  )
+          serviceEndDate = "31 January 2017"))))
 
   def overdueMessage = Message(
     To = ToDef(
@@ -53,11 +48,7 @@ object EmailClientSystemTest extends App {
           primaryKey = InvoiceId(s"invoiceId$unique"), // must be unique otherwise the email won't arrive
           price = "49.0 GBP",
           serviceStartDate = "31 January 2016",
-          serviceEndDate = "31 January 2017"
-        )
-      )
-    )
-  )
+          serviceEndDate = "31 January 2017"))))
 
   for {
     configAttempt <- Try {
@@ -69,11 +60,9 @@ object EmailClientSystemTest extends App {
   } yield Seq(a.pf1 -> message(1), a.pf2 -> message(2), a.pf3 -> message(3), a.pf4 -> message(4), a.cancelled -> overdueMessage).map {
     case (etSendId, index) =>
       val emailResult = EmailSendSteps(
-        deps
-      )(EmailRequest(
+        deps)(EmailRequest(
         etSendId = etSendId,
-        message = index
-      ))
+        message = index))
       println(s"result for $etSendId:::::: $emailResult")
   }
 


### PR DESCRIPTION
I started adding cloudwatch metrics for when something unexpected happens, but then I realised our deps weren't up to date.

This was the result.  GDPR level up!

We should try to minimise our deps to only things supported by big organisations (e.g. scala, play, AWS libs) then we have half a chance of keeping up to date without binary conflicts.

@jacobwinch @paulbrown1982 @lmath 