### PR TITLE
Add identity lookup to identity backfill lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ If there's any code in either that you feel could be unit tested, it should prob
 - **one jar per lambda** - minimise the size of the deployment artifact
 - **minimise dependencies (aka liabilities)** on external libraries as we have to keep them up to date, also they increase the size of the artifact
 
+# Howto update config
+At the moment we just use S3 for config.
+
+If you're making an addition, you can just copy the file from S3 for PROD and CODE, then update and upload.
+Check the version in the AwsS3.scala ConfigLoad object.
+`aws s3 cp s3://gu-reader-revenue-private/membership/payment-failure-lambdas/CODE/payment-failure-lambdas.private.v<VERSION>.json /etc/gu/CODE/ --profile membership`
+Then do the reverse to upload again.
+
+If you're making a change that you only want to go live on deployment (and have the ability to roll back
+with riffraff) then you can increment the version.  Make sure you upload the file with the new version,
+otherwise it will break the existing lambda immediately.
+
+Follow the same process to update the prod config.
+
+To check that you have done it correctly, run the ConfigLoaderSystemTest.
+You will have to remove the @Ignore from it before you can run it.  Remember to replace afterwards.
+That will check the latest version can be understood by the current version of the code.
+
+Ideally this test should be automated and your PR shouldn't be mergable until the config is readable.
+
 ## structure
 The main project aggregates all the sub projects from handlers and lib, so we can build and test them in one go.
 

--- a/handlers/identity-backfill/src/main/resources/log4j.properties
+++ b/handlers/identity-backfill/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log = .
+log4j.rootLogger = INFO, LAMBDA
+
+# Define the LAMBDA Appender
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
@@ -35,8 +35,7 @@ object GetByEmail {
       case _ => -\/(ApiError("not an OK response from api"))
     }
 
-  def apply(deps: IdentityClientDeps)(email: EmailAddress): ApiError \/ IdentityId = {
-    import deps._
+  def apply(email: EmailAddress)(getResponse: Request => Response, identityConfig: IdentityConfig): ApiError \/ IdentityId = {
 
     val url = HttpUrl.parse(identityConfig.baseUrl + "/user").newBuilder().addQueryParameter("emailAddress", email.value).build()
     val response = getResponse(new Request.Builder().url(url).addHeader("X-GU-ID-Client-Access-Token", "Bearer " + identityConfig.apiToken).build())
@@ -60,7 +59,3 @@ case class IdentityConfig(
 object IdentityConfig {
   implicit val reads: Reads[IdentityConfig] = Json.reads[IdentityConfig]
 }
-
-case class IdentityClientDeps(
-  getResponse: Request => Response,
-  identityConfig: IdentityConfig)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
@@ -1,0 +1,66 @@
+package com.gu.identity
+
+import com.gu.identity.GetByEmail.RawWireModel.{ User, UserResponse }
+import okhttp3.{ HttpUrl, Request, Response }
+import play.api.libs.json.{ Json, Reads }
+
+import scalaz.{ -\/, \/, \/- }
+import scalaz.syntax.std.either._
+
+object GetByEmail {
+
+  case class EmailAddress(value: String)
+  case class IdentityId(value: String)
+
+  case class ApiError(message: String)
+
+  object RawWireModel {
+
+    case class User(id: String)
+    implicit val userReads: Reads[User] = Json.reads[User]
+
+    case class UserResponse(status: String, user: User)
+    implicit val userResponseReads: Reads[UserResponse] = Json.reads[UserResponse]
+
+  }
+
+  object IdentityId {
+    def fromUser(user: User) =
+      IdentityId(user.id)
+  }
+
+  def userFromResponse(userResponse: UserResponse): ApiError \/ User =
+    userResponse match {
+      case UserResponse("ok", user) => \/-(user)
+      case _ => -\/(ApiError("not an OK response from api"))
+    }
+
+  def apply(deps: IdentityClientDeps)(email: EmailAddress): ApiError \/ IdentityId = {
+    import deps._
+
+    val url = HttpUrl.parse(identityConfig.baseUrl + "/user").newBuilder().addQueryParameter("emailAddress", email.value).build()
+    val response = getResponse(new Request.Builder().url(url).addHeader("X-GU-ID-Client-Access-Token", "Bearer " + identityConfig.apiToken).build())
+
+    for {
+      _ <- if (response.code == 200) \/-(()) else -\/(ApiError(s"failed http with ${response.code}"))
+      body = response.body.byteStream
+      userResponse <- Json.parse(body).validate[UserResponse].asEither.disjunction.leftMap(err => ApiError(err.mkString(", ")))
+      user <- userFromResponse(userResponse)
+      identityId = IdentityId.fromUser(user)
+    } yield identityId
+
+  }
+
+}
+
+case class IdentityConfig(
+  baseUrl: String,
+  apiToken: String)
+
+object IdentityConfig {
+  implicit val reads: Reads[IdentityConfig] = Json.reads[IdentityConfig]
+}
+
+case class IdentityClientDeps(
+  getResponse: Request => Response,
+  identityConfig: IdentityConfig)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -19,8 +19,8 @@ object Handler {
     runWithEffects(RawEffects.createDefault, LambdaIO(inputStream, outputStream, context))
 
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
-    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
-      IdentityBackfillSteps.apply
+    def operation: Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit] =
+      config => IdentityBackfillSteps.apply(config.stepsConfig, rawEffects.response)
     ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -4,18 +4,25 @@ import java.io.{ InputStream, OutputStream }
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
+import com.gu.identityBackfill.IdentityBackfillSteps.IdentityBackfillDeps
+import com.gu.identityBackfill.IdentityBackfillSteps.IdentityBackfillDeps.StepsConfig
 import com.gu.util.Config
-import com.gu.util.apigateway.ApiGatewayHandler
-import com.gu.util.zuora.ZuoraRestConfig
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.reader.Types.FailableOp
 
 object Handler {
 
-  def default(rawEffects: RawEffects) =
-    ApiGatewayHandler(rawEffects.stage, rawEffects.s3Load, { config: Config[ZuoraRestConfig] =>
-      IdentityBackfillSteps.default(rawEffects.now(), rawEffects.response, config)
-    })
+  // this is the entry point
+  // it's referenced by the cloudformation so make sure you keep it in step
+  // it's the only part you can't test of the handler
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
+    runWithEffects(RawEffects.createDefault, LambdaIO(inputStream, outputStream, context))
 
-  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    default(RawEffects.createDefault)(inputStream, outputStream, context)
+  def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
+    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
+      IdentityBackfillSteps.apply(IdentityBackfillDeps.default(rawEffects.now(), rawEffects.response, config))
+    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
+
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -4,8 +4,7 @@ import java.io.{ InputStream, OutputStream }
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
-import com.gu.identityBackfill.IdentityBackfillSteps.IdentityBackfillDeps
-import com.gu.identityBackfill.IdentityBackfillSteps.IdentityBackfillDeps.StepsConfig
+import com.gu.identityBackfill.IdentityBackfillSteps.StepsConfig
 import com.gu.util.Config
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
@@ -21,7 +20,7 @@ object Handler {
 
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
     def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
-      IdentityBackfillSteps.apply(IdentityBackfillDeps.default(rawEffects.now(), rawEffects.response, config))
+      IdentityBackfillSteps.apply
     ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -2,25 +2,30 @@ package com.gu.identityBackfill
 
 import java.time.LocalDate
 
+import com.gu.identity.IdentityConfig
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraRestConfig
 import com.gu.util.{ Config, Logging }
 import okhttp3.{ Request, Response }
-import play.api.libs.json.Json
+import play.api.libs.json.{ Json, Reads }
 
 object IdentityBackfillSteps extends Logging {
 
-  def default(now: LocalDate, response: Request => Response, config: Config[ZuoraRestConfig]): ApiGatewayRequest => FailableOp[Unit] = {
-    //val zuoraDeps = ZuoraDeps(response, config.zuoraRestConfig)
-    new IdentityBackfillSteps().apply
+  case class IdentityBackfillDeps()
+
+  object IdentityBackfillDeps extends Logging {
+
+    case class StepsConfig(identityConfig: IdentityConfig, zuoraRestConfig: ZuoraRestConfig)
+    implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
+
+    def default(now: LocalDate, response: Request => Response, config: Config[StepsConfig]): IdentityBackfillDeps = {
+      new IdentityBackfillDeps()
+    }
+
   }
 
-}
-
-class IdentityBackfillSteps() extends Logging {
-
-  def apply(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
+  def apply(identityBackfillDeps: IdentityBackfillDeps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     println("ap")
     for {
       autoCancelCallout <- Json.fromJson[Seq[String]](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -1,31 +1,18 @@
 package com.gu.identityBackfill
 
-import java.time.LocalDate
-
 import com.gu.identity.IdentityConfig
+import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraRestConfig
-import com.gu.util.{ Config, Logging }
-import okhttp3.{ Request, Response }
 import play.api.libs.json.{ Json, Reads }
 
 object IdentityBackfillSteps extends Logging {
 
-  case class IdentityBackfillDeps()
+  case class StepsConfig(identityConfig: IdentityConfig, zuoraRestConfig: ZuoraRestConfig)
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
 
-  object IdentityBackfillDeps extends Logging {
-
-    case class StepsConfig(identityConfig: IdentityConfig, zuoraRestConfig: ZuoraRestConfig)
-    implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
-
-    def default(now: LocalDate, response: Request => Response, config: Config[StepsConfig]): IdentityBackfillDeps = {
-      new IdentityBackfillDeps()
-    }
-
-  }
-
-  def apply(identityBackfillDeps: IdentityBackfillDeps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
+  def apply(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     println("ap")
     for {
       autoCancelCallout <- Json.fromJson[Seq[String]](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -1,10 +1,13 @@
 package com.gu.identityBackfill
 
-import com.gu.identity.IdentityConfig
+import com.gu.identity.GetByEmail.EmailAddress
+import com.gu.identity.{ GetByEmail, IdentityConfig }
+import com.gu.identityBackfill.IdentityBackfillSteps.WireModel.IdentityBackfillRequest
 import com.gu.util.Logging
-import com.gu.util.apigateway.ApiGatewayRequest
+import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraRestConfig
+import okhttp3.{ Request, Response }
 import play.api.libs.json.{ Json, Reads }
 
 object IdentityBackfillSteps extends Logging {
@@ -12,11 +15,25 @@ object IdentityBackfillSteps extends Logging {
   case class StepsConfig(identityConfig: IdentityConfig, zuoraRestConfig: ZuoraRestConfig)
   implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
 
-  def apply(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
+  object WireModel {
+
+    case class IdentityBackfillRequest(emailAddress: String)
+    implicit val identityBackfillRequest: Reads[IdentityBackfillRequest] = Json.reads[IdentityBackfillRequest]
+
+  }
+
+  def fromRequest(identityBackfillRequest: IdentityBackfillRequest): EmailAddress = {
+    EmailAddress(identityBackfillRequest.emailAddress)
+  }
+
+  def apply(config: StepsConfig, getResponse: Request => Response)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     println("ap")
     for {
-      autoCancelCallout <- Json.fromJson[Seq[String]](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
+      autoCancelCallout <- Json.fromJson[IdentityBackfillRequest](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
       _ = println(autoCancelCallout)
+      aaa = fromRequest(autoCancelCallout)
+      bbb <- GetByEmail(aaa)(getResponse, config.identityConfig).leftMap(a => ApiGatewayResponse.internalServerError(a.toString))
+      _ = println(bbb)
     } yield ()
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -11,7 +11,7 @@ class GetByEmailTest extends FlatSpec with Matchers {
   it should "get successful ok" in {
     val testingRawEffects = new TestingRawEffects(responses = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse))))
 
-    val actual: \/[GetByEmail.ApiError, GetByEmail.IdentityId] = GetByEmail(IdentityClientDeps(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken")))(EmailAddress("email@address"))
+    val actual: \/[GetByEmail.ApiError, GetByEmail.IdentityId] = GetByEmail(EmailAddress("email@address"))(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken"))
 
     actual should be(\/-(IdentityId("1234")))
   }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -1,0 +1,43 @@
+package com.gu.identity
+
+import com.gu.effects.TestingRawEffects
+import com.gu.identity.GetByEmail.{ EmailAddress, IdentityId }
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scalaz.{ \/, \/- }
+
+class GetByEmailTest extends FlatSpec with Matchers {
+
+  it should "get successful ok" in {
+    val testingRawEffects = new TestingRawEffects(responses = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse))))
+
+    val actual: \/[GetByEmail.ApiError, GetByEmail.IdentityId] = GetByEmail(IdentityClientDeps(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken")))(EmailAddress("email@address"))
+
+    actual should be(\/-(IdentityId("1234")))
+  }
+
+}
+
+object TestData {
+
+  val dummyIdentityResponse: String =
+    """
+      |{
+      |    "status": "ok",
+      |    "user": {
+      |        "id": "1234",
+      |        "dates": {
+      |            "accountCreatedDate": "2015-03-17T11:09:08Z"
+      |        },
+      |        "primaryEmailAddress": "john.duffell@guardian.co.uk",
+      |        "publicFields": {
+      |            "username": "johnduffell2",
+      |            "displayName": "johnduffell2",
+      |            "vanityUrl": "johnduffell2",
+      |            "usernameLowerCase": "johnduffell2"
+      |        }
+      |    }
+      |}
+    """.stripMargin
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -4,6 +4,7 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 
 import com.gu.effects.TestingRawEffects
 import com.gu.identityBackfill.EndToEndData._
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import org.scalatest.{ FlatSpec, Matchers }
 import play.api.libs.json.Json
 
@@ -16,7 +17,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     val config = new TestingRawEffects(false, 200, responses)
 
     //execute
-    Handler.default(config.rawEffects)(stream, os, null)
+    Handler.runWithEffects(config.rawEffects, LambdaIO(stream, os, null))
 
     val responseString = new String(os.toByteArray(), "UTF-8")
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -3,6 +3,7 @@ package com.gu.identityBackfill
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 
 import com.gu.effects.TestingRawEffects
+import com.gu.identity.TestData
 import com.gu.identityBackfill.EndToEndData._
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import org.scalatest.{ FlatSpec, Matchers }
@@ -41,7 +42,7 @@ object EndToEndData {
     }
   }
 
-  def responses: Map[String, (Int, String)] = Map()
+  def responses: Map[String, (Int, String)] = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse)))
 
   val identityBackfillRequest: String =
     """
@@ -96,7 +97,7 @@ object EndToEndData {
       |        "httpMethod": "POST",
       |        "apiId": "11111"
       |    },
-      |    "body": "[\"hello!!!!\"]",
+      |    "body": "{\"emailAddress\": \"email@address\"}",
       |    "isBase64Encoded": false
       |}
     """.stripMargin

--- a/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
@@ -1,8 +1,8 @@
 package manualTest
 
 import com.gu.effects.RawEffects
+import com.gu.identity.GetByEmail
 import com.gu.identity.GetByEmail.EmailAddress
-import com.gu.identity.{ GetByEmail, IdentityClientDeps }
 import com.gu.identityBackfill.IdentityBackfillSteps.StepsConfig
 import com.gu.util.{ Config, Logging }
 
@@ -18,8 +18,7 @@ object GetByEmailSystemTest extends App with Logging {
       Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString
     }.toEither.disjunction.withLogging("fromFile")
     config <- Config.parseConfig[StepsConfig](configAttempt).withLogging("parseConfig")
-    deps = IdentityClientDeps(RawEffects.createDefault.response, config.stepsConfig.identityConfig)
-    identityId <- GetByEmail(deps)(EmailAddress("john.duffell@guardian.co.uk")).withLogging("GetByEmail")
+    identityId <- GetByEmail(EmailAddress("john.duffell@guardian.co.uk"))(RawEffects.createDefault.response, config.stepsConfig.identityConfig).withLogging("GetByEmail")
   } yield {
     println(s"result for getbyemail:::::: $identityId")
   }

--- a/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
@@ -3,7 +3,7 @@ package manualTest
 import com.gu.effects.RawEffects
 import com.gu.identity.GetByEmail.EmailAddress
 import com.gu.identity.{ GetByEmail, IdentityClientDeps }
-import com.gu.identityBackfill.IdentityBackfillSteps.IdentityBackfillDeps.StepsConfig
+import com.gu.identityBackfill.IdentityBackfillSteps.StepsConfig
 import com.gu.util.{ Config, Logging }
 
 import scala.io.Source

--- a/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
@@ -1,0 +1,27 @@
+package manualTest
+
+import com.gu.effects.RawEffects
+import com.gu.identity.GetByEmail.EmailAddress
+import com.gu.identity.{ GetByEmail, IdentityClientDeps }
+import com.gu.identityBackfill.IdentityBackfillSteps.IdentityBackfillDeps.StepsConfig
+import com.gu.util.{ Config, Logging }
+
+import scala.io.Source
+import scala.util.Try
+import scalaz.syntax.std.either._
+
+// run this manually
+object GetByEmailSystemTest extends App with Logging {
+
+  for {
+    configAttempt <- Try {
+      Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString
+    }.toEither.disjunction.withLogging("fromFile")
+    config <- Config.parseConfig[StepsConfig](configAttempt).withLogging("parseConfig")
+    deps = IdentityClientDeps(RawEffects.createDefault.response, config.stepsConfig.identityConfig)
+    identityId <- GetByEmail(deps)(EmailAddress("john.duffell@guardian.co.uk")).withLogging("GetByEmail")
+  } yield {
+    println(s"result for getbyemail:::::: $identityId")
+  }
+
+}

--- a/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
@@ -13,7 +13,7 @@ object ConfigLoad extends Logging {
 
   // if you are updating the config, it's hard to test it in advance of deployment
   // with this, you can upload the new config with a new name
-  val version = "3"
+  val version = "4"
 
   def load(stage: Stage): Try[String] = {
     logger.info(s"Attempting to load config in $stage")

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -27,8 +27,9 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
   val response: Request => Response = {
     req =>
       result = req :: result
-      val (code, response) = responses.getOrElse(req.url().encodedPath(), (defaultCode, """{"success": true}"""))
-      logger.info(s"request for: ${req.url().encodedPath()} so returning $response")
+      val path = req.url().encodedPath() + Option( /*could be null*/ req.url().encodedQuery()).filter(_ != "").map(query => s"?$query").getOrElse("")
+      val (code, response) = responses.getOrElse(path, (defaultCode, """{"success": true}"""))
+      logger.info(s"request for: $path so returning $response")
       new Response.Builder()
         .request(req)
         .protocol(Protocol.HTTP_1_1)
@@ -65,10 +66,16 @@ object TestingRawEffects {
       |    "apiToken": "b",
       |    "tenantId": "c"
       |  },
-      |  "zuoraRestConfig": {
-      |    "baseUrl": "https://ddd",
-      |    "username": "e@f.com",
-      |    "password": "ggg"
+      |  "stepsConfig": {
+      |    "zuoraRestConfig": {
+      |      "baseUrl": "https://ddd",
+      |      "username": "e@f.com",
+      |      "password": "ggg"
+      |    },
+      |    "identityConfig": {
+      |      "baseUrl": "https://ididbaseurl",
+      |      "apiToken": "tokentokentokenidentity"
+      |    }
       |  },
       |  "etConfig": {
       |    "etSendIDs":

--- a/lib/handler/src/main/scala/com/gu/util/Logging.scala
+++ b/lib/handler/src/main/scala/com/gu/util/Logging.scala
@@ -1,11 +1,9 @@
 package com.gu.util
 
-import com.gu.util.reader.Types.{ FailableOp, WithDepsFailableOp }
+import com.gu.util.reader.Types.{ WithDepsFailableOp, _ }
 import org.apache.log4j.Logger
 
-import com.gu.util.reader.Types._
-
-import scalaz.{ -\/, \/- }
+import scalaz.{ -\/, \/, \/- }
 
 trait Logging {
 
@@ -24,10 +22,10 @@ trait Logging {
 
   }
 
-  implicit class LogImplicit2[A](failableOp: FailableOp[A]) {
+  implicit class LogImplicit2[E, A](failableOp: E \/ A) {
 
     // this is just a handy method to add logging to the end of any for comprehension
-    def withLogging(message: String): FailableOp[A] = {
+    def withLogging(message: String): E \/ A = {
 
       failableOp match {
         case \/-(continuation) =>

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -55,4 +55,19 @@ object Types {
 
   }
 
+  // handy class for converting things
+  implicit class EitherOps[L, A](theEither: L \/ A) {
+
+    def toFailableOp(action: String): FailableOp[A] = {
+      theEither match {
+        case \/-(success) => \/-(success)
+        case -\/(error) => {
+          logger.error(s"Failed to $action: $error")
+          -\/(internalServerError(s"Failed to execute lambda - unable to $action"))
+        }
+      }
+    }
+
+  }
+
 }

--- a/lib/handler/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -4,17 +4,17 @@ import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
 import org.scalatest.{ FlatSpec, Matchers }
 import play.api.libs.json.{ JsSuccess, Json }
 
-import scala.util.Success
+import scalaz.\/-
 
 class ConfigLoaderTest extends FlatSpec with Matchers {
 
   "loader" should "be able to load config successfully" in {
     val actualConfigObject = Config.parseConfig[String](codeConfig)
-    actualConfigObject should be(Success(
+    actualConfigObject should be(\/-(
       Config(
         Stage("DEV"),
         TrustedApiConfig("b", "c"),
-        zuoraRestConfig = "hi",
+        stepsConfig = "hi",
         etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"),
         stripeConfig = StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true))))
   }
@@ -78,7 +78,7 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
       |    "apiToken": "b",
       |    "tenantId": "c"
       |  },
-      |  "zuoraRestConfig": "hi",
+      |  "stepsConfig": "hi",
       |  "etConfig": {
       |    "etSendIDs":
       |    {

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -5,22 +5,24 @@ import java.io.{ InputStream, OutputStream }
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.autoCancel.AutoCancelSteps.AutoCancelStepsDeps
 import com.gu.effects.RawEffects
-import com.gu.util.apigateway.ApiGatewayHandler
-import com.gu.util.zuora.ZuoraRestConfig
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.reader.Types.FailableOp
 import com.gu.util.{ Config, Logging }
 
 object AutoCancelHandler extends App with Logging {
 
-  def default(rawEffects: RawEffects) =
-    ApiGatewayHandler(rawEffects.stage, rawEffects.s3Load, { config: Config[ZuoraRestConfig] =>
+  def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
+    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
       AutoCancelSteps(AutoCancelStepsDeps.default(rawEffects.now(), rawEffects.response, config))
-    })
+    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+  }
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
-  def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    default(RawEffects.createDefault)(inputStream, outputStream, context)
-  }
+  def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
+    runWithEffects(RawEffects.createDefault, LambdaIO(inputStream, outputStream, context))
 
 }

--- a/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -1,18 +1,19 @@
 package com.gu.autoCancel
 
+import java.time.LocalDate
+
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.paymentFailure.ZuoraEmailSteps.ZuoraEmailStepsDeps
 import com.gu.paymentFailure.{ ToMessage, ZuoraEmailSteps }
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.exacttarget.EmailRequest
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraRestConfig }
+import com.gu.util.zuora.ZuoraDeps
 import com.gu.util.{ Config, Logging }
 import okhttp3.{ Request, Response }
-import java.time.LocalDate
-
 import play.api.libs.json.Json
 
 import scalaz.\/-
@@ -20,8 +21,8 @@ import scalaz.\/-
 object AutoCancelSteps extends Logging {
 
   object AutoCancelStepsDeps {
-    def default(now: LocalDate, response: Request => Response, config: Config[ZuoraRestConfig]): AutoCancelStepsDeps = {
-      val zuoraDeps = ZuoraDeps(response, config.zuoraRestConfig)
+    def default(now: LocalDate, response: Request => Response, config: Config[StepsConfig]): AutoCancelStepsDeps = {
+      val zuoraDeps = ZuoraDeps(response, config.stepsConfig.zuoraRestConfig)
       AutoCancelStepsDeps(
         AutoCancel.apply(zuoraDeps),
         AutoCancelDataCollectionFilter.apply(AutoCancelDataCollectionFilter.ACFilterDeps.default(now, zuoraDeps)),

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -5,22 +5,24 @@ import java.io.{ InputStream, OutputStream }
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.paymentFailure.PaymentFailureSteps.PFDeps
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.Config
-import com.gu.util.apigateway.ApiGatewayHandler
-import com.gu.util.zuora.ZuoraRestConfig
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.reader.Types.FailableOp
 
 object Lambda {
 
-  def default(rawEffects: RawEffects) =
-    ApiGatewayHandler(rawEffects.stage, rawEffects.s3Load, { config: Config[ZuoraRestConfig] =>
+  def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
+    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
       PaymentFailureSteps(PFDeps.default(rawEffects.response, config))
-    })
+    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+  }
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
-  def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    default(RawEffects.createDefault)(inputStream, outputStream, context)
-  }
+  def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
+    runWithEffects(RawEffects.createDefault, LambdaIO(inputStream, outputStream, context))
 
 }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -2,6 +2,7 @@ package com.gu.paymentFailure
 
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.paymentFailure.ZuoraEmailSteps.ZuoraEmailStepsDeps
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.Auth.validTenant
 import com.gu.util.ETConfig.ETSendIds
 import com.gu.util._
@@ -12,7 +13,7 @@ import com.gu.util.exacttarget.{ EmailRequest, EmailSendSteps }
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
 import com.gu.util.zuora.internal.Types.ClientFailableOp
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraGetInvoiceTransactions, ZuoraRestConfig }
+import com.gu.util.zuora.{ ZuoraDeps, ZuoraGetInvoiceTransactions }
 import okhttp3.{ Request, Response }
 import play.api.libs.json.Json
 
@@ -45,7 +46,7 @@ object PaymentFailureSteps extends Logging {
   }
 
   object PFDeps {
-    def default(response: Request => Response, config: Config[ZuoraRestConfig]): PFDeps = {
+    def default(response: Request => Response, config: Config[StepsConfig]): PFDeps = {
       PFDeps(
         ZuoraEmailSteps.sendEmailRegardingAccount(ZuoraEmailStepsDeps.default(response, config)),
         config.etConfig.etSendIDs,
@@ -72,10 +73,10 @@ object ZuoraEmailSteps {
   }
 
   object ZuoraEmailStepsDeps {
-    def default(response: Request => Response, config: Config[ZuoraRestConfig]): ZuoraEmailStepsDeps = {
+    def default(response: Request => Response, config: Config[StepsConfig]): ZuoraEmailStepsDeps = {
       ZuoraEmailStepsDeps(
         EmailSendSteps.apply(EmailSendStepsDeps.default(config.stage, response, config.etConfig)),
-        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.zuoraRestConfig)))
+        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.stepsConfig.zuoraRestConfig)))
     }
   }
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -4,26 +4,24 @@ import java.io.{ InputStream, OutputStream }
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
-import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.Deps
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.{ Deps, StepsConfig }
 import com.gu.util.Config
-import com.gu.util.apigateway.ApiGatewayHandler
-import com.gu.util.zuora.ZuoraRestConfig
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.reader.Types.FailableOp
 
 object Lambda {
 
-  case class LambdaDeps(handler: (InputStream, OutputStream, Context) => Unit)
-
-  def default(rawEffects: RawEffects) =
-    ApiGatewayHandler(rawEffects.stage, rawEffects.s3Load, { config: Config[ZuoraRestConfig] =>
+  def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
+    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
       SourceUpdatedSteps(Deps.default(rawEffects.response, config))
-    })
+    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+  }
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
-  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    val deps = default(RawEffects.createDefault)
-    deps(inputStream, outputStream, context)
-  }
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
+    runWithEffects(RawEffects.createDefault, LambdaIO(inputStream, outputStream, context))
 
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -13,7 +13,7 @@ import com.gu.stripeCustomerSourceUpdated.zuora.ZuoraQueryPaymentMethod.{ Accoun
 import com.gu.util.zuora.ZuoraAccount.PaymentMethodId
 import com.gu.util.zuora._
 import okhttp3.{ Request, Response }
-import play.api.libs.json.Json
+import play.api.libs.json.{ Json, Reads }
 
 import scalaz._
 import scalaz.syntax.applicative._
@@ -22,6 +22,9 @@ import scalaz.std.list._
 import scalaz.EitherT._
 
 object SourceUpdatedSteps extends Logging {
+
+  case class StepsConfig(zuoraRestConfig: ZuoraRestConfig)
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
 
   type WithZuoraDepsFailableOp[A] = WithDepsFailableOp[ZuoraDeps, A]
   implicit val mWithZuoraDepsFailableOp: Monad[WithZuoraDepsFailableOp] = eitherTMonad[({ type XReader[AA] = Reader[ZuoraDeps, AA] })#XReader, ApiResponse]
@@ -94,8 +97,8 @@ object SourceUpdatedSteps extends Logging {
   }
 
   object Deps {
-    def default(response: Request => Response, config: Config[ZuoraRestConfig]): Deps = {
-      Deps(ZuoraDeps(response, config.zuoraRestConfig), StripeDeps(config.stripeConfig, new StripeSignatureChecker))
+    def default(response: Request => Response, config: Config[StepsConfig]): Deps = {
+      Deps(ZuoraDeps(response, config.stepsConfig.zuoraRestConfig), StripeDeps(config.stripeConfig, new StripeSignatureChecker))
     }
   }
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -3,14 +3,13 @@ package com.gu
 import java.time.LocalDate
 
 import com.gu.effects.TestingRawEffects
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.stripeCustomerSourceUpdated.{ StripeDeps, StripeSignatureChecker }
 import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
 import com.gu.util._
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
-import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraRestConfig }
 import com.gu.util.zuora.internal.Types.{ ClientFailableOp, WithDepsClientFailableOp, _ }
+import com.gu.util.zuora.{ ZuoraDeps, ZuoraRestConfig }
 import org.scalatest.Matchers
 import play.api.libs.json.Json
 
@@ -39,7 +38,7 @@ object TestData extends Matchers {
   val fakeConfig = Config(
     stage = Stage("DEV"),
     trustedApiConfig = fakeApiConfig,
-    zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg"),
+    stepsConfig = StepsConfig(zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg")),
     etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"),
     stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")), true))
 
@@ -54,7 +53,8 @@ object TestData extends Matchers {
     }
   }
 
-  def handlerDeps(operation: Config[ZuoraRestConfig] => ApiGatewayRequest => FailableOp[Unit]) = new ApiGatewayHandler(() => Success(""), Stage("DEV"), _ => Success(TestData.fakeConfig), operation)
+  val handlerDeps =
+    (Stage("DEV"), Success(""))
   def zuoraDeps(effects: TestingRawEffects) = ZuoraDeps(effects.response, TestData.fakeZuoraConfig)
   val stripeDeps = StripeDeps(TestData.fakeStripeConfig, new StripeSignatureChecker)
 

--- a/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -4,6 +4,7 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 
 import com.gu.TestData._
 import com.gu.effects.TestingRawEffects
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import org.scalatest.{ FlatSpec, Matchers }
 
 class EndToEndHandlerTest extends FlatSpec with Matchers {
@@ -20,7 +21,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     val os = new ByteArrayOutputStream()
     val config = new TestingRawEffects(false, 200, EndToEndData.responses)
     //execute
-    Lambda.default(config.rawEffects)(stream, os, null)
+    Lambda.runWithEffects(config.rawEffects, LambdaIO(stream, os, null))
 
     config.resultMap
       .get(("POST", "/messaging/v1/messageDefinitionSends/111/send")).get.get jsonMatches endToEndData.expectedEmailSend // TODO check the body too

--- a/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
+++ b/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
@@ -1,12 +1,13 @@
 package manualTest
 
 import com.gu.effects.ConfigLoad
-import com.gu.util.zuora.ZuoraRestConfig
-import com.gu.util.{ Config, Stage }
-import org.scalatest.{ FlatSpec, Ignore, Matchers }
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
+import com.gu.util.{Config, Stage}
+import org.scalatest.{FlatSpec, Ignore, Matchers}
 
 import scala.io.Source
-import scala.util.{ Success, Try }
+import scala.util.Try
+import scalaz.\/-
 import scalaz.syntax.std.either._
 
 // this test checks the actual config in S3 so it needs credentials.  this means you can only run it manually
@@ -16,32 +17,30 @@ class ConfigLoaderSystemTest extends FlatSpec with Matchers {
 
   "loader" should "be able to load the prod config successfully" in {
     val prod = ConfigLoad.load(Stage("PROD"))
-    validate(prod, Some(true))
+    validate(prod, Stage("PROD"))
   }
 
   it should "be able to load the code config successfully" in {
     val code: Try[String] = ConfigLoad.load(Stage("CODE"))
-    validate(code, None)
+    validate(code, Stage("CODE"))
   }
 
-  def validate(configAttemp: Try[String], verificationStatus: Option[Boolean]) = {
+  def validate(configAttemp: Try[String], stage: Stage) = {
     val con = for {
       a <- configAttemp.toEither.disjunction
-      b <- Config.parseConfig[ZuoraRestConfig](a)
+      b <- Config.parseConfig[StepsConfig](a)
     } yield b
     val loadedOK = con.map(config => ())
     withClue(configAttemp) {
-      loadedOK should be(Success(()))
-      verificationStatus.foreach {
-        expected => con.toOption.get.stripeConfig.signatureChecking should be(expected)
-      }
+      loadedOK should be(\/-(()))
+      con.toOption.get.stage should be(stage)
     }
   }
 
   it should "be able to load the local test config successfully" in {
     val configAttempt = Try { Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString }
 
-    validate(configAttempt, None)
+    validate(configAttempt, Stage("DEV"))
   }
 
 }

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -5,13 +5,14 @@ import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.zuora.ZuoraRestConfig
-import com.gu.util.{ Config, Stage }
+import com.gu.util.{ Config, Logging, Stage }
 
 import scala.io.Source
 import scala.util.{ Random, Try }
+import scalaz.syntax.std.either._
 
 // run this to send a one off email to yourself.  the email will take a few mins to arrive, but it proves the ET logic works
-object EmailClientSystemTest extends App {
+object EmailClientSystemTest extends App with Logging {
 
   private val recipient = "john.duffell@guardian.co.uk"
   private def unique = "pi123" + Random.nextInt
@@ -45,7 +46,7 @@ object EmailClientSystemTest extends App {
   for {
     configAttempt <- Try {
       Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString
-    }
+    }.toEither.disjunction.withLogging("fromFile")
     config <- Config.parseConfig[ZuoraRestConfig](configAttempt)
     deps = EmailSendStepsDeps.default(Stage("CODE"), RawEffects.createDefault.response, config.etConfig)
     etSendIds = config.etConfig.etSendIDs


### PR DESCRIPTION
This adds an identity lookup plus tests to the identity backfill.  This is needed to get the identity id of a user that we want to populate into zuora/sf.

I have also partly undone the refactoring I made to api gateway handler previously that got rid of the Deps object.  I haven't put back the Deps object, but I've just passed the deps in as parameters.  If there are too many deps, then the function is probably doing too much.

There is also a new manualTest, so if you run it locally with valid identity credentials, you can see it working.  Maybe we need some more documentation oh how to do this as it's not ideal to have a "test" that doesn't run automatically.

I have tested in CODE and all the lambdas seem to work in general.

@pvighi @paulbrown1982 @lmath @jacobwinch please have a quick look