### PR TITLE
add high level identity backfill steps

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -4,11 +4,15 @@ import java.io.{ InputStream, OutputStream }
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
-import com.gu.identityBackfill.IdentityBackfillSteps.StepsConfig
+import com.gu.identity.{ GetByEmail, IdentityConfig }
+import com.gu.identityBackfill.Types._
 import com.gu.util.Config
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.reader.Types.FailableOp
+import com.gu.util.zuora.ZuoraRestConfig
+import play.api.libs.json.{ Json, Reads }
+import scalaz.syntax.either._
 
 object Handler {
 
@@ -18,10 +22,42 @@ object Handler {
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
     runWithEffects(RawEffects.createDefault, LambdaIO(inputStream, outputStream, context))
 
+  case class StepsConfig(identityConfig: IdentityConfig, zuoraRestConfig: ZuoraRestConfig)
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
+
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
     def operation: Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit] =
-      config => IdentityBackfillSteps.apply(config.stepsConfig, rawEffects.response)
+      config => IdentityBackfillSteps(
+        GetByEmail(rawEffects.response, config.stepsConfig.identityConfig),
+        GetZuoraAccountsForEmail.apply,
+        CountZuoraAccountsForIdentityId.apply,
+        UpdateZuoraIdentityId.apply,
+        UpdateSalesforceIdentityId.apply)
     ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 
+}
+
+object GetZuoraAccountsForEmail {
+  def apply(emailAddress: EmailAddress): FailableOp[List[ZuoraAccountIdentitySFContact]] = {
+    ApiGatewayResponse.internalServerError("todo").left
+  }
+}
+
+object CountZuoraAccountsForIdentityId {
+  def apply(identityId: IdentityId): FailableOp[Int] = {
+    ApiGatewayResponse.internalServerError("todo").left
+  }
+}
+
+object UpdateZuoraIdentityId {
+  def apply(accountId: AccountId, identityId: IdentityId): FailableOp[Unit] = {
+    ApiGatewayResponse.internalServerError("todo").left
+  }
+}
+
+object UpdateSalesforceIdentityId {
+  def apply(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
+    ApiGatewayResponse.internalServerError("todo").left
+  }
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -35,7 +35,7 @@ object IdentityBackfillSteps extends Logging {
       request <- Json.fromJson[IdentityBackfillRequest](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
       emailAddress = fromRequest(request)
       identityId <- getByEmail(emailAddress).leftMap(a => ApiGatewayResponse.internalServerError(a.toString)).withLogging("GetByEmail")
-      _ <- if (request.dryRun) -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end")) else \/-(()) // FIXME remove this like
+      _ <- if (request.dryRun) -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end")) else \/-(()) // FIXME this will be removed once the later steps actually do something. it was just needed for testing
       zuoraAccountsForEmail <- getZuoraAccountsForEmail(emailAddress)
       zuoraAccountForEmail <- zuoraAccountsForEmail match { case one :: Nil => \/-(one); case _ => -\/(ApiGatewayResponse.internalServerError("should have exactly one zuora account per email at this stage")) }
       zuoraAccountsForIdentityId <- countZuoraAccountsForIdentityId(identityId)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -1,23 +1,22 @@
 package com.gu.identityBackfill
 
-import com.gu.identity.GetByEmail.EmailAddress
-import com.gu.identity.{ GetByEmail, IdentityConfig }
+import com.gu.identity.GetByEmail
 import com.gu.identityBackfill.IdentityBackfillSteps.WireModel.IdentityBackfillRequest
+import com.gu.identityBackfill.Types._
 import com.gu.util.Logging
 import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraRestConfig
-import okhttp3.{ Request, Response }
 import play.api.libs.json.{ Json, Reads }
+
+import scalaz.{ -\/, \/, \/- }
 
 object IdentityBackfillSteps extends Logging {
 
-  case class StepsConfig(identityConfig: IdentityConfig, zuoraRestConfig: ZuoraRestConfig)
-  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
-
   object WireModel {
 
-    case class IdentityBackfillRequest(emailAddress: String)
+    case class IdentityBackfillRequest(
+      emailAddress: String,
+      dryRun: Boolean)
     implicit val identityBackfillRequest: Reads[IdentityBackfillRequest] = Json.reads[IdentityBackfillRequest]
 
   }
@@ -26,15 +25,40 @@ object IdentityBackfillSteps extends Logging {
     EmailAddress(identityBackfillRequest.emailAddress)
   }
 
-  def apply(config: StepsConfig, getResponse: Request => Response)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
-    println("ap")
+  def apply(
+    getByEmail: EmailAddress => \/[GetByEmail.ApiError, IdentityId],
+    getZuoraAccountsForEmail: EmailAddress => FailableOp[List[ZuoraAccountIdentitySFContact]],
+    countZuoraAccountsForIdentityId: IdentityId => FailableOp[Int],
+    updateZuoraIdentityId: (AccountId, IdentityId) => FailableOp[Unit],
+    updateSalesforceIdentityId: (SFContactId, IdentityId) => FailableOp[Unit])(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     for {
-      autoCancelCallout <- Json.fromJson[IdentityBackfillRequest](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
-      _ = println(autoCancelCallout)
-      aaa = fromRequest(autoCancelCallout)
-      bbb <- GetByEmail(aaa)(getResponse, config.identityConfig).leftMap(a => ApiGatewayResponse.internalServerError(a.toString))
-      _ = println(bbb)
+      request <- Json.fromJson[IdentityBackfillRequest](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
+      emailAddress = fromRequest(request)
+      identityId <- getByEmail(emailAddress).leftMap(a => ApiGatewayResponse.internalServerError(a.toString)).withLogging("GetByEmail")
+      _ <- if (request.dryRun) -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end")) else \/-(()) // FIXME remove this like
+      zuoraAccountsForEmail <- getZuoraAccountsForEmail(emailAddress)
+      zuoraAccountForEmail <- zuoraAccountsForEmail match { case one :: Nil => \/-(one); case _ => -\/(ApiGatewayResponse.internalServerError("should have exactly one zuora account per email at this stage")) }
+      zuoraAccountsForIdentityId <- countZuoraAccountsForIdentityId(identityId)
+      _ <- if (zuoraAccountsForIdentityId > 0) \/-(()) else -\/(ApiGatewayResponse.internalServerError("already used that identity id"))
+      _ <- if (request.dryRun) -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end")) else \/-(())
+      _ <- updateZuoraIdentityId(zuoraAccountForEmail.accountId, identityId)
+      _ <- updateSalesforceIdentityId(zuoraAccountForEmail.sfContactId, identityId)
+      // need to remember which ones we updated?
     } yield ()
   }
+
+}
+
+object Types {
+
+  case class EmailAddress(value: String)
+  case class IdentityId(value: String)
+  case class SFContactId(value: String)
+  case class AccountId(value: String)
+
+  case class ZuoraAccountIdentitySFContact(
+    accountId: AccountId,
+    identityId: IdentityId,
+    sfContactId: SFContactId)
 
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -1,7 +1,7 @@
 package com.gu.identity
 
 import com.gu.effects.TestingRawEffects
-import com.gu.identity.GetByEmail.{ EmailAddress, IdentityId }
+import com.gu.identityBackfill.Types.{ EmailAddress, IdentityId }
 import org.scalatest.{ FlatSpec, Matchers }
 
 import scalaz.{ \/, \/- }
@@ -11,7 +11,7 @@ class GetByEmailTest extends FlatSpec with Matchers {
   it should "get successful ok" in {
     val testingRawEffects = new TestingRawEffects(responses = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse))))
 
-    val actual: \/[GetByEmail.ApiError, GetByEmail.IdentityId] = GetByEmail(EmailAddress("email@address"))(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken"))
+    val actual: \/[GetByEmail.ApiError, IdentityId] = GetByEmail(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken"))(EmailAddress("email@address"))
 
     actual should be(\/-(IdentityId("1234")))
   }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -1,13 +1,14 @@
 package com.gu.identityBackfill
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.BasicRequest
 import com.gu.identity.TestData
 import com.gu.identityBackfill.EndToEndData._
+import Runner._
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.{ Assertion, FlatSpec, Matchers }
 import play.api.libs.json.Json
 
 class EndToEndHandlerTest extends FlatSpec with Matchers {
@@ -36,6 +37,10 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     requests should be(List(BasicRequest("GET", "/user?emailAddress=email@address", "")))
   }
 
+}
+
+object Runner {
+
   def getResultAndRequests(input: String): (String, List[TestingRawEffects.BasicRequest]) = {
     val stream = new ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     val os = new ByteArrayOutputStream()
@@ -49,14 +54,6 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     (responseString, config.requestsAttempted)
   }
 
-}
-
-object Runner {
-
-}
-
-object EndToEndData {
-
   implicit class JsonMatcher(private val actual: String) {
     import Matchers._
     def jsonMatches(expected: String): Assertion = {
@@ -65,6 +62,10 @@ object EndToEndData {
       actualJson should be(expectedJson)
     }
   }
+
+}
+
+object EndToEndData {
 
   def responses: Map[String, (Int, String)] = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse)))
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -1,33 +1,57 @@
 package com.gu.identityBackfill
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.gu.effects.TestingRawEffects
+import com.gu.effects.TestingRawEffects.BasicRequest
 import com.gu.identity.TestData
 import com.gu.identityBackfill.EndToEndData._
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{Assertion, FlatSpec, Matchers}
 import play.api.libs.json.Json
 
 class EndToEndHandlerTest extends FlatSpec with Matchers {
 
+  it should "manage an end to end call in dry run mode" in {
+
+    val (responseString, requests): (String, List[TestingRawEffects.BasicRequest]) = getResultAndRequests(identityBackfillRequest(true))
+
+    val expectedResponse =
+      s"""
+         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Processing is not required: DRY RUN requested! skipping to the end"}
+         |""".stripMargin
+    responseString jsonMatches expectedResponse
+    requests should be(List(BasicRequest("GET", "/user?emailAddress=email@address", "")))
+  }
+
   it should "manage an end to end call" in {
 
-    val stream = new ByteArrayInputStream(identityBackfillRequest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    val (responseString, requests): (String, List[TestingRawEffects.BasicRequest]) = getResultAndRequests(identityBackfillRequest(false))
+
+    val expectedResponse =
+      s"""
+         |{"statusCode":"500","headers":{"Content-Type":"application/json"},"body":"Failed to process event due to the following error: todo"}
+         |""".stripMargin
+    responseString jsonMatches expectedResponse
+    requests should be(List(BasicRequest("GET", "/user?emailAddress=email@address", "")))
+  }
+
+  def getResultAndRequests(input: String): (String, List[TestingRawEffects.BasicRequest]) = {
+    val stream = new ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     val os = new ByteArrayOutputStream()
     val config = new TestingRawEffects(false, 200, responses)
 
     //execute
     Handler.runWithEffects(config.rawEffects, LambdaIO(stream, os, null))
 
-    val responseString = new String(os.toByteArray(), "UTF-8")
+    val responseString = new String(os.toByteArray, "UTF-8")
 
-    val expectedResponse =
-      s"""
-         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
-         |""".stripMargin
-    responseString jsonMatches expectedResponse
+    (responseString, config.requestsAttempted)
   }
+
+}
+
+object Runner {
 
 }
 
@@ -35,7 +59,7 @@ object EndToEndData {
 
   implicit class JsonMatcher(private val actual: String) {
     import Matchers._
-    def jsonMatches(expected: String) = {
+    def jsonMatches(expected: String): Assertion = {
       val expectedJson = Json.parse(expected)
       val actualJson = Json.parse(actual)
       actualJson should be(expectedJson)
@@ -44,8 +68,8 @@ object EndToEndData {
 
   def responses: Map[String, (Int, String)] = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse)))
 
-  val identityBackfillRequest: String =
-    """
+  def identityBackfillRequest(dryRun: Boolean): String =
+    s"""
       |{
       |    "resource": "/payment-failure",
       |    "path": "/payment-failure",
@@ -97,7 +121,7 @@ object EndToEndData {
       |        "httpMethod": "POST",
       |        "apiId": "11111"
       |    },
-      |    "body": "{\"emailAddress\": \"email@address\"}",
+      |    "body": "{\\"emailAddress\\": \\"email@address\\", \\"dryRun\\": $dryRun}",
       |    "isBase64Encoded": false
       |}
     """.stripMargin

--- a/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
@@ -2,8 +2,8 @@ package manualTest
 
 import com.gu.effects.RawEffects
 import com.gu.identity.GetByEmail
-import com.gu.identity.GetByEmail.EmailAddress
-import com.gu.identityBackfill.IdentityBackfillSteps.StepsConfig
+import com.gu.identityBackfill.Handler.StepsConfig
+import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.util.{ Config, Logging }
 
 import scala.io.Source
@@ -18,7 +18,7 @@ object GetByEmailSystemTest extends App with Logging {
       Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString
     }.toEither.disjunction.withLogging("fromFile")
     config <- Config.parseConfig[StepsConfig](configAttempt).withLogging("parseConfig")
-    identityId <- GetByEmail(EmailAddress("john.duffell@guardian.co.uk"))(RawEffects.createDefault.response, config.stepsConfig.identityConfig).withLogging("GetByEmail")
+    identityId <- GetByEmail(RawEffects.createDefault.response, config.stepsConfig.identityConfig)(EmailAddress("john.duffell@guardian.co.uk")).withLogging("GetByEmail")
   } yield {
     println(s"result for getbyemail:::::: $identityId")
   }

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -2,7 +2,7 @@ package com.gu.autoCancel
 
 import java.time.LocalDate
 
-import com.gu.effects.TestingRawEffects.BasicResult
+import com.gu.effects.TestingRawEffects.BasicRequest
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.autoCancel.AutoCancelDataCollectionFilter.ACFilterDeps
 import com.gu.effects.TestingRawEffects
@@ -40,7 +40,7 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
     val effects = new TestingRawEffects(false, 200)
     AutoCancel(TestData.zuoraDeps(effects))(AutoCancelRequest("AID", SubscriptionId("subid"), LocalDate.now))
 
-    effects.requestsAttempted should contain(BasicResult("PUT", "/accounts/AID", "{\"autoPay\":false}"))
+    effects.requestsAttempted should contain(BasicRequest("PUT", "/accounts/AID", "{\"autoPay\":false}"))
   }
 
   //  // todo need an ACSDeps so we don't need so many mock requests

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -2,7 +2,7 @@ package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.TestData
 import com.gu.effects.TestingRawEffects
-import com.gu.effects.TestingRawEffects.BasicResult
+import com.gu.effects.TestingRawEffects.BasicRequest
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedStepsTestData._
 import com.gu.stripeCustomerSourceUpdated.zuora.ZuoraQueryPaymentMethod.PaymentMethodFields
 import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
@@ -31,11 +31,11 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
-    val expectedGET = BasicResult(
+    val expectedGET = BasicRequest(
       "GET",
       "/accounts/accid/summary",
       "")
@@ -62,11 +62,11 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
-    val expectedGET = BasicResult(
+    val expectedGET = BasicRequest(
       "GET",
       "/accounts/accid/summary",
       "")
@@ -98,11 +98,11 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
-    val expectedGET = BasicResult(
+    val expectedGET = BasicRequest(
       "GET",
       "/accounts/accountidfake/summary",
       "")
@@ -141,19 +141,19 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
-    val expectedGET1 = BasicResult(
+    val expectedGET1 = BasicRequest(
       "GET",
       "/accounts/accountidfake/summary",
       "")
-    val expectedGET2 = BasicResult(
+    val expectedGET2 = BasicRequest(
       "GET",
       "/accounts/accountidANOTHER/summary",
       "")
-    val expectedGET3 = BasicResult(
+    val expectedGET3 = BasicRequest(
       "GET",
       "/accounts/accountidANOTHERONE/summary",
       "")
@@ -188,15 +188,15 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
-    val expectedGET1 = BasicResult(
+    val expectedGET1 = BasicRequest(
       "GET",
       "/accounts/accountidfake/summary",
       "")
-    val expectedGET2 = BasicResult(
+    val expectedGET2 = BasicRequest(
       "GET",
       "/accounts/accountidANOTHER/summary",
       "")
@@ -238,7 +238,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
@@ -259,7 +259,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
       "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
@@ -287,11 +287,11 @@ class SourceUpdatedStepsUpdatePaymentMethodTest extends FlatSpec with Matchers {
 
     val actual = SourceUpdatedSteps.createUpdatedDefaultPaymentMethod(PaymentMethodFields(PaymentMethodId("PMID"), AccountId("fake"), NumConsecutiveFailures(1)), eventData).run.run(TestData.zuoraDeps(effects))
 
-    val expectedPOST = BasicResult(
+    val expectedPOST = BasicRequest(
       "POST",
       "/object/payment-method",
       """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction","NumConsecutiveFailures":1}""")
-    val expectedPUT = BasicResult(
+    val expectedPUT = BasicRequest(
       "PUT",
       "/object/account/fake",
       """{"DefaultPaymentMethodId":"newPMID"}""")

--- a/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
+++ b/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
@@ -2,8 +2,8 @@ package manualTest
 
 import com.gu.effects.ConfigLoad
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
-import com.gu.util.{Config, Stage}
-import org.scalatest.{FlatSpec, Ignore, Matchers}
+import com.gu.util.{ Config, Stage }
+import org.scalatest.{ FlatSpec, Ignore, Matchers }
 
 import scala.io.Source
 import scala.util.Try


### PR DESCRIPTION
The process of doing an identity backfill involves checking zuora for duplicate email and identity ids, changing the account zuora to have the right id, then update the SF contact.
This PR adds the high level code to call these functions, and provide a placeholder for each.

I have also added a dry run mode, which means we can run the lambda and it will do all the checks without the actual backfill.  This will be useful in production to give us more confidence.

@pvighi @paulbrown1982 @jacobwinch @lmath comments please!