### PR TITLE
Add identity backfill pre-checks against zuora

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,14 @@ val scalaSettings = Seq(
     "-Ywarn-value-discard"
   ),
   javaOptions in Test += s"""-Dlog4j.configuration=file:${new File(".").getCanonicalPath}/test_log4j.properties""",
-  fork in Test := true
+  fork in Test := true,
+  {
+    import scalariform.formatter.preferences._
+    scalariformPreferences := scalariformPreferences.value
+      .setPreference(DanglingCloseParenthesis, Force)
+      .setPreference(SpacesAroundMultiImports, false)
+      .setPreference(NewlineAtEndOfFile, true)
+  }
 )
 
 lazy val zuora = (project in file("lib/zuora")).settings(scalaSettings).settings(

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
@@ -1,11 +1,11 @@
 package com.gu.identity
 
-import com.gu.identity.GetByEmail.RawWireModel.{ User, UserResponse }
-import com.gu.identityBackfill.Types.{ EmailAddress, IdentityId }
-import okhttp3.{ HttpUrl, Request, Response }
-import play.api.libs.json.{ Json, Reads }
+import com.gu.identity.GetByEmail.RawWireModel.{User, UserResponse}
+import com.gu.identityBackfill.Types.{EmailAddress, IdentityId}
+import okhttp3.{HttpUrl, Request, Response}
+import play.api.libs.json.{Json, Reads}
 
-import scalaz.{ -\/, \/, \/- }
+import scalaz.{-\/, \/, \/-}
 import scalaz.syntax.std.either._
 
 object GetByEmail {
@@ -50,7 +50,8 @@ object GetByEmail {
 
 case class IdentityConfig(
   baseUrl: String,
-  apiToken: String)
+  apiToken: String
+)
 
 object IdentityConfig {
   implicit val reads: Reads[IdentityConfig] = Json.reads[IdentityConfig]

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -31,12 +31,12 @@ object Handler {
     def operation: Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit] =
       config => IdentityBackfillSteps(
         GetByEmail(rawEffects.response, config.stepsConfig.identityConfig),
-        GetZuoraAccountsForEmail.apply(ZuoraDeps(rawEffects.response, config.stepsConfig.zuoraRestConfig)),
-        CountZuoraAccountsForIdentityId.apply(ZuoraDeps(rawEffects.response, config.stepsConfig.zuoraRestConfig)),
+        GetZuoraAccountsForEmail(ZuoraDeps(rawEffects.response, config.stepsConfig.zuoraRestConfig)),
+        CountZuoraAccountsForIdentityId(ZuoraDeps(rawEffects.response, config.stepsConfig.zuoraRestConfig)),
         UpdateZuoraIdentityId.apply,
         UpdateSalesforceIdentityId.apply
       )
-    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+    ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -21,7 +21,7 @@ object CountZuoraAccountsForIdentityId {
 
   def apply(zuoraDeps: ZuoraDeps)(identityId: IdentityId): FailableOp[Int] = {
     val accounts = for {
-      accountsWithEmail <- ListT(ZuoraQuery.query[ZuoraAccount](ZuoraQuery.Query(s"SELECT Id FROM Account where IdentityId__c='${identityId.value}'")).map(_.records))
+      accountsWithEmail <- ListT(ZuoraQuery.getResults[ZuoraAccount](ZuoraQuery.Query(s"SELECT Id FROM Account where IdentityId__c='${identityId.value}'")).map(_.records))
     } yield AccountId(accountsWithEmail.Id)
 
     accounts.run.run.run(zuoraDeps).bimap(e => ApiGatewayResponse.internalServerError(e.message), l => l.size)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -1,0 +1,30 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.identityBackfill.Types.{AccountId, IdentityId}
+import com.gu.identityBackfill.zuora.CountZuoraAccountsForIdentityId.WireModel.ZuoraAccount
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.FailableOp
+import com.gu.util.zuora.{ZuoraDeps, ZuoraQuery}
+import play.api.libs.json.Json
+
+import scalaz.ListT
+
+object CountZuoraAccountsForIdentityId {
+  object WireModel {
+
+    case class ZuoraAccount(
+      Id: String
+    )
+    implicit val zaReads = Json.reads[ZuoraAccount]
+
+  }
+
+  def apply(zuoraDeps: ZuoraDeps)(identityId: IdentityId): FailableOp[Int] = {
+    val accounts = for {
+      accountsWithEmail <- ListT(ZuoraQuery.query[ZuoraAccount](ZuoraQuery.Query(s"SELECT Id FROM Account where IdentityId__c='${identityId.value}'")).map(_.records))
+    } yield AccountId(accountsWithEmail.Id)
+
+    accounts.run.run.run(zuoraDeps).bimap(e => ApiGatewayResponse.internalServerError(e.message), l => l.size)
+  }
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -1,0 +1,40 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.identityBackfill.Types._
+import com.gu.identityBackfill.zuora.GetZuoraAccountsForEmail.WireModel._
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.FailableOp
+import com.gu.util.zuora.{ZuoraDeps, ZuoraQuery}
+import play.api.libs.json.Json
+
+import scalaz.ListT
+
+object GetZuoraAccountsForEmail {
+
+  object WireModel {
+
+    case class ZuoraContact(Id: String)
+    implicit val zcReads = Json.reads[ZuoraContact]
+    case class ZuoraAccount(
+      Id: String,
+      IdentityId__c: String,
+      sfContactId__c: String
+    )
+    implicit val zaReads = Json.reads[ZuoraAccount]
+
+  }
+
+  def apply(zuoraDeps: ZuoraDeps)(emailAddress: EmailAddress): FailableOp[List[ZuoraAccountIdentitySFContact]] = {
+    val accounts = for {
+      contactWithEmail <- ListT(ZuoraQuery.query[ZuoraContact](ZuoraQuery.Query(s"SELECT Id FROM Contact where WorkEmail='${emailAddress.value}'")).map(_.records))
+      accountsWithEmail <- ListT(ZuoraQuery.query[ZuoraAccount](ZuoraQuery.Query(s"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='${contactWithEmail.Id}'")).map(_.records))
+    } yield ZuoraAccountIdentitySFContact(
+      AccountId(accountsWithEmail.Id),
+      IdentityId(accountsWithEmail.IdentityId__c),
+      SFContactId(accountsWithEmail.sfContactId__c)
+    )
+
+    accounts.run.run.run(zuoraDeps).leftMap(e => ApiGatewayResponse.internalServerError(e.message))
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -1,15 +1,18 @@
 package com.gu.identity
 
 import com.gu.effects.TestingRawEffects
-import com.gu.identityBackfill.Types.{ EmailAddress, IdentityId }
-import org.scalatest.{ FlatSpec, Matchers }
+import com.gu.effects.TestingRawEffects.HTTPResponse
+import com.gu.identityBackfill.Types.{EmailAddress, IdentityId}
+import org.scalatest.{FlatSpec, Matchers}
 
-import scalaz.{ \/, \/- }
+import scalaz.{\/, \/-}
 
 class GetByEmailTest extends FlatSpec with Matchers {
 
   it should "get successful ok" in {
-    val testingRawEffects = new TestingRawEffects(responses = Map("/user?emailAddress=email@address" -> ((200, TestData.dummyIdentityResponse))))
+    val testingRawEffects = new TestingRawEffects(
+      responses = TestData.responses
+    )
 
     val actual: \/[GetByEmail.ApiError, IdentityId] = GetByEmail(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken"))(EmailAddress("email@address"))
 
@@ -20,6 +23,9 @@ class GetByEmailTest extends FlatSpec with Matchers {
 
 object TestData {
 
+  def responses: Map[String, HTTPResponse] = Map(
+    "/user?emailAddress=email@address" -> HTTPResponse(200, TestData.dummyIdentityResponse)
+  )
   val dummyIdentityResponse: String =
     """
       |{

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -1,0 +1,100 @@
+package com.gu.identityBackfill
+
+import com.gu.identityBackfill.StepsData._
+import com.gu.identityBackfill.Types.{IdentityId, _}
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.reader.Types.FailableOp
+import org.scalatest.{FlatSpec, Matchers}
+
+import scalaz.{-\/, \/-}
+
+class StepsTest extends FlatSpec with Matchers {
+
+  class StepsWithMocks {
+
+    var zuoraUpdate: Option[(AccountId, IdentityId)] = None // !!
+    var salesforceUpdate: Option[(SFContactId, IdentityId)] = None // !!
+
+    def getSteps(
+      noOfAccountWithSameId: Int = 0,
+      numberOfZuoraAccountsForEmail: Int = 1
+    ): ApiGatewayRequest => FailableOp[Unit] = IdentityBackfillSteps(
+      getByEmail = _ => \/-(IdentityId("asdf")),
+      getZuoraAccountsForEmail = _ => \/-(List.fill(numberOfZuoraAccountsForEmail)(ZuoraAccountIdentitySFContact(AccountId("acc"), IdentityId(""), SFContactId("sf")))),
+      countZuoraAccountsForIdentityId = _ => \/-(noOfAccountWithSameId),
+      updateZuoraIdentityId = (accountId, identityId) => {
+        zuoraUpdate = Some((accountId, identityId))
+        \/-(())
+      },
+      updateSalesforceIdentityId = (sFContactId, identityId) => {
+        salesforceUpdate = Some((sFContactId, identityId))
+        \/-(())
+      }
+    )
+
+  }
+
+  it should "go through a happy case in real mode" in {
+
+    val stepsWithMocks = new StepsWithMocks
+    import stepsWithMocks._
+
+    val result =
+      getSteps()(ApiGatewayRequest(None, identityBackfillRequest(false), None))
+
+    val expectedResult = \/-(())
+    result should be(expectedResult)
+    zuoraUpdate should be(Some((AccountId("acc"), IdentityId("asdf"))))
+    salesforceUpdate should be(Some((SFContactId("sf"), IdentityId("asdf"))))
+  }
+
+  it should "go through a happy case in dry run mode without calling update" in {
+
+    val stepsWithMocks = new StepsWithMocks
+    import stepsWithMocks._
+
+    val result =
+      getSteps()(ApiGatewayRequest(None, identityBackfillRequest(true), None))
+
+    val expectedResult = -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end"))
+    result should be(expectedResult)
+    zuoraUpdate should be(None)
+    salesforceUpdate should be(None)
+  }
+
+  it should "go through a already got identity case without calling update even not in dry run mode" in {
+
+    val stepsWithMocks = new StepsWithMocks
+    import stepsWithMocks._
+
+    val result =
+      getSteps(noOfAccountWithSameId = 1)(ApiGatewayRequest(None, identityBackfillRequest(false), None))
+
+    val expectedResult = -\/(ApiGatewayResponse.notFound("already used that identity id"))
+    result should be(expectedResult)
+    zuoraUpdate should be(None)
+    salesforceUpdate should be(None)
+  }
+
+  it should "go through a multiple zuora account without calling update even not in dry run mode" in {
+
+    val stepsWithMocks = new StepsWithMocks
+    import stepsWithMocks._
+
+    val result =
+      getSteps(numberOfZuoraAccountsForEmail = 2)(ApiGatewayRequest(None, identityBackfillRequest(false), None))
+
+    val expectedResult = -\/(ApiGatewayResponse.notFound("should have exactly one zuora account per email at this stage"))
+    result should be(expectedResult)
+    zuoraUpdate should be(None)
+    salesforceUpdate should be(None)
+  }
+
+}
+
+object StepsData {
+
+  def identityBackfillRequest(dryRun: Boolean): String =
+    s"""{"emailAddress": "email@address", "dryRun": $dryRun}""""
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
@@ -1,0 +1,50 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.effects.TestingRawEffects
+import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
+import com.gu.identityBackfill.Types._
+import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scalaz.\/-
+
+class CountZuoraAccountsForIdentityIdTest extends FlatSpec with Matchers {
+
+  it should "get one result for an identity id if there already is one" in {
+    val effects = new TestingRawEffects(postResponses = CountZuoraAccountsForIdentityIdData.postResponses(true))
+    val get = CountZuoraAccountsForIdentityId(ZuoraDeps(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
+    val contacts = get(IdentityId("1234"))
+    val expected = \/-(1)
+    contacts should be(expected)
+  }
+
+}
+
+object CountZuoraAccountsForIdentityIdData {
+
+  def postResponses(hasResult: Boolean): Map[POSTRequest, HTTPResponse] = {
+
+    val result = """
+                   |{
+                   |  "Id": "12345678"
+                   |}
+                   |"""
+
+    val accountQueryResponse: String =
+      s"""
+         |{
+         |    "records": [
+         |      ${if (hasResult) result else ""}
+         |    ],
+         |    "size": 1,
+         |    "done": true
+         |}
+    """.stripMargin
+
+    Map(
+      POSTRequest("/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}""")
+        -> HTTPResponse(200, accountQueryResponse)
+    )
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -1,0 +1,60 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.effects.TestingRawEffects
+import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
+import com.gu.identityBackfill.Types._
+import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scalaz.\/-
+
+class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
+
+  it should "get the accounts for an email" in {
+    val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses)
+    val get = GetZuoraAccountsForEmail(ZuoraDeps(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
+    val contacts = get(EmailAddress("email@address"))
+    val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), IdentityId("10101010"), SFContactId("00110000011AABBAAB"))))
+    contacts should be(expected)
+  }
+
+}
+
+object GetZuoraAccountsForEmailData {
+
+  def postResponses: Map[POSTRequest, HTTPResponse] = Map(
+    POSTRequest("/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}""")
+      -> HTTPResponse(200, contactQueryResponse),
+    POSTRequest("/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}""")
+      -> HTTPResponse(200, accountQueryResponse)
+  )
+
+  val accountQueryResponse: String =
+    """
+      |{
+      |    "records": [
+      |        {
+      |            "IdentityId__c": "10101010",
+      |            "sfContactId__c": "00110000011AABBAAB",
+      |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
+      |        }
+      |    ],
+      |    "size": 1,
+      |    "done": true
+      |}
+    """.stripMargin
+
+  val contactQueryResponse: String =
+    """
+      |{
+      |    "records": [
+      |        {
+      |            "Id": "2c92a0fb4a38064e014a3f48f1713ada"
+      |        }
+      |    ],
+      |    "size": 1,
+      |    "done": true
+      |}
+    """.stripMargin
+
+}

--- a/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/manualTest/GetByEmailSystemTest.scala
@@ -4,7 +4,7 @@ import com.gu.effects.RawEffects
 import com.gu.identity.GetByEmail
 import com.gu.identityBackfill.Handler.StepsConfig
 import com.gu.identityBackfill.Types.EmailAddress
-import com.gu.util.{ Config, Logging }
+import com.gu.util.{Config, Logging}
 
 import scala.io.Source
 import scala.util.Try

--- a/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
@@ -3,11 +3,11 @@ package com.gu.effects
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.s3.model.{ GetObjectRequest, S3ObjectInputStream }
-import com.gu.util.{ Logging, Stage }
+import com.amazonaws.services.s3.model.{GetObjectRequest, S3ObjectInputStream}
+import com.gu.util.{Logging, Stage}
 
 import scala.io.Source
-import scala.util.{ Failure, Try }
+import scala.util.{Failure, Try}
 
 object ConfigLoad extends Logging {
 
@@ -58,6 +58,7 @@ object aws {
     new SystemPropertiesCredentialsProvider,
     new ProfileCredentialsProvider(ProfileName),
     new InstanceProfileCredentialsProvider(false),
-    new EC2ContainerCredentialsProviderWrapper)
+    new EC2ContainerCredentialsProviderWrapper
+  )
 
 }

--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import com.gu.util.Logging
 import okhttp3.internal.Util.UTF_8
-import okhttp3.{ OkHttpClient, Request, RequestBody, Response }
+import okhttp3.{OkHttpClient, Request, RequestBody, Response}
 import okio.Buffer
 
 object Http extends Logging {

--- a/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
@@ -1,7 +1,7 @@
 package com.gu.effects
 
 import com.gu.util.Stage
-import okhttp3.{ Request, Response }
+import okhttp3.{Request, Response}
 import java.time.LocalDate
 
 import scala.util.Try
@@ -10,7 +10,8 @@ case class RawEffects(
   response: Request => Response,
   stage: Stage,
   s3Load: Stage => Try[String],
-  now: () => LocalDate)
+  now: () => LocalDate
+)
 
 object RawEffects {
 

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -3,14 +3,19 @@ package com.gu.effects
 import java.time.LocalDate
 
 import com.gu.effects.TestingRawEffects._
-import com.gu.util.{ Logging, Stage }
+import com.gu.util.{Logging, Stage}
 import okhttp3._
 import okhttp3.internal.Util.UTF_8
 import okio.Buffer
 
 import scala.util.Success
 
-class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, responses: Map[String, (Int, String)] = Map()) extends Logging {
+class TestingRawEffects(
+  val isProd: Boolean = false,
+  val defaultCode: Int = 1,
+  responses: Map[String, HTTPResponse] = Map(),
+  postResponses: Map[POSTRequest, HTTPResponse] = Map()
+) extends Logging {
 
   var requests: List[Request] = Nil // !
 
@@ -27,8 +32,19 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
     req =>
       requests = req :: requests
       val path = getPathWithQueryString(req)
-      val (code, response) = responses.getOrElse(path, (defaultCode, """{"success": true}"""))
-      logger.info(s"request for: $path so returning $response")
+      logger.info(s"HTTP ${req.method} request for: $path")
+      val aaa =
+        if (req.method() == "GET") {
+          responses.get(path) // todo should change to have GETs and POSTs in one list using a Sum type, and have a getUnusedRequests or something at the end to assert they were "used" by the code
+        } else if (req.method() == "POST") {
+          val reqBody = body(req.body)
+          logger.info(s"HTTP POST body is $reqBody")
+          postResponses.get(POSTRequest(path, reqBody)).orElse(responses.get(path)) // use get response
+        } else responses.get(path)
+      val HTTPResponse(code, response) = aaa.getOrElse(
+        HTTPResponse(defaultCode, """{"success": true}""")
+      )
+      logger.info(s"HTTP precanned response is: $code - $response")
       new Response.Builder()
         .request(req)
         .protocol(Protocol.HTTP_1_1)
@@ -42,15 +58,15 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
     req.url().encodedPath() + Option( /*could be null*/ req.url().encodedQuery()).filter(_ != "").map(query => s"?$query").getOrElse("")
   }
 
+  def body(b: RequestBody): String = {
+    val buffer = new Buffer()
+    b.writeTo(buffer)
+    buffer.readString(UTF_8)
+  }
+
   // TODO nicer type than tuple
   def resultMap: Map[(String, String), Option[String]] = {
     //verify
-    def body(b: RequestBody): String = {
-      val buffer = new Buffer()
-      b.writeTo(buffer)
-      buffer.readString(UTF_8)
-    }
-
     requests.map(req => (req.method, req.url.encodedPath) -> Option(req.body).map(body)).toMap
   }
   val rawEffects = RawEffects(response, stage, _ => Success(codeConfig), () => LocalDate.of(2017, 11, 19))
@@ -58,6 +74,9 @@ class TestingRawEffects(val isProd: Boolean = false, val defaultCode: Int = 1, r
 }
 
 object TestingRawEffects {
+
+  case class POSTRequest(urlPathAndQuery: String, postBody: String)
+  case class HTTPResponse(code: Int, body: String)
 
   case class BasicRequest(method: String, path: String, body: String)
 

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -33,7 +33,7 @@ class TestingRawEffects(
       requests = req :: requests
       val path = getPathWithQueryString(req)
       logger.info(s"HTTP ${req.method} request for: $path")
-      val aaa =
+      val presetResponse =
         if (req.method() == "GET") {
           responses.get(path) // todo should change to have GETs and POSTs in one list using a Sum type, and have a getUnusedRequests or something at the end to assert they were "used" by the code
         } else if (req.method() == "POST") {
@@ -41,7 +41,7 @@ class TestingRawEffects(
           logger.info(s"HTTP POST body is $reqBody")
           postResponses.get(POSTRequest(path, reqBody)).orElse(responses.get(path)) // use get response
         } else responses.get(path)
-      val HTTPResponse(code, response) = aaa.getOrElse(
+      val HTTPResponse(code, response) = presetResponse.getOrElse(
         HTTPResponse(defaultCode, """{"success": true}""")
       )
       logger.info(s"HTTP precanned response is: $code - $response")

--- a/lib/handler/src/main/scala/com/gu/util/ConfigLoader.scala
+++ b/lib/handler/src/main/scala/com/gu/util/ConfigLoader.scala
@@ -4,12 +4,13 @@ import com.gu.util.ETConfig.ETSendIds
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-import scalaz.{ -\/, \/, \/- }
+import scalaz.{-\/, \/, \/-}
 
 case class ETConfig(
   etSendIDs: ETSendIds,
   clientId: String,
-  clientSecret: String)
+  clientSecret: String
+)
 
 object ETConfig {
 
@@ -23,7 +24,8 @@ object ETConfig {
     pf2: ETSendId,
     pf3: ETSendId,
     pf4: ETSendId,
-    cancelled: ETSendId) {
+    cancelled: ETSendId
+  ) {
     def find(attempt: Int): Option[ETSendId] = Some(attempt match {
       case 1 => pf1
       case 2 => pf2
@@ -37,7 +39,8 @@ object ETConfig {
   implicit val zuoraConfigReads: Reads[ETConfig] = (
     (JsPath \ "etSendIDs").read[ETSendIds] and
     (JsPath \ "clientId").read[String] and
-    (JsPath \ "clientSecret").read[String])(ETConfig.apply _)
+    (JsPath \ "clientSecret").read[String]
+  )(ETConfig.apply _)
 }
 
 case class TrustedApiConfig(apiToken: String, tenantId: String)
@@ -45,7 +48,8 @@ case class TrustedApiConfig(apiToken: String, tenantId: String)
 object TrustedApiConfig {
   implicit val apiConfigReads: Reads[TrustedApiConfig] = (
     (JsPath \ "apiToken").read[String] and
-    (JsPath \ "tenantId").read[String])(TrustedApiConfig.apply _)
+    (JsPath \ "tenantId").read[String]
+  )(TrustedApiConfig.apply _)
 }
 
 case class StripeSecretKey(key: String) extends AnyVal
@@ -58,16 +62,19 @@ case class StripeWebhook(ukStripeSecretKey: StripeSecretKey, auStripeSecretKey: 
 object StripeWebhook {
   implicit val stripeWebhookConfigReads: Reads[StripeWebhook] = (
     (JsPath \ "api.key.secret").read[String].map(StripeSecretKey.apply) and
-    (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply))(StripeWebhook.apply _)
+    (JsPath \ "au-membership.key.secret").read[String].map(StripeSecretKey.apply)
+  )(StripeWebhook.apply _)
 }
 
 case class StripeConfig(
   customerSourceUpdatedWebhook: StripeWebhook,
-  signatureChecking: Boolean)
+  signatureChecking: Boolean
+)
 object StripeConfig {
   implicit val stripeConfigReads: Reads[StripeConfig] = (
     (JsPath \ "customerSourceUpdatedWebhook").read[StripeWebhook] and
-    (JsPath \ "signatureChecking").readNullable[String].map(!_.contains("false")))(StripeConfig.apply _)
+    (JsPath \ "signatureChecking").readNullable[String].map(!_.contains("false"))
+  )(StripeConfig.apply _)
 }
 
 case class Config[StepsConfig](
@@ -75,7 +82,8 @@ case class Config[StepsConfig](
   trustedApiConfig: TrustedApiConfig,
   stepsConfig: StepsConfig,
   etConfig: ETConfig,
-  stripeConfig: StripeConfig)
+  stripeConfig: StripeConfig
+)
 
 case class Stage(value: String) extends AnyVal {
   def isProd: Boolean = value == "PROD"
@@ -88,7 +96,8 @@ object Config extends Logging {
     (JsPath \ "trustedApiConfig").read[TrustedApiConfig] and
     (JsPath \ "stepsConfig").read[StepsConfig] and
     (JsPath \ "etConfig").read[ETConfig] and
-    (JsPath \ "stripe").read[StripeConfig])(Config.apply[StepsConfig] _)
+    (JsPath \ "stripe").read[StripeConfig]
+  )(Config.apply[StepsConfig] _)
 
   def parseConfig[StepsConfig: Reads](jsonConfig: String): \/[ConfigFailure, Config[StepsConfig]] = {
     Json.fromJson[Config[StepsConfig]](Json.parse(jsonConfig)) match {

--- a/lib/handler/src/main/scala/com/gu/util/Logging.scala
+++ b/lib/handler/src/main/scala/com/gu/util/Logging.scala
@@ -1,15 +1,13 @@
 package com.gu.util
 
-import com.gu.util.reader.Types.{ WithDepsFailableOp, _ }
+import com.gu.util.reader.Types.{WithDepsFailableOp, _}
 import org.apache.log4j.Logger
-
-import scalaz.{ -\/, \/, \/- }
 
 trait Logging {
 
   val logger = Logger.getLogger(getClass.getName)
 
-  implicit class LogImplicit[A, D](configHttpFailableOp: WithDepsFailableOp[D, A]) {
+  protected implicit class LogImplicit[A, D](configHttpFailableOp: WithDepsFailableOp[D, A]) {
 
     // this is just a handy method to add logging to the end of any for comprehension
     def withLogging(message: String): WithDepsFailableOp[D, A] = {
@@ -22,20 +20,12 @@ trait Logging {
 
   }
 
-  implicit class LogImplicit2[E, A](failableOp: E \/ A) {
+  protected implicit class LogImplicit2[A](op: A) {
 
     // this is just a handy method to add logging to the end of any for comprehension
-    def withLogging(message: String): E \/ A = {
-
-      failableOp match {
-        case \/-(continuation) =>
-          logger.info(s"$message: continued processing with value: $continuation")
-          \/-(continuation)
-        case -\/(response) =>
-          logger.error(s"$message: returned here with value: $response")
-          -\/(response) // todo some day make an error object with a backtrace...
-      }
-
+    def withLogging(message: String): A = {
+      logger.info(s"$message: continued processing with value: $op")
+      op
     }
 
   }

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -38,8 +38,8 @@ object ApiGatewayHandler extends Logging {
     if (credentialsAreValid(requestAuth, trustedApiConfig)) \/-(()) else -\/(unauthorized)
   }
 
-  def default[StepsConfig: Reads]: (Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit], LambdaIO) => Reader[(Stage, Try[String]), Unit] =
-    apply(LoadConfig.default[StepsConfig], _, _)
+  def default[StepsConfig: Reads](operation: Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit], io: LambdaIO): Reader[(Stage, Try[String]), Unit] =
+    apply(LoadConfig.default[StepsConfig], operation, io)
 
   def apply[StepsConfig](
     loadConfig: Reader[(Stage, Try[String]), FailableOp[Config[StepsConfig]]],

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -1,19 +1,19 @@
 package com.gu.util.apigateway
 
-import java.io.{ InputStream, OutputStream }
+import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.util.Auth.credentialsAreValid
 import com.gu.util.Config.ConfigFailure
 import com.gu.util._
-import com.gu.util.apigateway.ApiGatewayResponse.{ outputForAPIGateway, successfulExecution, unauthorized }
+import com.gu.util.apigateway.ApiGatewayResponse.{outputForAPIGateway, successfulExecution, unauthorized}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.reader.Types.{ FailableOp, _ }
-import play.api.libs.json.{ Json, Reads }
+import com.gu.util.reader.Types.{FailableOp, _}
+import play.api.libs.json.{Json, Reads}
 
 import scala.io.Source
 import scala.util.Try
-import scalaz.{ -\/, Reader, \/, \/- }
+import scalaz.{-\/, Reader, \/, \/-}
 
 object ApiGatewayHandler extends Logging {
 
@@ -44,7 +44,8 @@ object ApiGatewayHandler extends Logging {
   def apply[StepsConfig](
     loadConfig: Reader[(Stage, Try[String]), FailableOp[Config[StepsConfig]]],
     operation: Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit],
-    lambdaIO: LambdaIO): Reader[(Stage, Try[String]), Unit] = {
+    lambdaIO: LambdaIO
+  ): Reader[(Stage, Try[String]), Unit] = {
 
     import lambdaIO._
 

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -35,7 +35,8 @@ object URLParams {
   implicit val jf = (
     (JsPath \ "apiToken").readNullable[String] and
     (JsPath \ "onlyCancelDirectDebit").readNullable[String].map(_.contains("true")) and
-    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString)))(URLParams.apply _)
+    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString))
+  )(URLParams.apply _)
 }
 
 object ApiGatewayRequest {

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -1,11 +1,11 @@
 package com.gu.util.apigateway
 
-import java.io.{ OutputStream, OutputStreamWriter }
+import java.io.{OutputStream, OutputStreamWriter}
 
 import com.gu.util.Logging
-import com.gu.util.apigateway.ResponseModels.{ ApiResponse, Headers }
+import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}
 import com.gu.util.apigateway.ResponseWriters._
-import play.api.libs.json.{ Json, Writes }
+import play.api.libs.json.{Json, Writes}
 
 object ResponseModels {
 
@@ -19,14 +19,16 @@ object ResponseWriters {
 
   implicit val headersWrites = new Writes[Headers] {
     def writes(headers: Headers) = Json.obj(
-      "Content-Type" -> headers.contentType)
+      "Content-Type" -> headers.contentType
+    )
   }
 
   implicit val responseWrites = new Writes[ApiResponse] {
     def writes(response: ApiResponse) = Json.obj(
       "statusCode" -> response.statusCode,
       "headers" -> response.headers,
-      "body" -> response.body)
+      "body" -> response.body
+    )
   }
 
 }
@@ -45,6 +47,7 @@ object ApiGatewayResponse extends Logging {
   def noActionRequired(reason: String) = ApiResponse("200", new Headers, s"Processing is not required: $reason")
 
   val unauthorized = ApiResponse("401", new Headers, "Credentials are missing or invalid")
+  def notFound(message: String) = ApiResponse("404", new Headers, s"not found: $message")
   val badRequest = ApiResponse("400", new Headers, "Failure to parse JSON successfully")
   def internalServerError(error: String) = ApiResponse("500", new Headers, s"Failed to process event due to the following error: $error")
 

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -1,11 +1,11 @@
 package com.gu.util.reader
 
-import com.gu.util.apigateway.ApiGatewayResponse.{ badRequest, internalServerError, logger }
+import com.gu.util.apigateway.ApiGatewayResponse.{badRequest, internalServerError, logger}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import play.api.libs.json.{ JsError, JsResult, JsSuccess }
+import play.api.libs.json.{JsError, JsResult, JsSuccess}
 
-import scala.util.{ Failure, Success, Try }
-import scalaz.{ -\/, EitherT, Reader, \/, \/- }
+import scala.util.{Failure, Success, Try}
+import scalaz.{-\/, EitherT, Reader, \/, \/-}
 
 object Types {
 

--- a/lib/handler/src/test/scala/com/gu/util/ApiGatewayHandlerReadsTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/ApiGatewayHandlerReadsTest.scala
@@ -3,7 +3,7 @@ package com.gu.util
 import com.gu.util.apigateway.ApiGatewayRequest
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
-import play.api.libs.json.{ JsResult, JsSuccess, Json }
+import play.api.libs.json.{JsResult, JsSuccess, Json}
 
 class ApiGatewayHandlerReadsTest extends FlatSpec {
 
@@ -14,7 +14,8 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
     val eventHeaders = Map(
       "SomeHeader1" -> "testvalue",
       "Content-Type" -> "application/json",
-      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString")
+      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
+    )
     val validApiGatewayEventJson =
       s"""
         |{
@@ -64,7 +65,9 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
       ApiGatewayRequest(
         queryStringParameters = None,
         body = eventBodySimple,
-        headers = Some(eventHeaders)))
+        headers = Some(eventHeaders)
+      )
+    )
 
     val event: JsResult[ApiGatewayRequest] = Json.parse(validApiGatewayEventJson).validate[ApiGatewayRequest]
 

--- a/lib/handler/src/test/scala/com/gu/util/AuthTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/AuthTest.scala
@@ -1,9 +1,9 @@
 package com.gu.util
 
 import com.gu.util.Auth._
-import com.gu.util.apigateway.{ ApiGatewayRequest, RequestAuth }
+import com.gu.util.apigateway.{ApiGatewayRequest, RequestAuth}
 import org.scalatest.FlatSpec
-import play.api.libs.json.{ JsError, JsSuccess, JsValue, Json }
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 
 class AuthTest extends FlatSpec {
 
@@ -13,15 +13,18 @@ class AuthTest extends FlatSpec {
 
     def constructQueryStrings(apiClientId: String, apiToken: String) = Json.obj(
       "apiClientId" -> apiClientId,
-      "apiToken" -> apiToken)
+      "apiToken" -> apiToken
+    )
     val headers = Json.obj(
-      "Content-Type" -> "text/xml")
+      "Content-Type" -> "text/xml"
+    )
     val sampleJson = Json.obj(
       "resource" -> "test-resource",
       "path" -> "/test-path",
       "httpMethod" -> "POST",
       "headers" -> headers,
-      "queryStringParameters" -> constructQueryStrings(apiClientId, apiToken))
+      "queryStringParameters" -> constructQueryStrings(apiClientId, apiToken)
+    )
     sampleJson
   }
 
@@ -30,7 +33,8 @@ class AuthTest extends FlatSpec {
       "resource" -> "test-resource",
       "path" -> "/test-path",
       "httpMethod" -> "POST",
-      "body" -> "")
+      "body" -> ""
+    )
     sampleJson.validate[ApiGatewayRequest] match {
       case JsError(e) => fail(s"couldn't parse with $e")
       case JsSuccess(req, _) =>

--- a/lib/handler/src/test/scala/com/gu/util/ConfigLoaderTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/ConfigLoaderTest.scala
@@ -1,8 +1,8 @@
 package com.gu.util
 
-import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
-import org.scalatest.{ FlatSpec, Matchers }
-import play.api.libs.json.{ JsSuccess, Json }
+import com.gu.util.ETConfig.{ETSendId, ETSendIds}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsSuccess, Json}
 
 import scalaz.\/-
 
@@ -16,7 +16,9 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
         TrustedApiConfig("b", "c"),
         stepsConfig = "hi",
         etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("111"), ETSendId("222"), ETSendId("333"), ETSendId("444"), ETSendId("ccc")), clientId = "jjj", clientSecret = "kkk"),
-        stripeConfig = StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true))))
+        stripeConfig = StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)
+      )
+    ))
   }
 
   "loader" should "the sig verified status is on by default" in {
@@ -28,7 +30,8 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
                          |  }""".stripMargin
     val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
     actualConfigObject should be(JsSuccess(
-      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)))
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)
+    ))
   }
 
   "loader" should "sig verifying is on if we ask for it to be on" in {
@@ -41,7 +44,8 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
                          |  }""".stripMargin
     val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
     actualConfigObject should be(JsSuccess(
-      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)))
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)
+    ))
   }
 
   "loader" should "sig verifying is still on if we ask for sdjfkhgsdf" in {
@@ -54,7 +58,8 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
                          |  }""".stripMargin
     val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
     actualConfigObject should be(JsSuccess(
-      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)))
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), true)
+    ))
   }
 
   "loader" should "sig verifying is ONLY off if we ask for false" in {
@@ -67,7 +72,8 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
                          |  }""".stripMargin
     val actualConfigObject = Json.fromJson[StripeConfig](Json.parse(configString))
     actualConfigObject should be(JsSuccess(
-      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), false)))
+      StripeConfig(StripeWebhook(StripeSecretKey("abc"), StripeSecretKey("def")), false)
+    ))
   }
 
   val codeConfig: String =

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -2,26 +2,28 @@ package com.gu.util.zuora
 
 import com.gu.util.zuora.internal.Types._
 import com.gu.util.zuora.ZuoraModels._
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.ZuoraRestRequestMaker._
-import okhttp3.{ Request, Response }
+import okhttp3.{Request, Response}
 import java.time.LocalDate
 
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{ JsPath, Json, Reads, Writes }
+import play.api.libs.json.{JsPath, Json, Reads, Writes}
 
 case class ZuoraRestConfig(
   baseUrl: String,
   username: String,
-  password: String)
+  password: String
+)
 
 object ZuoraRestConfig {
 
   implicit val zuoraConfigReads: Reads[ZuoraRestConfig] = (
     (JsPath \ "baseUrl").read[String] and
     (JsPath \ "username").read[String] and
-    (JsPath \ "password").read[String])(ZuoraRestConfig.apply _)
+    (JsPath \ "password").read[String]
+  )(ZuoraRestConfig.apply _)
 
 }
 
@@ -40,23 +42,27 @@ object ZuoraGetAccountSummary {
   implicit val basicAccountInfoReads: Reads[BasicAccountInfo] = (
     (JsPath \ "id").read[String].map(AccountId.apply) and
     (JsPath \ "balance").read[Double] and
-    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId])(BasicAccountInfo.apply _)
+    (JsPath \ "defaultPaymentMethod" \ "id").read[PaymentMethodId]
+  )(BasicAccountInfo.apply _)
 
   implicit val invoiceReads: Reads[Invoice] = (
     (JsPath \ "id").read[String] and
     (JsPath \ "dueDate").read[LocalDate] and
     (JsPath \ "balance").read[Double] and
-    (JsPath \ "status").read[String])(Invoice.apply _)
+    (JsPath \ "status").read[String]
+  )(Invoice.apply _)
 
   implicit val subscriptionSummaryReads: Reads[SubscriptionSummary] = (
     (JsPath \ "id").read[String].map(SubscriptionId.apply) and
     (JsPath \ "subscriptionNumber").read[String] and
-    (JsPath \ "status").read[String])(SubscriptionSummary.apply _)
+    (JsPath \ "status").read[String]
+  )(SubscriptionSummary.apply _)
 
   implicit val accountSummaryReads: Reads[AccountSummary] = (
     (JsPath \ "basicInfo").read[BasicAccountInfo] and
     (JsPath \ "subscriptions").read[List[SubscriptionSummary]] and
-    (JsPath \ "invoices").read[List[Invoice]])(AccountSummary.apply _)
+    (JsPath \ "invoices").read[List[Invoice]]
+  )(AccountSummary.apply _)
 
   def apply(accountId: String): WithDepsClientFailableOp[ZuoraDeps, AccountSummary] =
     get[AccountSummary](s"accounts/$accountId/summary")
@@ -77,7 +83,8 @@ object ZuoraGetInvoiceTransactions {
     (JsPath \ "serviceEndDate").read[LocalDate] and
     (JsPath \ "chargeAmount").read[Double] and
     (JsPath \ "chargeName").read[String] and
-    (JsPath \ "productName").read[String])(InvoiceItem.apply _)
+    (JsPath \ "productName").read[String]
+  )(InvoiceItem.apply _)
 
   implicit val itemisedInvoiceReads: Reads[ItemisedInvoice] = (
     (JsPath \ "id").read[String] and
@@ -85,7 +92,8 @@ object ZuoraGetInvoiceTransactions {
     (JsPath \ "amount").read[Double] and
     (JsPath \ "balance").read[Double] and
     (JsPath \ "status").read[String] and
-    (JsPath \ "invoiceItems").read[List[InvoiceItem]])(ItemisedInvoice.apply _)
+    (JsPath \ "invoiceItems").read[List[InvoiceItem]]
+  )(ItemisedInvoice.apply _)
 
   implicit val invoiceTransactionSummaryReads: Reads[InvoiceTransactionSummary] =
     (JsPath \ "invoices").read[List[ItemisedInvoice]].map {
@@ -105,7 +113,8 @@ object ZuoraCancelSubscription {
     def writes(subscriptionCancellation: SubscriptionCancellation) = Json.obj(
       "cancellationEffectiveDate" -> subscriptionCancellation.cancellationEffectiveDate,
       "cancellationPolicy" -> "SpecificDate",
-      "invoiceCollect" -> false)
+      "invoiceCollect" -> false
+    )
   }
 
   def apply(subscription: SubscriptionId, cancellationDate: LocalDate): WithDepsClientFailableOp[ZuoraDeps, Unit] =
@@ -119,7 +128,8 @@ object ZuoraUpdateCancellationReason {
 
   implicit val subscriptionUpdateWrites = new Writes[SubscriptionUpdate] {
     def writes(subscriptionUpdate: SubscriptionUpdate) = Json.obj(
-      "CancellationReason__c" -> subscriptionUpdate.cancellationReason)
+      "CancellationReason__c" -> subscriptionUpdate.cancellationReason
+    )
   }
 
   def apply(subscription: SubscriptionId): WithDepsClientFailableOp[ZuoraDeps, Unit] =
@@ -133,7 +143,8 @@ object ZuoraDisableAutoPay {
 
   implicit val accountUpdateWrites = new Writes[AccountUpdate] {
     def writes(accountUpdate: AccountUpdate) = Json.obj(
-      "autoPay" -> accountUpdate.autoPay)
+      "autoPay" -> accountUpdate.autoPay
+    )
   }
 
   def apply(accountId: String): WithDepsClientFailableOp[ZuoraDeps, Unit] =

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -30,7 +30,7 @@ object ZuoraQuery {
   implicit val wQueryMoreReq: Writes[QueryMoreReq] = Json.writes[QueryMoreReq]
 
   // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
-  def query[QUERYRECORD: Reads](query: Query): WithDepsClientFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
+  def getResults[QUERYRECORD: Reads](query: Query): WithDepsClientFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
     post(query, s"action/query")
 
 }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -22,7 +22,8 @@ object ZuoraQuery {
     (JsPath \ "records").read[List[QUERYRECORD]] and
     (JsPath \ "size").read[Int] and
     (JsPath \ "done").read[Boolean] and
-    (JsPath \ "queryLocator").readNullable[QueryLocator]).apply(QueryResult.apply[QUERYRECORD] _)
+    (JsPath \ "queryLocator").readNullable[QueryLocator]
+  ).apply(QueryResult.apply[QUERYRECORD] _)
 
   case class QueryMoreReq(queryLocator: QueryLocator)
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/internal/Logging.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/internal/Logging.scala
@@ -2,14 +2,14 @@ package com.gu.util.zuora.internal
 
 import Types._
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 import org.apache.log4j.Logger
 
 trait Logging { // in future maybe put logging into a context so the messages stack together like a stack trace
 
   val logger = Logger.getLogger(getClass.getName)
 
-  implicit class LogImplicit[A, D](configHttpFailableOp: WithDepsClientFailableOp[D, A]) {
+  protected implicit class LogImplicit[A, D](configHttpFailableOp: WithDepsClientFailableOp[D, A]) {
 
     // this is just a handy method to add logging to the end of any for comprehension
     def withLogging(message: String): WithDepsClientFailableOp[D, A] = {
@@ -22,7 +22,7 @@ trait Logging { // in future maybe put logging into a context so the messages st
 
   }
 
-  implicit class LogImplicit2[A](failableOp: ClientFailableOp[A]) {
+  protected implicit class LogImplicit2[A](failableOp: ClientFailableOp[A]) {
 
     // this is just a handy method to add logging to the end of any for comprehension
     def withLogging(message: String): ClientFailableOp[A] = {

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/internal/Types.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/internal/Types.scala
@@ -1,6 +1,6 @@
 package com.gu.util.zuora.internal
 
-import scalaz.{ EitherT, Reader, \/ }
+import scalaz.{EitherT, Reader, \/}
 
 object Types {
 
@@ -22,14 +22,4 @@ object Types {
 
 }
 
-case class ClientFail(statusCode: String, message: String)
-object ClientFail extends Logging {
-
-  //  val successfulExecution = ApiResponse("200", new Headers, "Success")
-  //  def noActionRequired(reason: String) = ApiResponse("200", new Headers, s"Processing is not required: $reason")
-  //
-  //  val unauthorized = ApiResponse("401", new Headers, "Credentials are missing or invalid")
-  //  val badRequest = ApiResponse("400", new Headers, "Failure to parse JSON successfully")
-  def internalServerError(error: String) = ClientFail("500", error)
-
-}
+case class ClientFail(message: String)

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -1,16 +1,16 @@
 package com.gu.util
 
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraGetAccountSummary.BasicAccountInfo
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.internal.ClientFail
-import com.gu.util.zuora.{ ZuoraRestConfig, ZuoraRestRequestMaker }
+import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3._
 import org.scalatest.Matchers._
 import org.scalatest._
-import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json.{JsValue, Json}
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 
 class ZuoraRestServiceTest extends AsyncFlatSpec {
 
@@ -35,24 +35,28 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
   val dummyJson = Json.parse(
     """{
       |  "body": "test"
-      |}""".stripMargin)
+      |}""".stripMargin
+  )
 
   val validUpdateSubscriptionResult = Json.parse(
     """{
       |  "success": true,
       |  "id": "id123", "balance": 1.2, "defaultPaymentMethod": {"id": "pmid"}
-      |}""".stripMargin)
+      |}""".stripMargin
+  )
 
   val validFailedUpdateSubscriptionResult = Json.parse(
     """{
       |  "success": false,
       |  "subscriptionId": "id123"
-      |}""".stripMargin)
+      |}""".stripMargin
+  )
 
   val validZuoraNoOtherFields = Json.parse(
     """{
       |  "success": true
-      |}""".stripMargin)
+      |}""".stripMargin
+  )
 
   def constructTestRequest(json: JsValue = dummyJson): Request = {
     val body = RequestBody.create(MediaType.parse("application/json"), json.toString)
@@ -74,7 +78,7 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
     response
   }
 
-  def internalServerError(message: String) = ClientFail("500", message)
+  def internalServerError(message: String) = ClientFail(message)
 
   "convertResponseToCaseClass" should "return a left[String] for an unsuccessful response code" in {
     val response = constructTestResponse(500)

--- a/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -1,10 +1,11 @@
 package com.gu.autoCancel
 
-import com.gu.util.{ Logging, ZuoraToApiGateway }
+import com.gu.util.{Logging, ZuoraToApiGateway}
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraModels.SubscriptionId
-import com.gu.util.zuora._
 import java.time.LocalDate
+
+import com.gu.util.zuora.{ZuoraCancelSubscription, ZuoraDeps, ZuoraDisableAutoPay, ZuoraUpdateCancellationReason}
 
 object AutoCancel extends Logging {
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -13,7 +13,8 @@ case class AutoCancelCallout(
   creditCardExpirationMonth: String,
   creditCardExpirationYear: String,
   invoiceId: String,
-  currency: String) {
+  currency: String
+) {
   def isAutoPay = autoPay == "true"
   def nonDirectDebit = paymentMethodType != "BankTransfer"
 }

--- a/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelDataCollectionFilter.scala
@@ -1,12 +1,12 @@
 package com.gu.autoCancel
 
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
-import com.gu.util.{ Logging, ZuoraToApiGateway }
+import com.gu.util.{Logging, ZuoraToApiGateway}
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, Invoice }
+import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, Invoice}
 import com.gu.util.zuora.ZuoraModels.SubscriptionId
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraGetAccountSummary }
+import com.gu.util.zuora.{ZuoraDeps, ZuoraGetAccountSummary}
 import java.time.LocalDate
 
 import com.gu.util.zuora.internal.Types.WithDepsClientFailableOp
@@ -18,14 +18,16 @@ object AutoCancelDataCollectionFilter extends Logging {
   case class ACFilterDeps(
     now: LocalDate,
     getAccountSummary: String => WithDepsClientFailableOp[ZuoraDeps, AccountSummary],
-    zuoraDeps: ZuoraDeps)
+    zuoraDeps: ZuoraDeps
+  )
 
   object ACFilterDeps {
     def default(now: LocalDate, zuoraDeps: ZuoraDeps): ACFilterDeps = {
       ACFilterDeps(
         now,
         ZuoraGetAccountSummary.apply,
-        zuoraDeps)
+        zuoraDeps
+      )
     }
   }
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -16,7 +16,7 @@ object AutoCancelHandler extends App with Logging {
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
     def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
       AutoCancelSteps(AutoCancelStepsDeps.default(rawEffects.now(), rawEffects.response, config))
-    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+    ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 
   // this is the entry point

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -1,15 +1,15 @@
 package com.gu.autoCancel
 
-import java.io.{ InputStream, OutputStream }
+import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.autoCancel.AutoCancelSteps.AutoCancelStepsDeps
 import com.gu.effects.RawEffects
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest}
 import com.gu.util.reader.Types.FailableOp
-import com.gu.util.{ Config, Logging }
+import com.gu.util.{Config, Logging}
 
 object AutoCancelHandler extends App with Logging {
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelInputFilter.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelInputFilter.scala
@@ -4,7 +4,7 @@ import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
 import com.gu.util.reader.Types.FailableOp
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 
 object AutoCancelInputFilter extends Logging {
   def apply(callout: AutoCancelCallout, onlyCancelDirectDebit: Boolean): FailableOp[Unit] = {

--- a/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -5,15 +5,15 @@ import java.time.LocalDate
 import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.paymentFailure.ZuoraEmailSteps.ZuoraEmailStepsDeps
-import com.gu.paymentFailure.{ ToMessage, ZuoraEmailSteps }
+import com.gu.paymentFailure.{ToMessage, ZuoraEmailSteps}
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.exacttarget.EmailRequest
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraDeps
-import com.gu.util.{ Config, Logging }
-import okhttp3.{ Request, Response }
+import com.gu.util.{Config, Logging}
+import okhttp3.{Request, Response}
 import play.api.libs.json.Json
 
 import scalaz.\/-
@@ -27,7 +27,8 @@ object AutoCancelSteps extends Logging {
         AutoCancel.apply(zuoraDeps),
         AutoCancelDataCollectionFilter.apply(AutoCancelDataCollectionFilter.ACFilterDeps.default(now, zuoraDeps)),
         config.etConfig.etSendIDs,
-        ZuoraEmailSteps.sendEmailRegardingAccount(ZuoraEmailStepsDeps.default(response, config)))
+        ZuoraEmailSteps.sendEmailRegardingAccount(ZuoraEmailStepsDeps.default(response, config))
+      )
     }
   }
 
@@ -35,7 +36,8 @@ object AutoCancelSteps extends Logging {
     autoCancel: AutoCancelRequest => FailableOp[Unit],
     autoCancelFilter2: AutoCancelCallout => FailableOp[AutoCancelRequest],
     etSendIds: ETSendIds,
-    sendEmailRegardingAccount: (String, PaymentFailureInformation => EmailRequest) => FailableOp[Unit])
+    sendEmailRegardingAccount: (String, PaymentFailureInformation => EmailRequest) => FailableOp[Unit]
+  )
 
   def apply(deps: AutoCancelStepsDeps)(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
     for {

--- a/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -3,7 +3,7 @@ package com.gu.paymentFailure
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
+import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice}
 import java.time.LocalDate
 
 import scalaz.\/

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -1,6 +1,6 @@
 package com.gu.paymentFailure
 
-import java.io.{ InputStream, OutputStream }
+import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
@@ -8,7 +8,7 @@ import com.gu.paymentFailure.PaymentFailureSteps.PFDeps
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.Config
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest}
 import com.gu.util.reader.Types.FailableOp
 
 object Lambda {

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -16,7 +16,7 @@ object Lambda {
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
     def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
       PaymentFailureSteps(PFDeps.default(rawEffects.response, config))
-    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+    ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 
   // this is the entry point

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
@@ -11,7 +11,8 @@ case class BillingDetails(
   postCode: Option[String],
   city: Option[String],
   state: Option[String],
-  country: Option[String])
+  country: Option[String]
+)
 
 object BillingDetails {
 
@@ -22,7 +23,8 @@ object BillingDetails {
       (JsPath \ "billToContactPostalCode").readNullable[String] and
       (JsPath \ "billToContactCity").readNullable[String] and
       (JsPath \ "billToContactState").readNullable[String] and
-      (JsPath \ "billToContactCountry").readNullable[String]).apply(BillingDetails.apply _)
+      (JsPath \ "billToContactCountry").readNullable[String]
+    ).apply(BillingDetails.apply _)
   }
 }
 case class PaymentFailureCallout(
@@ -39,7 +41,8 @@ case class PaymentFailureCallout(
   currency: String,
   tenantId: String,
   title: Option[String],
-  billingDetails: BillingDetails)
+  billingDetails: BillingDetails
+)
 
 object PaymentFailureCallout {
 
@@ -58,6 +61,7 @@ object PaymentFailureCallout {
       (JsPath \ "currency").read[String] and
       (JsPath \ "tenantId").read[String] and
       (JsPath \ "title").readNullable[String] and
-      (JsPath).read[BillingDetails]).apply(PaymentFailureCallout.apply _)
+      (JsPath).read[BillingDetails]
+    ).apply(PaymentFailureCallout.apply _)
   }
 }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -7,18 +7,18 @@ import com.gu.util.Auth.validTenant
 import com.gu.util.ETConfig.ETSendIds
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
-import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
-import com.gu.util.exacttarget.{ EmailRequest, EmailSendSteps }
+import com.gu.util.exacttarget.{EmailRequest, EmailSendSteps}
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
 import com.gu.util.zuora.internal.Types.ClientFailableOp
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraGetInvoiceTransactions }
-import okhttp3.{ Request, Response }
+import com.gu.util.zuora.{ZuoraDeps, ZuoraGetInvoiceTransactions}
+import okhttp3.{Request, Response}
 import play.api.libs.json.Json
 
 import scalaz.syntax.std.option._
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 
 object PaymentFailureSteps extends Logging {
 
@@ -50,14 +50,16 @@ object PaymentFailureSteps extends Logging {
       PFDeps(
         ZuoraEmailSteps.sendEmailRegardingAccount(ZuoraEmailStepsDeps.default(response, config)),
         config.etConfig.etSendIDs,
-        config.trustedApiConfig)
+        config.trustedApiConfig
+      )
     }
   }
 
   case class PFDeps(
     sendEmailRegardingAccount: (String, PaymentFailureInformation => EmailRequest) => FailableOp[Unit],
     etSendIDs: ETSendIds,
-    trustedApiConfig: TrustedApiConfig)
+    trustedApiConfig: TrustedApiConfig
+  )
 
 }
 
@@ -76,12 +78,14 @@ object ZuoraEmailSteps {
     def default(response: Request => Response, config: Config[StepsConfig]): ZuoraEmailStepsDeps = {
       ZuoraEmailStepsDeps(
         EmailSendSteps.apply(EmailSendStepsDeps.default(config.stage, response, config.etConfig)),
-        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.stepsConfig.zuoraRestConfig)))
+        a => ZuoraGetInvoiceTransactions(a).run.run(ZuoraDeps(response, config.stepsConfig.zuoraRestConfig))
+      )
     }
   }
 
   case class ZuoraEmailStepsDeps(
     sendEmail: EmailRequest => FailableOp[Unit],
-    getInvoiceTransactions: String => ClientFailableOp[InvoiceTransactionSummary])
+    getInvoiceTransactions: String => ClientFailableOp[InvoiceTransactionSummary]
+  )
 
 }

--- a/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -35,7 +35,11 @@ object ToMessage {
           billing_city = paymentFailureCallout.billingDetails.city,
           billing_state = paymentFailureCallout.billingDetails.state,
           billing_country = paymentFailureCallout.billingDetails.country,
-          title = paymentFailureCallout.title))))
+          title = paymentFailureCallout.title
+        )
+      )
+    )
+  )
 
   def apply(callout: AutoCancelCallout, paymentFailureInformation: PaymentFailureInformation) = Message(
     To = ToDef(
@@ -53,7 +57,11 @@ object ToMessage {
           primaryKey = InvoiceId(callout.invoiceId),
           price = price(paymentFailureInformation.amount, callout.currency),
           serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
-          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)))))
+          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)
+        )
+      )
+    )
+  )
 
   val currencySymbol = Map("GBP" -> "£", "AUD" -> "$", "EUR" -> "€", "USD" -> "$", "CAD" -> "$", "NZD" -> "$")
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -15,7 +15,7 @@ object Lambda {
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
     def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
       SourceUpdatedSteps(Deps.default(rawEffects.response, config))
-    ApiGatewayHandler.default[StepsConfig](implicitly)(operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
+    ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }
 
   // this is the entry point

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -1,13 +1,13 @@
 package com.gu.stripeCustomerSourceUpdated
 
-import java.io.{ InputStream, OutputStream }
+import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
-import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.{ Deps, StepsConfig }
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.{Deps, StepsConfig}
 import com.gu.util.Config
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest }
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest}
 import com.gu.util.reader.Types.FailableOp
 
 object Lambda {

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedCallout.scala
@@ -10,7 +10,8 @@ case class EventDataObject(
   country: StripeCountry,
   customer: StripeCustomerId,
   expiry: StripeExpiry,
-  last4: StripeLast4)
+  last4: StripeLast4
+)
 case class SourceUpdatedCallout(id: StripeEventId, data: EventData)
 
 case class StripeEventId(value: String) extends AnyVal
@@ -78,13 +79,16 @@ object SourceUpdatedCallout {
     (JsPath \ "customer").read[String].map(StripeCustomerId.apply) and
     (
       (JsPath \ "exp_month").read[Int] and
-      (JsPath \ "exp_year").read[Int])(StripeExpiry.apply _) and
-      (JsPath \ "last4").read[String].map(StripeLast4.apply))(EventDataObject.apply _)
+      (JsPath \ "exp_year").read[Int]
+    )(StripeExpiry.apply _) and
+      (JsPath \ "last4").read[String].map(StripeLast4.apply)
+  )(EventDataObject.apply _)
 
   implicit val eventDataReads: Reads[EventData] = (JsPath \ "object").read[EventDataObject].map(EventData.apply _)
 
   implicit val jf: Reads[SourceUpdatedCallout] = (
     (JsPath \ "id").read[String].map(StripeEventId.apply) and
-    (JsPath \ "data").read[EventData])(SourceUpdatedCallout.apply _)
+    (JsPath \ "data").read[EventData]
+  )(SourceUpdatedCallout.apply _)
 
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -1,19 +1,19 @@
 package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.stripeCustomerSourceUpdated.StripeRequestSignatureChecker.verifyRequest
-import com.gu.stripeCustomerSourceUpdated.zuora.{ CreatePaymentMethod, SetDefaultPaymentMethod, ZuoraQueryPaymentMethod }
+import com.gu.stripeCustomerSourceUpdated.zuora.{CreatePaymentMethod, SetDefaultPaymentMethod, ZuoraQueryPaymentMethod}
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse, StripeAccount }
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse, StripeAccount}
 import com.gu.util.reader.Types._
-import com.gu.stripeCustomerSourceUpdated.zuora.CreatePaymentMethod.{ CreateStripePaymentMethod, CreditCardType }
+import com.gu.stripeCustomerSourceUpdated.zuora.CreatePaymentMethod.{CreateStripePaymentMethod, CreditCardType}
 import com.gu.util.zuora.ZuoraGetAccountSummary.AccountSummary
-import com.gu.stripeCustomerSourceUpdated.zuora.ZuoraQueryPaymentMethod.{ AccountPaymentMethodIds, PaymentMethodFields }
+import com.gu.stripeCustomerSourceUpdated.zuora.ZuoraQueryPaymentMethod.{AccountPaymentMethodIds, PaymentMethodFields}
 import com.gu.util.zuora.ZuoraAccount.PaymentMethodId
 import com.gu.util.zuora._
-import okhttp3.{ Request, Response }
-import play.api.libs.json.{ Json, Reads }
+import okhttp3.{Request, Response}
+import play.api.libs.json.{Json, Reads}
 
 import scalaz._
 import scalaz.syntax.applicative._
@@ -88,7 +88,8 @@ object SourceUpdatedSteps extends Logging {
         eventDataObject.last4,
         eventDataObject.expiry,
         creditCardType,
-        paymentMethodFields.NumConsecutiveFailures))
+        paymentMethodFields.NumConsecutiveFailures
+      ))
     } yield result
   }
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
@@ -2,11 +2,11 @@ package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.logger
 import com.gu.util.apigateway.StripeAccount
-import com.gu.util.{ StripeConfig, StripeSecretKey }
+import com.gu.util.{StripeConfig, StripeSecretKey}
 import com.stripe.exception.SignatureVerificationException
 import com.stripe.net.Webhook.Signature
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 case class StripeDeps(config: StripeConfig, signatureChecker: SignatureChecker)
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/CreatePaymentMethod.scala
@@ -3,10 +3,10 @@ package com.gu.stripeCustomerSourceUpdated.zuora
 import com.gu.stripeCustomerSourceUpdated._
 import com.gu.util.ZuoraToApiGateway
 import com.gu.util.reader.Types.WithDepsFailableOp
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, NumConsecutiveFailures, PaymentMethodId }
+import com.gu.util.zuora.ZuoraAccount.{AccountId, NumConsecutiveFailures, PaymentMethodId}
 import com.gu.util.zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraRestRequestMaker.post
-import play.api.libs.json.{ JsPath, Json, Reads, Writes }
+import play.api.libs.json.{JsPath, Json, Reads, Writes}
 
 object CreatePaymentMethod {
 
@@ -18,7 +18,8 @@ object CreatePaymentMethod {
     last4: StripeLast4,
     expiration: StripeExpiry,
     creditCardType: CreditCardType,
-    numConsecutiveFailures: NumConsecutiveFailures)
+    numConsecutiveFailures: NumConsecutiveFailures
+  )
 
   sealed abstract class CreditCardType(val value: String)
   object CreditCardType {
@@ -41,7 +42,8 @@ object CreatePaymentMethod {
       "CreditCardExpirationYear" -> command.expiration.exp_year,
       "CreditCardType" -> command.creditCardType.value,
       "Type" -> "CreditCardReferenceTransaction",
-      "NumConsecutiveFailures" -> command.numConsecutiveFailures)
+      "NumConsecutiveFailures" -> command.numConsecutiveFailures
+    )
   }
 
   implicit val reads: Reads[CreatePaymentMethodResult] =

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/SetDefaultPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/SetDefaultPaymentMethod.scala
@@ -2,11 +2,11 @@ package com.gu.stripeCustomerSourceUpdated.zuora
 
 import com.gu.util.ZuoraToApiGateway
 import com.gu.util.reader.Types.WithDepsFailableOp
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraDeps
 import com.gu.util.zuora.ZuoraReaders.unitReads
 import com.gu.util.zuora.ZuoraRestRequestMaker.put
-import play.api.libs.json.{ Json, Writes }
+import play.api.libs.json.{Json, Writes}
 
 object SetDefaultPaymentMethod {
 
@@ -14,7 +14,8 @@ object SetDefaultPaymentMethod {
 
   implicit val writes = new Writes[SetDefaultPaymentMethod] {
     def writes(subscriptionUpdate: SetDefaultPaymentMethod) = Json.obj(
-      "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId)
+      "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId
+    )
   }
 
   def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId): WithDepsFailableOp[ZuoraDeps, Unit] =

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
@@ -1,13 +1,13 @@
 package com.gu.stripeCustomerSourceUpdated.zuora
 
-import com.gu.stripeCustomerSourceUpdated.{ StripeCustomerId, StripeSourceId }
-import com.gu.util.{ Logging, ZuoraToApiGateway }
+import com.gu.stripeCustomerSourceUpdated.{StripeCustomerId, StripeSourceId}
+import com.gu.util.{Logging, ZuoraToApiGateway}
 import com.gu.util.apigateway.ApiGatewayResponse
 import play.api.libs.json._
 
-import scalaz.{ -\/, NonEmptyList, \/- }
+import scalaz.{-\/, NonEmptyList, \/-}
 import com.gu.util.zuora.ZuoraAccount._
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraQuery }
+import com.gu.util.zuora.{ZuoraDeps, ZuoraQuery}
 import com.gu.util.zuora.ZuoraQuery.Query
 import com.gu.util.reader.Types._
 
@@ -16,7 +16,8 @@ object ZuoraQueryPaymentMethod extends Logging {
   case class PaymentMethodFields(
     Id: PaymentMethodId,
     AccountId: AccountId,
-    NumConsecutiveFailures: NumConsecutiveFailures)
+    NumConsecutiveFailures: NumConsecutiveFailures
+  )
   implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
 
   case class AccountPaymentMethodIds(accountId: AccountId, paymentMethods: NonEmptyList[PaymentMethodFields])

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
@@ -28,7 +28,7 @@ object ZuoraQueryPaymentMethod extends Logging {
          | FROM PaymentMethod
          |  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = '${sourceId.value}' AND SecondTokenId = '${customerId.value}'""".stripMargin
 
-    ZuoraQuery.query[PaymentMethodFields](Query(query)).leftMap(ZuoraToApiGateway.fromClientFail).run.map(_.flatMap { result =>
+    ZuoraQuery.getResults[PaymentMethodFields](Query(query)).leftMap(ZuoraToApiGateway.fromClientFail).run.map(_.flatMap { result =>
 
       def groupedList(records: List[PaymentMethodFields]): List[(AccountId, NonEmptyList[PaymentMethodFields])] = {
         records.groupBy(_.AccountId).toList.collect {

--- a/src/main/scala/com/gu/util/ZuoraToApiGateway.scala
+++ b/src/main/scala/com/gu/util/ZuoraToApiGateway.scala
@@ -1,11 +1,12 @@
 package com.gu.util
 
-import com.gu.util.apigateway.ResponseModels.{ ApiResponse, Headers }
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.zuora.internal.ClientFail
 
 object ZuoraToApiGateway {
 
   def fromClientFail(clientFail: ClientFail): ApiResponse =
-    ApiResponse(clientFail.statusCode, new Headers, s"zuora client fail: ${clientFail.message}")
+    ApiGatewayResponse.internalServerError(s"zuora client fail: ${clientFail.message}")
 
 }

--- a/src/main/scala/com/gu/util/exacttarget/EmailSendSteps.scala
+++ b/src/main/scala/com/gu/util/exacttarget/EmailSendSteps.scala
@@ -4,13 +4,13 @@ import com.gu.util.ETConfig.ETSendId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.exacttarget.ETClient.ETClientDeps
 import com.gu.util.exacttarget.EmailSendSteps.logger
-import com.gu.util.exacttarget.SalesforceAuthenticate.{ ETImpure, SalesforceAuth }
+import com.gu.util.exacttarget.SalesforceAuthenticate.{ETImpure, SalesforceAuth}
 import com.gu.util.reader.Types._
-import com.gu.util.{ ETConfig, Logging, Stage }
-import okhttp3.{ MediaType, Request, RequestBody, Response }
-import play.api.libs.json.{ Json, Writes, _ }
+import com.gu.util.{ETConfig, Logging, Stage}
+import okhttp3.{MediaType, Request, RequestBody, Response}
+import play.api.libs.json.{Json, Writes, _}
 
-import scalaz.{ -\/, \/, \/- }
+import scalaz.{-\/, \/, \/-}
 
 case class ContactAttributesDef(SubscriberAttributes: SubscriberAttributesDef)
 
@@ -32,7 +32,8 @@ case class SubscriberAttributesDef(
   billing_city: Option[String] = None,
   billing_state: Option[String] = None,
   billing_country: Option[String] = None,
-  title: Option[String] = None)
+  title: Option[String] = None
+)
 
 sealed trait PrimaryKey {
   // ET will filter out multiple emails with the same payment id for PF1,2,3,4
@@ -67,7 +68,8 @@ object SubscriberAttributesDef {
         },
         "price" -> JsString(o.price),
         "serviceStartDate" -> JsString(o.serviceStartDate),
-        "serviceEndDate" -> JsString(o.serviceEndDate))
+        "serviceEndDate" -> JsString(o.serviceEndDate)
+      )
 
       val optionalFields = Map(
         "billing_address1" -> o.billing_address1.map(JsString),
@@ -76,7 +78,8 @@ object SubscriberAttributesDef {
         "billing_city" -> o.billing_city.map(JsString),
         "billing_state" -> o.billing_state.map(JsString),
         "billing_country" -> o.billing_country.map(JsString),
-        "title" -> o.title.map(JsString)).collect { case (key, Some(value)) => key -> value }
+        "title" -> o.title.map(JsString)
+      ).collect { case (key, Some(value)) => key -> value }
 
       val allFields = fields ++ optionalFields
       JsObject(allFields)
@@ -100,7 +103,8 @@ object EmailSendSteps extends Logging {
 
   case class EmailSendStepsDeps(
     sendEmail: EmailRequest => FailableOp[Unit],
-    filterEmail: EmailRequest => FailableOp[Unit])
+    filterEmail: EmailRequest => FailableOp[Unit]
+  )
 
   object EmailSendStepsDeps {
     def default(stage: Stage, response: Request => Response, etConfig: ETConfig): EmailSendStepsDeps = {
@@ -121,7 +125,8 @@ object ETClient {
 
   case class ETClientDeps(
     response: (Request => Response),
-    etConfig: ETConfig)
+    etConfig: ETConfig
+  )
 
   def sendEmail(eTClientDeps: ETClientDeps)(emailRequest: EmailRequest): FailableOp[Unit] = {
     for {

--- a/src/main/scala/com/gu/util/exacttarget/SalesforceAuthenticate.scala
+++ b/src/main/scala/com/gu/util/exacttarget/SalesforceAuthenticate.scala
@@ -2,12 +2,12 @@ package com.gu.util.exacttarget
 
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.FailableOp
-import com.gu.util.{ ETConfig, Logging }
-import okhttp3.{ FormBody, Request, Response }
+import com.gu.util.{ETConfig, Logging}
+import okhttp3.{FormBody, Request, Response}
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{ JsPath, JsSuccess, Json, Reads }
+import play.api.libs.json.{JsPath, JsSuccess, Json, Reads}
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 
 object SalesforceAuthenticate extends Logging {
 
@@ -20,7 +20,8 @@ object SalesforceAuthenticate extends Logging {
 
     implicit val salesforceAuthReads: Reads[SalesforceAuth] = (
       (JsPath \ "accessToken").read[String] and
-      (JsPath \ "expiresIn").read[Int])(SalesforceAuth.apply _)
+      (JsPath \ "expiresIn").read[Int]
+    )(SalesforceAuth.apply _)
 
   }
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -4,17 +4,17 @@ import java.time.LocalDate
 
 import com.gu.effects.TestingRawEffects
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
-import com.gu.stripeCustomerSourceUpdated.{ StripeDeps, StripeSignatureChecker }
-import com.gu.util.ETConfig.{ ETSendId, ETSendIds }
+import com.gu.stripeCustomerSourceUpdated.{StripeDeps, StripeSignatureChecker}
+import com.gu.util.ETConfig.{ETSendId, ETSendIds}
 import com.gu.util._
-import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{ InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice }
-import com.gu.util.zuora.internal.Types.{ ClientFailableOp, WithDepsClientFailableOp, _ }
-import com.gu.util.zuora.{ ZuoraDeps, ZuoraRestConfig }
+import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice}
+import com.gu.util.zuora.internal.Types.{ClientFailableOp, WithDepsClientFailableOp, _}
+import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
 import org.scalatest.Matchers
 import play.api.libs.json.Json
 
 import scala.util.Success
-import scalaz.{ Reader, \/ }
+import scalaz.{Reader, \/}
 
 object TestData extends Matchers {
 
@@ -40,7 +40,8 @@ object TestData extends Matchers {
     trustedApiConfig = fakeApiConfig,
     stepsConfig = StepsConfig(zuoraRestConfig = ZuoraRestConfig("https://ddd", "e@f.com", "ggg")),
     etConfig = ETConfig(etSendIDs = ETSendIds(ETSendId("11"), ETSendId("22"), ETSendId("33"), ETSendId("44"), ETSendId("can")), clientId = "jjj", clientSecret = "kkk"),
-    stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")), true))
+    stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")), true)
+  )
 
   val missingCredentialsResponse = """{"statusCode":"401","headers":{"Content-Type":"application/json"},"body":"Credentials are missing or invalid"}"""
   val successfulResponse = """{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}"""

--- a/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelDataCollectionFilterTest.scala
@@ -1,14 +1,14 @@
 package com.gu.autoCancel
 
 import com.gu.util.apigateway.ApiGatewayResponse._
-import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary }
+import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary}
 import com.gu.util.zuora.ZuoraModels._
 import java.time.LocalDate
 
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
 import org.scalatest._
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 
 class AutoCancelDataCollectionFilterTest extends FlatSpec {
 

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -2,11 +2,11 @@ package com.gu.autoCancel
 
 import com.gu.util.TrustedApiConfig
 import com.gu.util.apigateway.ApiGatewayResponse._
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest, RequestAuth, StripeAccount }
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, RequestAuth, StripeAccount}
 import org.scalatest._
-import play.api.libs.json.{ JsSuccess, Json }
+import play.api.libs.json.{JsSuccess, Json}
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 object AutoCancelHandlerTest {
 
   def fakeCallout(autoPay: Boolean) = {

--- a/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelStepsTest.scala
@@ -7,11 +7,11 @@ import com.gu.autoCancel.AutoCancel.AutoCancelRequest
 import com.gu.autoCancel.AutoCancelDataCollectionFilter.ACFilterDeps
 import com.gu.effects.TestingRawEffects
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, PaymentMethodId }
+import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraDeps
-import com.gu.util.zuora.ZuoraGetAccountSummary.{ AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary }
+import com.gu.util.zuora.ZuoraGetAccountSummary.{AccountSummary, BasicAccountInfo, Invoice, SubscriptionSummary}
 import com.gu.util.zuora.ZuoraModels._
-import com.gu.{ TestData, WithDependenciesFailableOp }
+import com.gu.{TestData, WithDependenciesFailableOp}
 import org.scalatest._
 
 import scalaz.\/-
@@ -29,7 +29,9 @@ class AutoCancelStepsTest extends FlatSpec with Matchers {
       getAccountSummary = _ => WithDependenciesFailableOp.liftT(AccountSummary(basicInfo, List(subscription), List(singleOverdueInvoice))),
       ZuoraDeps(
         a.response,
-        TestData.fakeZuoraConfig))
+        TestData.fakeZuoraConfig
+      )
+    )
     val autoCancelCallout = AutoCancelHandlerTest.fakeCallout(true)
     val cancel: FailableOp[AutoCancelRequest] = AutoCancelDataCollectionFilter(aCDeps)(autoCancelCallout)
 

--- a/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -1,11 +1,12 @@
 package com.gu.paymentFailure
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.gu.TestData._
 import com.gu.effects.TestingRawEffects
+import com.gu.effects.TestingRawEffects.HTTPResponse
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 
 class EndToEndHandlerTest extends FlatSpec with Matchers {
 
@@ -41,10 +42,11 @@ trait EndtoEndBaseData {
   def zuoraCalloutJson: String
   def expectedEmailSend: String
 
-  def responses: Map[String, (Int, String)] = Map(
-    ("/transactions/invoices/accounts/2c92c0f85fc90734015fca884c3f04cf", (200, invoices)),
-    ("/v1/requestToken", (200, """{"accessToken":"", "expiresIn":1}""")),
-    ("/messaging/v1/messageDefinitionSends/111/send", (202, "")))
+  def responses: Map[String, HTTPResponse] = Map(
+    ("/transactions/invoices/accounts/2c92c0f85fc90734015fca884c3f04cf", HTTPResponse(200, invoices)),
+    ("/v1/requestToken", HTTPResponse(200, """{"accessToken":"", "expiresIn":1}""")),
+    ("/messaging/v1/messageDefinitionSends/111/send", HTTPResponse(202, ""))
+  )
 
   val invoices =
     """

--- a/src/test/scala/com/gu/paymentFailure/GetPaymentDataTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/GetPaymentDataTest.scala
@@ -1,6 +1,6 @@
 package com.gu.paymentFailure
 
-import com.gu.TestData.{ accountId, weirdInvoiceTransactionSummary }
+import com.gu.TestData.{accountId, weirdInvoiceTransactionSummary}
 import org.scalatest.FlatSpec
 
 import scalaz.\/

--- a/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/MessageWritesTest.scala
@@ -24,7 +24,11 @@ class MessageWritesTest extends FlatSpec {
             primaryKey = PaymentId("paymentId"),
             price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
-            serviceEndDate = "31 January 2017"))))
+            serviceEndDate = "31 January 2017"
+          )
+        )
+      )
+    )
 
     val expectedJson =
       """
@@ -71,7 +75,11 @@ class MessageWritesTest extends FlatSpec {
             primaryKey = InvoiceId("paymentId"),
             price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
-            serviceEndDate = "31 January 2017"))))
+            serviceEndDate = "31 January 2017"
+          )
+        )
+      )
+    )
 
     val expectedJson =
       """

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -9,16 +9,16 @@ import com.gu.paymentFailure.ZuoraEmailSteps.ZuoraEmailStepsDeps
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.ETConfig.ETSendId
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse }
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
-import com.gu.util.{ Config, Stage }
-import org.scalatest.{ FlatSpec, Matchers }
+import com.gu.util.{Config, Stage}
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
-import scalaz.{ -\/, Reader, \/- }
+import scalaz.{-\/, Reader, \/-}
 
 class PaymentFailureHandlerTest extends FlatSpec with Matchers {
 
@@ -62,10 +62,15 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
                 req => {
                   storedReq = Some(req)
                   \/-(()): FailableOp[Unit]
-                }, FilterEmail(Stage("PROD")))),
-            a => \/-(basicInvoiceTransactionSummary))),
+                }, FilterEmail(Stage("PROD"))
+              )
+            ),
+            a => \/-(basicInvoiceTransactionSummary)
+          )
+        ),
         config.etConfig.etSendIDs,
-        config.trustedApiConfig))
+        config.trustedApiConfig
+      ))
     }
     apiGatewayHandler(configToFunction, LambdaIO(stream, os, null)).run(handlerDeps)
 
@@ -90,7 +95,12 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
               primaryKey = PaymentId("somePaymentId"),
               price = "£49.00",
               serviceStartDate = "21 November 2016",
-              serviceEndDate = "21 December 2016")))))
+              serviceEndDate = "21 December 2016"
+            )
+          )
+        )
+      )
+    )
 
     storedReq should be(Some(expectedMessage))
     responseString jsonMatches successfulResponse
@@ -120,9 +130,11 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
     PaymentFailureSteps.apply(PFDeps(
       ZuoraEmailSteps.sendEmailRegardingAccount(ZuoraEmailStepsDeps(
         sendEmail = _ => -\/(ApiGatewayResponse.internalServerError("something failed!")),
-        getInvoiceTransactions = _ => \/-(fakeInvoiceTransactionSummary))),
+        getInvoiceTransactions = _ => \/-(fakeInvoiceTransactionSummary)
+      )),
       config.etConfig.etSendIDs,
-      config.trustedApiConfig)) _
+      config.trustedApiConfig
+    )) _
   }
 
   "lambda" should "return error if message can't be queued" in {
@@ -143,10 +155,16 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
                   req => {
                     storedReq = Some(req)
                     -\/(ApiGatewayResponse.internalServerError("something failed!")): FailableOp[Unit]
-                  }, FilterEmail(Stage("PROD")))),
-              a => \/-(basicInvoiceTransactionSummary))),
+                  }, FilterEmail(Stage("PROD"))
+                )
+              ),
+              a => \/-(basicInvoiceTransactionSummary)
+            )
+          ),
           config.etConfig.etSendIDs,
-          config.trustedApiConfig))
+          config.trustedApiConfig
+        )
+      )
     }
     apiGatewayHandler(configToFunction, LambdaIO(stream, os, null)).run(handlerDeps)
 

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureStepsTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureStepsTest.scala
@@ -2,7 +2,7 @@ package com.gu.paymentFailure
 
 import com.gu.TestData.fakeApiConfig
 import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 
 import scalaz.\/
 

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -2,20 +2,21 @@ package com.gu.stripeCustomerSourceUpdated
 
 import com.gu.TestData
 import com.gu.effects.TestingRawEffects
-import com.gu.effects.TestingRawEffects.BasicRequest
+import com.gu.effects.TestingRawEffects.{BasicRequest, HTTPResponse}
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedStepsTestData._
 import com.gu.stripeCustomerSourceUpdated.zuora.ZuoraQueryPaymentMethod.PaymentMethodFields
-import com.gu.util.apigateway.{ ApiGatewayRequest, ApiGatewayResponse }
-import com.gu.util.zuora.ZuoraAccount.{ AccountId, NumConsecutiveFailures, PaymentMethodId }
-import org.scalatest.{ FlatSpec, Matchers }
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.zuora.ZuoraAccount.{AccountId, NumConsecutiveFailures, PaymentMethodId}
+import org.scalatest.{FlatSpec, Matchers}
 
-import scalaz.{ -\/, \/- }
+import scalaz.{-\/, \/-}
 
 class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matchers {
 
   "SourceUpdatedSteps" should "getAccountToUpdate non default pm" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |    {
@@ -26,19 +27,23 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
           |  ],
           |  "size": 1,
           |  "done": true
-          |}""".stripMargin)), //defaultPMID
-      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))))
+          |}""".stripMargin
+      )), //defaultPMID
+      ("/accounts/accid/summary", HTTPResponse(200, defaultAccountSummaryJson))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     val expectedGET = BasicRequest(
       "GET",
       "/accounts/accid/summary",
-      "")
+      ""
+    )
 
     effects.requestsAttempted should be(List(expectedGET, expectedPOST))
     actual should be(\/-(List()))
@@ -46,7 +51,8 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
   "SourceUpdatedSteps" should "getAccountToUpdate default pm" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |    {
@@ -57,19 +63,23 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
           |  ],
           |  "size": 1,
           |  "done": true
-          |}""".stripMargin)), //defaultPMID
-      ("/accounts/accid/summary", (200, defaultAccountSummaryJson))))
+          |}""".stripMargin
+      )), //defaultPMID
+      ("/accounts/accid/summary", HTTPResponse(200, defaultAccountSummaryJson))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     val expectedGET = BasicRequest(
       "GET",
       "/accounts/accid/summary",
-      "")
+      ""
+    )
 
     effects.requestsAttempted should be(List(expectedGET, expectedPOST))
     actual should be(\/-(List(PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accid"), NumConsecutiveFailures(3)))))
@@ -77,7 +87,8 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
   "SourceUpdatedSteps" should "getAccountToUpdate default pm with multiple on the same account" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |    {
@@ -93,19 +104,23 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
           |  ],
           |  "size": 2,
           |  "done": true
-          |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
+          |}""".stripMargin
+      )), //defaultPMID
+      ("/accounts/accountidfake/summary", HTTPResponse(200, defaultAccountSummaryJson))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     val expectedGET = BasicRequest(
       "GET",
       "/accounts/accountidfake/summary",
-      "")
+      ""
+    )
 
     effects.requestsAttempted should be(List(expectedGET, expectedPOST))
     actual should be(\/-(List(PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)))))
@@ -113,7 +128,8 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account three only" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |    {
@@ -134,39 +150,47 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
           |  ],
           |  "size": 3,
           |  "done": true
-          |}""".stripMargin)),
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson)),
-      ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM"))),
-      ("/accounts/accountidANOTHERONE/summary", (200, accountSummaryJson("anotherPMAGAIN")))))
+          |}""".stripMargin
+      )),
+      ("/accounts/accountidfake/summary", HTTPResponse(200, defaultAccountSummaryJson)),
+      ("/accounts/accountidANOTHER/summary", HTTPResponse(200, accountSummaryJson("anotherPM"))),
+      ("/accounts/accountidANOTHERONE/summary", HTTPResponse(200, accountSummaryJson("anotherPMAGAIN")))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     val expectedGET1 = BasicRequest(
       "GET",
       "/accounts/accountidfake/summary",
-      "")
+      ""
+    )
     val expectedGET2 = BasicRequest(
       "GET",
       "/accounts/accountidANOTHER/summary",
-      "")
+      ""
+    )
     val expectedGET3 = BasicRequest(
       "GET",
       "/accounts/accountidANOTHERONE/summary",
-      "")
+      ""
+    )
     effects.requestsAttempted.toSet should be(Set(expectedGET1, expectedGET2, expectedGET3, expectedPOST))
     actual.map(_.toSet) should be(\/-(Set(
       PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)),
       PaymentMethodFields(PaymentMethodId("anotherPM"), AccountId("accountidANOTHER"), NumConsecutiveFailures(4)),
-      PaymentMethodFields(PaymentMethodId("anotherPMAGAIN"), AccountId("accountidANOTHERONE"), NumConsecutiveFailures(4)))))
+      PaymentMethodFields(PaymentMethodId("anotherPMAGAIN"), AccountId("accountidANOTHERONE"), NumConsecutiveFailures(4))
+    )))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account two of them but only one is default PM" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |    {
@@ -182,32 +206,39 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
           |  ],
           |  "size": 2,
           |  "done": true
-          |}""".stripMargin)),
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson)),
-      ("/accounts/accountidANOTHER/summary", (200, accountSummaryJson("anotherPM")))))
+          |}""".stripMargin
+      )),
+      ("/accounts/accountidfake/summary", HTTPResponse(200, defaultAccountSummaryJson)),
+      ("/accounts/accountidANOTHER/summary", HTTPResponse(200, accountSummaryJson("anotherPM")))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     val expectedGET1 = BasicRequest(
       "GET",
       "/accounts/accountidfake/summary",
-      "")
+      ""
+    )
     val expectedGET2 = BasicRequest(
       "GET",
       "/accounts/accountidANOTHER/summary",
-      "")
+      ""
+    )
     effects.requestsAttempted.toSet should be(Set(expectedGET1, expectedGET2, expectedPOST))
     actual.map(_.toSet) should be(\/-(Set(
-      PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2)))))
+      PaymentMethodFields(PaymentMethodId("defaultPMID"), AccountId("accountidfake"), NumConsecutiveFailures(2))
+    )))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate multiple on different account more than three" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |    {
@@ -233,36 +264,43 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
           |  ],
           |  "size": 4,
           |  "done": true
-          |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
+          |}""".stripMargin
+      )), //defaultPMID
+      ("/accounts/accountidfake/summary", HTTPResponse(200, defaultAccountSummaryJson))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     effects.requestsAttempted should be(List(expectedPOST))
     actual should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
   }
 
   "SourceUpdatedSteps" should "getAccountToUpdate no payment methods at all" in {
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/action/query", (200,
+      ("/action/query", HTTPResponse(
+        200,
         """{
           |  "records": [
           |  ],
           |  "size": 0,
           |  "done": true
-          |}""".stripMargin)), //defaultPMID
-      ("/accounts/accountidfake/summary", (200, defaultAccountSummaryJson))))
+          |}""".stripMargin
+      )), //defaultPMID
+      ("/accounts/accountidfake/summary", HTTPResponse(200, defaultAccountSummaryJson))
+    ))
 
     val actual = SourceUpdatedSteps.getPaymentMethodsToUpdate(StripeCustomerId("fakecustid"), StripeSourceId("fakecardid")).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}")
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures\\n FROM PaymentMethod\\n  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+    )
     effects.requestsAttempted should be(List(expectedPOST))
     actual should be(\/-(List()))
   }
@@ -274,8 +312,9 @@ class SourceUpdatedStepsUpdatePaymentMethodTest extends FlatSpec with Matchers {
   "SourceUpdatedSteps" should "updatePaymentMethod" in {
 
     val effects = new TestingRawEffects(false, 500, Map(
-      ("/object/payment-method", (200, """{"Success": true,"Id": "newPMID"}""")),
-      ("/object/account/fake", (200, """{"Success": true,"Id": "fakeaccountid"}"""))))
+      ("/object/payment-method", HTTPResponse(200, """{"Success": true,"Id": "newPMID"}""")),
+      ("/object/account/fake", HTTPResponse(200, """{"Success": true,"Id": "fakeaccountid"}"""))
+    ))
 
     val eventData = EventDataObject(
       id = StripeSourceId("card_def456"),
@@ -283,18 +322,21 @@ class SourceUpdatedStepsUpdatePaymentMethodTest extends FlatSpec with Matchers {
       country = StripeCountry("US"),
       customer = StripeCustomerId("cus_ghi789"),
       expiry = StripeExpiry(exp_month = 7, exp_year = 2020),
-      last4 = StripeLast4("1234"))
+      last4 = StripeLast4("1234")
+    )
 
     val actual = SourceUpdatedSteps.createUpdatedDefaultPaymentMethod(PaymentMethodFields(PaymentMethodId("PMID"), AccountId("fake"), NumConsecutiveFailures(1)), eventData).run.run(TestData.zuoraDeps(effects))
 
     val expectedPOST = BasicRequest(
       "POST",
       "/object/payment-method",
-      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction","NumConsecutiveFailures":1}""")
+      """{"AccountId":"fake","TokenId":"card_def456","SecondTokenId":"cus_ghi789","CreditCardCountry":"US","CreditCardNumber":"1234","CreditCardExpirationMonth":7,"CreditCardExpirationYear":2020,"CreditCardType":"Visa","Type":"CreditCardReferenceTransaction","NumConsecutiveFailures":1}"""
+    )
     val expectedPUT = BasicRequest(
       "PUT",
       "/object/account/fake",
-      """{"DefaultPaymentMethodId":"newPMID"}""")
+      """{"DefaultPaymentMethodId":"newPMID"}"""
+    )
 
     effects.requestsAttempted should be(List(expectedPUT, expectedPOST))
     actual should be(\/-(()))
@@ -311,7 +353,8 @@ class SourceUpdatedStepsApplyTest extends FlatSpec with Matchers {
     val badHeaders = Map(
       "SomeHeader1" -> "testvalue",
       "Content-Type" -> "application/json",
-      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString")
+      "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
+    )
 
     val someBody =
       """

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeCustomerUpdatedReadsTest.scala
@@ -2,7 +2,7 @@ package com.gu.stripeCustomerSourceUpdated
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
-import play.api.libs.json.{ JsResult, JsSuccess, Json }
+import play.api.libs.json.{JsResult, JsSuccess, Json}
 import SourceUpdatedCallout._
 
 class StripeCustomerUpdatedReadsTest extends FlatSpec {
@@ -68,7 +68,11 @@ class StripeCustomerUpdatedReadsTest extends FlatSpec {
             country = StripeCountry("US"),
             customer = StripeCustomerId("cus_ghi789"),
             expiry = StripeExpiry(exp_month = 7, exp_year = 2020),
-            last4 = StripeLast4("1234")))))
+            last4 = StripeLast4("1234")
+          )
+        )
+      )
+    )
 
     val event: JsResult[SourceUpdatedCallout] = Json.parse(validEventJson).validate[SourceUpdatedCallout]
 

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureCheckerTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import com.gu.TestData
 import com.gu.util.apigateway.StripeAccount
-import com.gu.util.{ StripeConfig, StripeSecretKey }
+import com.gu.util.{StripeConfig, StripeSecretKey}
 import org.joda.time.DateTime
 import com.gu.stripeCustomerSourceUpdated.StripeRequestSignatureChecker._
 
@@ -77,7 +77,8 @@ class StripeRequestSignatureCheckerTest extends FlatSpec {
     """.stripMargin
 
   def headersWithStripeSignature(timestamp: String, signature: String) = Map(
-    "Stripe-Signature" -> s"t=$timestamp,v1=$signature")
+    "Stripe-Signature" -> s"t=$timestamp,v1=$signature"
+  )
 
   class FakeStripeSignatureChecker(stripeConfig: StripeConfig) extends SignatureChecker {
     override def verifySignature(secretKey: StripeSecretKey, payload: String, signatureHeader: Option[String], tolerance: Long): Boolean = {

--- a/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
+++ b/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
@@ -3,7 +3,7 @@ package com.gu.util.exacttarget
 import com.gu.util.ETConfig.ETSendId
 import com.gu.util.Stage
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 
 import scalaz.\/-
 
@@ -26,7 +26,11 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
             primaryKey = PaymentId("paymentId"),
             price = "49.0 GBP",
             serviceStartDate = "31 January 2016",
-            serviceEndDate = "31 January 2017"))))
+            serviceEndDate = "31 January 2017"
+          )
+        )
+      )
+    )
   }
 
   private val guardian = "john.duffell@guardian.co.uk"
@@ -36,7 +40,8 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
 
     val req = EmailRequest(
       etSendId = ETSendId("etSendId"),
-      makeMessage(email))
+      makeMessage(email)
+    )
 
     val stage = Stage(if (isProd) "PROD" else "CODE")
 
@@ -47,7 +52,8 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
         varAttempted = true
         \/-(()) // always success
       },
-      filterEmail = FilterEmail.apply(stage) _)
+      filterEmail = FilterEmail.apply(stage) _
+    )
 
     EmailSendSteps(deps)(req)
 

--- a/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
+++ b/src/test/scala/manualTest/ConfigLoaderSystemTest.scala
@@ -2,8 +2,8 @@ package manualTest
 
 import com.gu.effects.ConfigLoad
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
-import com.gu.util.{ Config, Stage }
-import org.scalatest.{ FlatSpec, Ignore, Matchers }
+import com.gu.util.{Config, Stage}
+import org.scalatest.{FlatSpec, Ignore, Matchers}
 
 import scala.io.Source
 import scala.util.Try

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -5,10 +5,10 @@ import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.zuora.ZuoraRestConfig
-import com.gu.util.{ Config, Logging, Stage }
+import com.gu.util.{Config, Logging, Stage}
 
 import scala.io.Source
-import scala.util.{ Random, Try }
+import scala.util.{Random, Try}
 import scalaz.syntax.std.either._
 
 // run this to send a one off email to yourself.  the email will take a few mins to arrive, but it proves the ET logic works
@@ -33,7 +33,11 @@ object EmailClientSystemTest extends App with Logging {
           primaryKey = key, // must be unique otherwise the email won't arrive
           price = "49.0 GBP",
           serviceStartDate = "31 January 2016",
-          serviceEndDate = "31 January 2017"))))
+          serviceEndDate = "31 January 2017"
+        )
+      )
+    )
+  )
 
   def five(etSendIds: ETSendIds, product: String) =
     Seq(
@@ -41,7 +45,8 @@ object EmailClientSystemTest extends App with Logging {
       etSendIds.pf2 -> message(s"$product-pf2", PaymentId(s"paymentId$unique"), product),
       etSendIds.pf3 -> message(s"$product-pf3", PaymentId(s"paymentId$unique"), product),
       etSendIds.pf4 -> message(s"$product-pf4", PaymentId(s"paymentId$unique"), product),
-      etSendIds.cancelled -> message(s"$product-overdue", InvoiceId(s"invoiceId$unique"), product))
+      etSendIds.cancelled -> message(s"$product-overdue", InvoiceId(s"invoiceId$unique"), product)
+    )
 
   for {
     configAttempt <- Try {
@@ -58,12 +63,15 @@ object EmailClientSystemTest extends App with Logging {
     "Guardian Weekly Zone C",
     "Contributor",
     "Newspaper Voucher",
-    "Newspaper Delivery").flatMap(product => five(etSendIds, product)).foreach {
+    "Newspaper Delivery"
+  ).flatMap(product => five(etSendIds, product)).foreach {
       case (etSendId, index) =>
         val emailResult = EmailSendSteps(
-          deps)(EmailRequest(
+          deps
+        )(EmailRequest(
           etSendId = etSendId,
-          message = index))
+          message = index
+        ))
         println(s"result for $etSendId:::::: $emailResult")
     }
 


### PR DESCRIPTION
This is part of the overall task to link a never transacted existing identity account with a zuora account having the same email address but a single product.

This PR adds the pre-checks against zuora that we are allowed to backfill an identity account.
These checks come after looking up the identity id by email address.

### Method
We check that there is exactly one account in zuora with that billing work email address.
We then check there are no accounts in zuora with that indeitity id
If either of those checks fail, we return a 404 to basically say there's a client error in suggesting to update that account.
If both pass, then we return a 200 no action needed if we are in dry run mode.  In prod mode we will return a 500 error "TODO".  This is because the actual code to backfill is not written yet.

unfortunately I mixed in a load of reformatting 😵 , so it's not a small size pr. Feel free to tell me to split it into two PRs and I won't be able to say no!
@paulbrown1982 @jacobwinch @pvighi @lmath 