### PR TITLE
Health checks for lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ The testing story is not perfect at the moment!  You are responsible for getting
 ### code only changes
 You can be confident when making code only changes.  Run `sbt test`. They will run on your build of your branch and when you merge to master.  Don't forget to "Run with Coverage" in IntelliJ.
 
-### changes to config
-The system won't safe you for free here.  Once you changed your config (see the howto below), you should run ConfigLoaderSystemTest.  This test does not (YET!) run automatically, so if you deploy to PROD without checking this, the lambdas will deploy but not actually work.
-
 ### system integration points
 Traiditonal health checking doesn't happen.  After deploy you can't relax until you know an HTTP request will hit your lambda, and that your lambda can access any external services.
 You can run the health check as a local test by downloading the DEV config, and running HealthCheckSystemTest.
 You can run it in CODE and PROD by downloading the health check config from DEV and running CODEPRODHealthCheck.
-The CODE and PROD health checks are called by RunScope every 5 minutes.
+The PROD health checks are called by RunScope every 5 minutes.
 
 To download the dev config use the following command:
 `aws s3 cp s3://gu-reader-revenue-private/membership/payment-failure-lambdas/DEV/ /etc/gu/ --exclude "*" --include "payment-failure-*" --profile membership --recursive`
+
+### changes to config
+The system won't save you for free here.  Once you changed your config (see the howto below), you should run ConfigLoaderSystemTest.  This test does not (YET!) run automatically, so if you deploy to PROD without checking this, the lambdas will deploy but not actually work.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Stripe Webhook > AWS Cloudfront > AWS API Gateway > AWS Lambda
 
 **Identity backfill**
 
-[identity-backfill](handlers/)
+[identity-backfill](handlers/identity-backfill/)
 
 **Libraries**
 

--- a/README.md
+++ b/README.md
@@ -77,35 +77,9 @@ Ideally this test should be automated and your PR shouldn't be mergable until th
 ## structure
 The main project aggregates all the sub projects from handlers and lib, so we can build and test them in one go.
 
-## root
-Contains three Scala lambdas behind the same API gateway.
-At present these can be deployed to CODE and PROD as MemSub::Membership Admin::Zuora Auto Cancel.
+**root** (auto cancel, payment failure and stripe hook)
 
-Testing: to get all the emails from ET, run the EmailClientSystemTest against your own email address.  You should get a deluge of emails.
-
-TODO These three lambdas should be moved into a new set of 3 projects in the handlers folder.
-
-**autoCancel**: 
-Used to cancel subscriptions with overdue invoices, based on an event trigger within Zuora.
-
-The full workflow is currently:
-Zuora Callout > AWS CloudFront* > AWS API Gateway (Lambda Proxy Integration) > AWS Lambda
-
-**paymentFailure**:
-Used to trigger emails due to failed payment events in Zuora.
-
-The full workflow is currently:
-Zuora Callout > AWS CloudFront* > AWS API Gateway (Lambda Proxy Integration) > AWS Lambda > Exact Target / Marketing Cloud (which actually sends the emails).
-
-**stripeCustomerSourceUpdated**: 
-Used to automatically update a customer's payment method in Zuora so that the customer doesn't have to update their card details manually. 
-
-Stripe works with card networks so that when a customer's card details are updated, this fires an event and we can provide an endpoint for Stripe to call.
-
-The full workflow is currently:
-Stripe Webhook > AWS Cloudfront > AWS API Gateway > AWS Lambda
-
-*An additional CloudFront distribution is currently required because zuora callouts do not support SNI, and the default CloudFront distribution (which gets set up in front of API Gateway) seems to require it.
+[root handlers readme](handlers/root.md)
 
 **Identity backfill**
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can be confident when making code only changes.  Run `sbt test`. They will r
 Traiditonal health checking doesn't happen.  After deploy you can't relax until you know an HTTP request will hit your lambda, and that your lambda can access any external services.
 You can run the health check as a local test by downloading the DEV config, and running HealthCheckSystemTest.
 You can run it in CODE and PROD by downloading the health check config from DEV and running CODEPRODHealthCheck.
-The PROD health checks are called by RunScope every 5 minutes.
+The PROD health checks are [called by RunScope](https://www.runscope.com/radar/wrb0ytfjy4a4) every 5 minutes.
 
 To download the dev config use the following command:
 `aws s3 cp s3://gu-reader-revenue-private/membership/payment-failure-lambdas/DEV/ /etc/gu/ --exclude "*" --include "payment-failure-*" --profile membership --recursive`

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -8,8 +8,8 @@ import com.gu.identity.{GetByEmail, IdentityConfig}
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.zuora.{CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail}
 import com.gu.util.Config
-import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
 import play.api.libs.json.{Json, Reads}
@@ -28,7 +28,7 @@ object Handler {
   implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
 
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
-    def operation: Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit] =
+    def operation: Config[StepsConfig] => Operation =
       config => IdentityBackfillSteps(
         GetByEmail(rawEffects.response, config.stepsConfig.identityConfig),
         GetZuoraAccountsForEmail(ZuoraDeps(rawEffects.response, config.stepsConfig.zuoraRestConfig)),

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -30,7 +30,7 @@ class StepsTest extends FlatSpec with Matchers {
         salesforceUpdate = Some((sFContactId, identityId))
         \/-(())
       }
-    )
+    ).steps
 
   }
 

--- a/handlers/identity-backfill/src/test/scala/manualTest/HealthCheckSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/manualTest/HealthCheckSystemTest.scala
@@ -1,0 +1,114 @@
+package manualTest
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+import com.gu.effects.RawEffects
+import com.gu.identityBackfill.Handler
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import manualTest.HealthCheckData._
+import org.scalatest.{Assertion, FlatSpec, Ignore, Matchers}
+import play.api.libs.json.Json
+
+import scala.io.Source
+import scala.util.Try
+
+// this test runs the health check from locally. this means you can only run it manually
+// you should also run the healthcheck in code after deploy
+@Ignore
+class HealthCheckSystemTest extends FlatSpec with Matchers {
+
+  it should "successfull run the health check using the local code against real backend" in {
+
+    val stream = new ByteArrayInputStream(healthcheckRequest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    val os = new ByteArrayOutputStream()
+    val rawEffects = RawEffects.createDefault.copy(s3Load = { stage =>
+      Try {
+        Source.fromFile("/etc/gu/payment-failure-lambdas.private.json").mkString
+      }
+    })
+
+    //execute
+    Handler.runWithEffects(rawEffects, LambdaIO(stream, os, null))
+
+    val responseString = new String(os.toByteArray, "UTF-8")
+
+    val expectedResponse =
+      s"""
+         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
+         |""".stripMargin
+    responseString jsonMatches expectedResponse
+  }
+
+  // TODO test that the health check fails when it should!
+
+  implicit class JsonMatcher(private val actual: String) {
+    def jsonMatches(expected: String): Assertion = {
+      val expectedJson = Json.parse(expected)
+      val actualJson = Json.parse(actual)
+      actualJson should be(expectedJson)
+    }
+  }
+
+}
+
+object HealthCheckData {
+
+  def healthcheckRequest: String =
+    s"""
+       |{
+       |    "resource": "/payment-failure",
+       |    "path": "/payment-failure",
+       |    "httpMethod": "POST",
+       |    "headers": {
+       |        "CloudFront-Forwarded-Proto": "https",
+       |        "CloudFront-Is-Desktop-Viewer": "true",
+       |        "CloudFront-Is-Mobile-Viewer": "false",
+       |        "CloudFront-Is-SmartTV-Viewer": "false",
+       |        "CloudFront-Is-Tablet-Viewer": "false",
+       |        "CloudFront-Viewer-Country": "US",
+       |        "Content-Type": "application/json; charset=utf-8",
+       |        "Host": "hosthosthost",
+       |        "User-Agent": "Amazon CloudFront",
+       |        "Via": "1.1 c154e1d9f76106d9025a8ffb4f4831ae.cloudfront.net (CloudFront), 1.1 11b20299329437ea4e28ea2b556ea990.cloudfront.net (CloudFront)",
+       |        "X-Amz-Cf-Id": "hihi",
+       |        "X-Amzn-Trace-Id": "Root=1-5a0f2574-4cb4d1534b9f321a3b777624",
+       |        "X-Forwarded-For": "1.1.1.1, 1.1.1.1",
+       |        "X-Forwarded-Port": "443",
+       |        "X-Forwarded-Proto": "https"
+       |    },
+       |    "queryStringParameters": {
+       |        "isHealthcheck": "true",
+       |        "apiToken": "a"
+       |    },
+       |    "pathParameters": null,
+       |    "stageVariables": null,
+       |    "requestContext": {
+       |        "path": "/CODE/payment-failure",
+       |        "accountId": "865473395570",
+       |        "resourceId": "ls9b61",
+       |        "stage": "CODE",
+       |        "requestId": "11111111-cbc2-11e7-a389-b7e6e2ab8316",
+       |        "identity": {
+       |            "cognitoIdentityPoolId": null,
+       |            "accountId": null,
+       |            "cognitoIdentityId": null,
+       |            "caller": null,
+       |            "apiKey": "",
+       |            "sourceIp": "1.1.1.1",
+       |            "accessKey": null,
+       |            "cognitoAuthenticationType": null,
+       |            "cognitoAuthenticationProvider": null,
+       |            "userArn": null,
+       |            "userAgent": "Amazon CloudFront",
+       |            "user": null
+       |        },
+       |        "resourcePath": "/payment-failure",
+       |        "httpMethod": "POST",
+       |        "apiId": "11111"
+       |    },
+       |    "body": "",
+       |    "isBase64Encoded": false
+       |}
+    """.stripMargin
+
+}

--- a/handlers/root.md
+++ b/handlers/root.md
@@ -1,0 +1,31 @@
+This refers to the monolithic code in the main src folders in the root of the project.  These will be moved to this subdir in future.
+
+## root
+Contains three Scala lambdas behind the same API gateway.
+At present these can be deployed to CODE and PROD as MemSub::Membership Admin::Zuora Auto Cancel.
+
+Testing: to get all the emails from ET, run the EmailClientSystemTest against your own email address.  You should get a deluge of emails.
+
+TODO These three lambdas should be moved into a new set of 3 projects in the handlers folder.
+
+**autoCancel**: 
+Used to cancel subscriptions with overdue invoices, based on an event trigger within Zuora.
+
+The full workflow is currently:
+Zuora Callout > AWS CloudFront* > AWS API Gateway (Lambda Proxy Integration) > AWS Lambda
+
+**paymentFailure**:
+Used to trigger emails due to failed payment events in Zuora.
+
+The full workflow is currently:
+Zuora Callout > AWS CloudFront* > AWS API Gateway (Lambda Proxy Integration) > AWS Lambda > Exact Target / Marketing Cloud (which actually sends the emails).
+
+**stripeCustomerSourceUpdated**: 
+Used to automatically update a customer's payment method in Zuora so that the customer doesn't have to update their card details manually. 
+
+Stripe works with card networks so that when a customer's card details are updated, this fires an event and we can provide an endpoint for Stripe to call.
+
+The full workflow is currently:
+Stripe Webhook > AWS Cloudfront > AWS API Gateway > AWS Lambda
+
+*An additional CloudFront distribution is currently required because zuora callouts do not support SNI, and the default CloudFront distribution (which gets set up in front of API Gateway) seems to require it.

--- a/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
@@ -17,7 +17,7 @@ object RawEffects {
 
   // This is the effects that actually does stuff in side effects
   def createDefault = {
-    val stage = Stage(System.getenv("Stage"))
+    val stage = Stage(Option(System.getenv("Stage")).filter(_ != "").getOrElse("DEV"))
     RawEffects(Http.response, stage, ConfigLoad.load, () => LocalDate.now)
   }
 

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayRequest.scala
@@ -17,7 +17,12 @@ object StripeAccount {
 
   implicit val reads: Reads[StripeAccount] = JsPath.read[String].map(fromString(_).get)
 }
-case class URLParams(apiToken: Option[String], onlyCancelDirectDebit: Boolean, stripeAccount: Option[StripeAccount])
+case class URLParams(
+  apiToken: Option[String],
+  onlyCancelDirectDebit: Boolean,
+  stripeAccount: Option[StripeAccount],
+  isHealthcheck: Boolean
+)
 
 /* Using query strings because for Basic Auth to work Zuora requires us to return a WWW-Authenticate
   header, and API Gateway does not support this header (returns x-amzn-Remapped-WWW-Authenticate instead)
@@ -35,7 +40,8 @@ object URLParams {
   implicit val jf = (
     (JsPath \ "apiToken").readNullable[String] and
     (JsPath \ "onlyCancelDirectDebit").readNullable[String].map(_.contains("true")) and
-    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString))
+    (JsPath \ "stripeAccount").readNullable[String].map(_.flatMap(StripeAccount.fromString)) and
+    (JsPath \ "isHealthcheck").readNullable[String].map(_.contains("true"))
   )(URLParams.apply _)
 }
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -6,15 +6,14 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.autoCancel.AutoCancelSteps.AutoCancelStepsDeps
 import com.gu.effects.RawEffects
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
+import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest}
-import com.gu.util.reader.Types.FailableOp
 import com.gu.util.{Config, Logging}
 
 object AutoCancelHandler extends App with Logging {
 
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
-    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
+    def operation(config: Config[StepsConfig]): ApiGatewayHandler.Operation =
       AutoCancelSteps(AutoCancelStepsDeps.default(rawEffects.now(), rawEffects.response, config))
     ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -7,14 +7,13 @@ import com.gu.effects.RawEffects
 import com.gu.paymentFailure.PaymentFailureSteps.PFDeps
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.Config
+import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest}
-import com.gu.util.reader.Types.FailableOp
 
 object Lambda {
 
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
-    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
+    def operation(config: Config[StepsConfig]): ApiGatewayHandler.Operation =
       PaymentFailureSteps(PFDeps.default(rawEffects.response, config))
     ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -6,14 +6,13 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.{Deps, StepsConfig}
 import com.gu.util.Config
+import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest}
-import com.gu.util.reader.Types.FailableOp
 
 object Lambda {
 
   def runWithEffects(rawEffects: RawEffects, lambdaIO: LambdaIO): Unit = {
-    def operation(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] =
+    def operation(config: Config[StepsConfig]): ApiGatewayHandler.Operation =
       SourceUpdatedSteps(Deps.default(rawEffects.response, config))
     ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
   }

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -8,8 +8,8 @@ import com.gu.paymentFailure.PaymentFailureSteps.PFDeps
 import com.gu.paymentFailure.ZuoraEmailSteps.ZuoraEmailStepsDeps
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.ETConfig.ETSendId
-import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.reader.Types._
@@ -53,7 +53,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
 
     val os = new ByteArrayOutputStream()
     //execute
-    def configToFunction(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] = {
+    def configToFunction(config: Config[StepsConfig]): Operation = {
       PaymentFailureSteps.apply(PFDeps(
         ZuoraEmailSteps.sendEmailRegardingAccount(
           ZuoraEmailStepsDeps(
@@ -123,7 +123,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
     responseString jsonMatches expectedResponse
   }
 
-  def apiGatewayHandler: (Config[StepsConfig] => ApiGatewayRequest => FailableOp[Unit], LambdaIO) => Reader[(Stage, Try[String]), Unit] = {
+  def apiGatewayHandler: (Config[StepsConfig] => Operation, LambdaIO) => Reader[(Stage, Try[String]), Unit] = {
     ApiGatewayHandler[StepsConfig](Reader { _ => \/-(TestData.fakeConfig) }, _, _)
   }
   def basicOp(fakeInvoiceTransactionSummary: InvoiceTransactionSummary = basicInvoiceTransactionSummary) = { config: Config[StepsConfig] =>
@@ -134,7 +134,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
       )),
       config.etConfig.etSendIDs,
       config.trustedApiConfig
-    )) _
+    ))
   }
 
   "lambda" should "return error if message can't be queued" in {
@@ -145,7 +145,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
     val os = new ByteArrayOutputStream()
 
     //execute
-    def configToFunction(config: Config[StepsConfig]): ApiGatewayRequest => FailableOp[Unit] = {
+    def configToFunction(config: Config[StepsConfig]): Operation = {
       PaymentFailureSteps.apply(
         PFDeps(
           ZuoraEmailSteps.sendEmailRegardingAccount(

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -388,7 +388,7 @@ class SourceUpdatedStepsApplyTest extends FlatSpec with Matchers {
 
     val testGatewayRequest = ApiGatewayRequest(None, someBody.toString, Some(badHeaders))
 
-    val actual = SourceUpdatedSteps.apply(sourceUpdatedSteps)(testGatewayRequest)
+    val actual = SourceUpdatedSteps.apply(sourceUpdatedSteps).steps(testGatewayRequest)
 
     effects.requestsAttempted should be(Nil)
     actual.leftMap(_.statusCode) should be(-\/("401"))

--- a/src/test/scala/manualTest/CODEPRODHealthCheck.scala
+++ b/src/test/scala/manualTest/CODEPRODHealthCheck.scala
@@ -1,0 +1,139 @@
+package manualTest
+
+import com.gu.effects.Http
+import okhttp3.{Request, Response}
+import org.scalatest.{Assertion, FlatSpec, Ignore, Matchers}
+import play.api.libs.json.Json
+
+import scala.io.Source
+import scala.util.Try
+
+// this test runs the health check from locally. this means you can only run it manually
+// you should run the healthcheck in code and in prod after deployments
+@Ignore
+class CODEPRODHealthCheck extends FlatSpec with Matchers {
+
+  import com.gu.util.reader.Types._
+
+  it should "successfull run the health checks against CODE" in {
+
+    healthcheckForEnv(_.CODE)
+
+  }
+
+  it should "successfull run the health checks against PROD" in {
+
+    healthcheckForEnv(_.PROD)
+
+  }
+
+  private def healthcheckForEnv(env: HealthChecks => List[HealthCheckConfig]) = {
+    val healthchecks = for {
+      jsonString <- Try {
+        Source.fromFile("/etc/gu/payment-failure-healthcheck.private.json").mkString
+      }.toFailableOp("read local config")
+      healthcheck <- Json.parse(jsonString).validate[HealthChecks](HealthChecks.reads).toFailableOp
+
+    } yield env(healthcheck)
+
+    val expectedResponse =
+      s"""
+         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
+         |""".stripMargin
+
+    healthchecks.fold(err => fail(s"couldn't load config: $err"), identity).foreach { healthcheck =>
+      val responseString = get(healthcheck, Http.response)
+      responseString jsonMatches expectedResponse
+    }
+  }
+
+  def get(healthcheck: HealthCheckConfig, response: Request => Response): String = {
+    val request = new Request.Builder().url(healthcheck.url).header("x-api-key", healthcheck.apiKey).get().build()
+    val responseO = response(request)
+    if (responseO.isSuccessful) {
+      responseO.body().string()
+    } else {
+      s"RESPONSE CODE: ${responseO.code()}"
+    }
+  }
+
+  implicit class JsonMatcher(private val actual: String) {
+    def jsonMatches(expected: String): Assertion = {
+      val expectedJson = Json.parse(expected)
+      val actualJson = Json.parse(actual)
+      actualJson should be(expectedJson)
+    }
+  }
+
+}
+
+case class HealthCheckConfig(url: String, apiKey: String)
+case class HealthChecks(CODE: List[HealthCheckConfig], PROD: List[HealthCheckConfig])
+object HealthCheckConfig {
+  implicit val reads = Json.reads[HealthCheckConfig]
+}
+object HealthChecks {
+  implicit val reads = Json.reads[HealthChecks]
+}
+
+object HealthCheckData {
+
+  def healthcheckRequest(apiToken: String): String =
+    s"""
+       |{
+       |    "resource": "/payment-failure",
+       |    "path": "/payment-failure",
+       |    "httpMethod": "POST",
+       |    "headers": {
+       |        "CloudFront-Forwarded-Proto": "https",
+       |        "CloudFront-Is-Desktop-Viewer": "true",
+       |        "CloudFront-Is-Mobile-Viewer": "false",
+       |        "CloudFront-Is-SmartTV-Viewer": "false",
+       |        "CloudFront-Is-Tablet-Viewer": "false",
+       |        "CloudFront-Viewer-Country": "US",
+       |        "Content-Type": "application/json; charset=utf-8",
+       |        "Host": "hosthosthost",
+       |        "User-Agent": "Amazon CloudFront",
+       |        "Via": "1.1 c154e1d9f76106d9025a8ffb4f4831ae.cloudfront.net (CloudFront), 1.1 11b20299329437ea4e28ea2b556ea990.cloudfront.net (CloudFront)",
+       |        "X-Amz-Cf-Id": "hihi",
+       |        "X-Amzn-Trace-Id": "Root=1-5a0f2574-4cb4d1534b9f321a3b777624",
+       |        "X-Forwarded-For": "1.1.1.1, 1.1.1.1",
+       |        "X-Forwarded-Port": "443",
+       |        "X-Forwarded-Proto": "https"
+       |    },
+       |    "queryStringParameters": {
+       |        "isHealthcheck": "true",
+       |        "apiToken": "$apiToken"
+       |    },
+       |    "pathParameters": null,
+       |    "stageVariables": null,
+       |    "requestContext": {
+       |        "path": "/CODE/payment-failure",
+       |        "accountId": "865473395570",
+       |        "resourceId": "ls9b61",
+       |        "stage": "CODE",
+       |        "requestId": "11111111-cbc2-11e7-a389-b7e6e2ab8316",
+       |        "identity": {
+       |            "cognitoIdentityPoolId": null,
+       |            "accountId": null,
+       |            "cognitoIdentityId": null,
+       |            "caller": null,
+       |            "apiKey": "",
+       |            "sourceIp": "1.1.1.1",
+       |            "accessKey": null,
+       |            "cognitoAuthenticationType": null,
+       |            "cognitoAuthenticationProvider": null,
+       |            "userArn": null,
+       |            "userAgent": "Amazon CloudFront",
+       |            "user": null
+       |        },
+       |        "resourcePath": "/payment-failure",
+       |        "httpMethod": "POST",
+       |        "apiId": "11111"
+       |    },
+       |    "body": "",
+       |    "isBase64Encoded": false
+       |}
+    """.stripMargin
+
+}


### PR DESCRIPTION
I am deploying the lambdas quite often to CODE and PROD.  It's quite hard to know if I broke something unrelated.  Deployment is just copying a JAR file and we only find out if there's a problem when an alarm goes off.

This PR adds another field to the steps/operation object to define a health check operation.  This is called when you hit the lambda's url with isHealthcheck=true in the URL.  You don't need any api token as enforced by the lambda, but you would need the api key for API gateway.

I have added an example health check for identity backfill, which calls identity and zuora to make sure it can do a lookup in each.

A third aspect is a local test which can run the healthcheck against the DEV config.
Also there is a CODE/PROD local test which hits the configured urls in the healthcheck local config file, and makes sure things are working in CODE or PROD.

@jacobwinch will be happy about this quality improvement? ;)

@pvighi @paulbrown1982 @lmath 