### PR TITLE
allow identity id to be optional when returned by zuora

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -18,7 +18,7 @@ object GetZuoraAccountsForEmail {
     implicit val zcReads = Json.reads[ZuoraContact]
     case class ZuoraAccount(
       Id: String,
-      IdentityId__c: String,
+      IdentityId__c: Option[String],
       sfContactId__c: String
     )
     implicit val zaReads = Json.reads[ZuoraAccount]
@@ -37,7 +37,7 @@ object GetZuoraAccountsForEmail {
       }
     } yield ZuoraAccountIdentitySFContact(
       AccountId(accountsWithEmail.Id),
-      IdentityId(accountsWithEmail.IdentityId__c),
+      accountsWithEmail.IdentityId__c.map(IdentityId.apply),
       SFContactId(accountsWithEmail.sfContactId__c)
     )
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -82,7 +82,7 @@ object EndToEndData {
   def responses: Map[String, HTTPResponse] =
     TestData.responses
   def postResponses: Map[POSTRequest, HTTPResponse] =
-    GetZuoraAccountsForEmailData.postResponses ++
+    GetZuoraAccountsForEmailData.postResponses(false) ++
       CountZuoraAccountsForIdentityIdData.postResponses(false)
 
   def identityBackfillRequest(dryRun: Boolean): String =

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -34,36 +34,25 @@ object GetZuoraAccountsForEmailData {
     POSTRequest("/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}""")
       -> HTTPResponse(200, contactQueryResponse),
     POSTRequest("/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}""")
-      -> HTTPResponse(200, if (withIdentity) accountQueryResponseWithIdentity else accountQueryResponseWithoutIdentity)
+      -> HTTPResponse(200, accountQueryResponse(withIdentity))
   )
 
-  val accountQueryResponseWithIdentity: String =
-    """
-      |{
-      |    "records": [
-      |        {
-      |            "IdentityId__c": "10101010",
-      |            "sfContactId__c": "00110000011AABBAAB",
-      |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
-      |        }
-      |    ],
-      |    "size": 1,
-      |    "done": true
-      |}
-    """.stripMargin
-
-  val accountQueryResponseWithoutIdentity: String =
-    """
-      |{
-      |    "records": [
-      |        {
-      |            "sfContactId__c": "00110000011AABBAAB",
-      |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
-      |        }
-      |    ],
-      |    "size": 1,
-      |    "done": true
-      |}
+  def accountQueryResponse(withIdentity: Boolean): String =
+    s"""
+       |{
+       |    "records": [
+       |        {${
+      if (withIdentity) """
+       |            "IdentityId__c": "10101010","""
+      else ""
+    }
+       |            "sfContactId__c": "00110000011AABBAAB",
+       |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
+       |        }
+       |    ],
+       |    "size": 1,
+       |    "done": true
+       |}
     """.stripMargin
 
   val contactQueryResponse: String =

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -10,11 +10,19 @@ import scalaz.\/-
 
 class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
 
-  it should "get the accounts for an email" in {
-    val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses)
+  it should "get the accounts for an email with identity" in {
+    val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(true))
     val get = GetZuoraAccountsForEmail(ZuoraDeps(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
     val contacts = get(EmailAddress("email@address"))
-    val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), IdentityId("10101010"), SFContactId("00110000011AABBAAB"))))
+    val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), Some(IdentityId("10101010")), SFContactId("00110000011AABBAAB"))))
+    contacts should be(expected)
+  }
+
+  it should "get the accounts for an email without identity" in {
+    val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(false))
+    val get = GetZuoraAccountsForEmail(ZuoraDeps(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
+    val contacts = get(EmailAddress("email@address"))
+    val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))))
     contacts should be(expected)
   }
 
@@ -22,19 +30,33 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
 
 object GetZuoraAccountsForEmailData {
 
-  def postResponses: Map[POSTRequest, HTTPResponse] = Map(
+  def postResponses(withIdentity: Boolean): Map[POSTRequest, HTTPResponse] = Map(
     POSTRequest("/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}""")
       -> HTTPResponse(200, contactQueryResponse),
     POSTRequest("/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}""")
-      -> HTTPResponse(200, accountQueryResponse)
+      -> HTTPResponse(200, if (withIdentity) accountQueryResponseWithIdentity else accountQueryResponseWithoutIdentity)
   )
 
-  val accountQueryResponse: String =
+  val accountQueryResponseWithIdentity: String =
     """
       |{
       |    "records": [
       |        {
       |            "IdentityId__c": "10101010",
+      |            "sfContactId__c": "00110000011AABBAAB",
+      |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
+      |        }
+      |    ],
+      |    "size": 1,
+      |    "done": true
+      |}
+    """.stripMargin
+
+  val accountQueryResponseWithoutIdentity: String =
+    """
+      |{
+      |    "records": [
+      |        {
       |            "sfContactId__c": "00110000011AABBAAB",
       |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
       |        }


### PR DESCRIPTION
This was discovered in testing with a real user - 

we don't expect them to have an identity id in zuora
if they don't have an identity id in zuora, the field is not returned at all (rather than blank)
this was crashing the deserialiser.

This change allowes the deserialiser to understand missing using an option
adds a test to deserialise without as well as with
actually checks the value (as a double check) to make sure we're not redoing a user we already did.  This would be caught by the later check of number of accounts with the id, but double check won't slow it down.
Added a test for the above too.

@paulbrown1982 @jacobwinch 