### PR TITLE
Add code so identity backfill can auth against salesforce

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -14,7 +14,6 @@ import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
-import okhttp3.{Request, Response}
 import play.api.libs.json.{Json, Reads}
 import scalaz.syntax.either._
 
@@ -43,7 +42,7 @@ object Handler {
           CountZuoraAccountsForIdentityId(zuoraDeps),
           AddIdentityIdToAccount(zuoraDeps),
           () => SalesforceAuthenticate(rawEffects.response, config.stepsConfig.sfConfig),
-          UpdateSalesforceIdentityId(rawEffects.response, config.stepsConfig.sfConfig)
+          UpdateSalesforceIdentityId.apply
         )
       }
     ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
@@ -52,7 +51,7 @@ object Handler {
 }
 
 object UpdateSalesforceIdentityId {
-  def apply(getResponse: Request => Response, sFConfig: SFConfig)(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
+  def apply(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
     ApiGatewayResponse.internalServerError("todo").left
   }
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -38,7 +38,7 @@ object IdentityBackfillSteps extends Logging {
 
     def steps(apiGatewayRequest: ApiGatewayRequest) =
       for {
-        request <- Json.fromJson[IdentityBackfillRequest](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
+        request <- Json.parse(apiGatewayRequest.body).validate[IdentityBackfillRequest].toFailableOp.withLogging("zuora callout")
         emailAddress = fromRequest(request)
         identityId <- getByEmail(emailAddress).leftMap(a => ApiGatewayResponse.internalServerError(a.toString)).withLogging("GetByEmail")
         zuoraAccountsForEmail <- getZuoraAccountsForEmail(emailAddress)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -3,12 +3,12 @@ package com.gu.identityBackfill
 import com.gu.identity.GetByEmail
 import com.gu.identityBackfill.IdentityBackfillSteps.WireModel.IdentityBackfillRequest
 import com.gu.identityBackfill.Types._
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types._
 import play.api.libs.json.{Json, Reads}
-
 import scalaz.{-\/, \/, \/-}
 
 object IdentityBackfillSteps extends Logging {
@@ -32,7 +32,8 @@ object IdentityBackfillSteps extends Logging {
     getZuoraAccountsForEmail: EmailAddress => FailableOp[List[ZuoraAccountIdentitySFContact]],
     countZuoraAccountsForIdentityId: IdentityId => FailableOp[Int],
     updateZuoraIdentityId: (AccountId, IdentityId) => FailableOp[Unit],
-    updateSalesforceIdentityId: (SFContactId, IdentityId) => FailableOp[Unit]
+    sfAuth: () => FailableOp[SalesforceAuth], // we need to do this and we need it for the health check but it's not really a business step, TODO think about this more
+    updateSalesforceIdentityId: SalesforceAuth => (SFContactId, IdentityId) => FailableOp[Unit]
   ): Operation = {
 
     def steps(apiGatewayRequest: ApiGatewayRequest) =
@@ -53,7 +54,8 @@ object IdentityBackfillSteps extends Logging {
         _ <- if (zuoraAccountsForIdentityId == 0) \/-(()) else -\/(ApiGatewayResponse.notFound("already used that identity id"))
         _ <- (if (request.dryRun) -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end")) else \/-(())).withLogging("dryrun aborter")
         _ <- updateZuoraIdentityId(zuoraAccountForEmail.accountId, identityId)
-        _ <- updateSalesforceIdentityId(zuoraAccountForEmail.sfContactId, identityId)
+        sfAuth <- sfAuth()
+        _ <- updateSalesforceIdentityId(sfAuth)(zuoraAccountForEmail.sfContactId, identityId)
         // need to remember which ones we updated?
       } yield ()
 
@@ -61,6 +63,7 @@ object IdentityBackfillSteps extends Logging {
       for {
         identityId <- getByEmail(EmailAddress("john.duffell@guardian.co.uk")).leftMap(a => ApiGatewayResponse.internalServerError(a.toString)).withLogging("healthcheck getByEmail")
         _ <- countZuoraAccountsForIdentityId(identityId)
+        _ <- sfAuth()
       } yield ()
 
     Operation(steps = steps, healthcheck = () => healthcheck())

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticate.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticate.scala
@@ -1,0 +1,63 @@
+package com.gu.identityBackfill.salesforce
+
+import com.gu.util.Logging
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.FailableOp
+import okhttp3.{FormBody, Request, Response}
+import play.api.libs.json.{JsSuccess, Json, Reads}
+import scalaz.{-\/, \/-}
+
+object SalesforceAuthenticate extends Logging {
+
+  case class SFConfig(
+    url: String,
+    client_id: String,
+    client_secret: String,
+    username: String,
+    password: String,
+    token: String
+  )
+  object SFConfig {
+    implicit val reads: Reads[SFConfig] = Json.reads[SFConfig]
+  }
+
+  case class SalesforceAuth(access_token: String, instance_url: String)
+
+  object SalesforceAuth {
+
+    implicit val salesforceAuthReads: Reads[SalesforceAuth] = Json.reads[SalesforceAuth]
+
+  }
+
+  def apply(
+    response: (Request => Response),
+    config: SFConfig
+  ): FailableOp[SalesforceAuth] = {
+    val request: Request = buildAuthRequest(config)
+    logger.info(s"Attempting to perform Salesforce Authentication")
+    val responseBody = Json.parse(response(request).body().string())
+    responseBody.validate[SalesforceAuth] match {
+      case JsSuccess(result, _) =>
+        logger.info(s"Successful Salesforce authentication.")
+        \/-(result)
+      case _ =>
+        logger.error(s"Failed to authenticate with Salesforce | body was: ${responseBody.toString}")
+        -\/(ApiGatewayResponse.internalServerError(s"Failed to authenticate with Salesforce"))
+    }
+  }
+
+  private def buildAuthRequest(config: SFConfig) = {
+    import config._
+    val builder =
+      new Request.Builder()
+        .url(url + "/services/oauth2/token")
+    val formBody = new FormBody.Builder()
+      .add("client_id", client_id)
+      .add("client_secret", client_secret)
+      .add("username", username)
+      .add("password", password + token)
+      .add("grant_type", "password")
+      .build()
+    builder.post(formBody).build()
+  }
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
@@ -1,7 +1,6 @@
-package manualTest
+package com.gu.identity
 
 import com.gu.effects.{ConfigLoad, RawEffects}
-import com.gu.identity.GetByEmail
 import com.gu.identityBackfill.Handler.StepsConfig
 import com.gu.identityBackfill.Types.{EmailAddress, IdentityId}
 import com.gu.test.EffectsTest
@@ -11,7 +10,7 @@ import scalaz.\/-
 import scalaz.syntax.std.either._
 
 // run this manually
-class GetByEmailSystemTest extends FlatSpec with Matchers {
+class GetByEmailEffectsTest extends FlatSpec with Matchers {
 
   it should "successfull run the health check using the local code against real backend" taggedAs EffectsTest in {
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -6,7 +6,8 @@ import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{BasicRequest, HTTPResponse, POSTRequest}
 import com.gu.identity.TestData
 import com.gu.identityBackfill.EndToEndData._
-import Runner._
+import com.gu.identityBackfill.Runner._
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticateData
 import com.gu.identityBackfill.zuora.{CountZuoraAccountsForIdentityIdData, GetZuoraAccountsForEmailData}
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import org.scalatest.{Assertion, FlatSpec, Matchers}
@@ -41,6 +42,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
          |""".stripMargin
     responseString jsonMatches expectedResponse
     requests should be(List(
+      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""),
       BasicRequest("PUT", "/accounts/2c92a0fb4a38064e014a3f48f1663ad8", """{"IdentityId__c":"1234"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
@@ -83,7 +85,8 @@ object EndToEndData {
     TestData.responses
   def postResponses: Map[POSTRequest, HTTPResponse] =
     GetZuoraAccountsForEmailData.postResponses(false) ++
-      CountZuoraAccountsForIdentityIdData.postResponses(false)
+      CountZuoraAccountsForIdentityIdData.postResponses(false) ++
+      SalesforceAuthenticateData.postResponses
 
   def identityBackfillRequest(dryRun: Boolean): String =
     s"""

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -28,7 +28,8 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
-      BasicRequest("GET", "/user?emailAddress=email@address", "")
+      BasicRequest("GET", "/user?emailAddress=email@address", ""),
+      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password""")
     ))
   }
 
@@ -42,12 +43,12 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
          |""".stripMargin
     responseString jsonMatches expectedResponse
     requests should be(List(
-      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""),
       BasicRequest("PUT", "/accounts/2c92a0fb4a38064e014a3f48f1663ad8", """{"IdentityId__c":"1234"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
-      BasicRequest("GET", "/user?emailAddress=email@address", "")
+      BasicRequest("GET", "/user?emailAddress=email@address", ""),
+      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password""")
     ))
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -28,8 +28,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
-      BasicRequest("GET", "/user?emailAddress=email@address", ""),
-      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password""")
+      BasicRequest("GET", "/user?emailAddress=email@address", "")
     ))
   }
 
@@ -43,12 +42,12 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
          |""".stripMargin
     responseString jsonMatches expectedResponse
     requests should be(List(
+      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""),
       BasicRequest("PUT", "/accounts/2c92a0fb4a38064e014a3f48f1663ad8", """{"IdentityId__c":"1234"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
-      BasicRequest("GET", "/user?emailAddress=email@address", ""),
-      BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password""")
+      BasicRequest("GET", "/user?emailAddress=email@address", "")
     ))
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
@@ -1,12 +1,11 @@
-package manualTest
+package com.gu.identityBackfill
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.gu.effects.RawEffects
-import com.gu.identityBackfill.Handler
+import com.gu.identityBackfill.HealthCheckData._
 import com.gu.test.EffectsTest
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import manualTest.HealthCheckData._
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import play.api.libs.json.Json
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -2,6 +2,7 @@ package com.gu.identityBackfill
 
 import com.gu.identityBackfill.StepsData._
 import com.gu.identityBackfill.Types.{IdentityId, _}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types.FailableOp
 import org.scalatest.{FlatSpec, Matchers}
@@ -29,8 +30,8 @@ class StepsTest extends FlatSpec with Matchers {
         zuoraUpdate = Some((accountId, identityId))
         \/-(())
       },
-      sfHealthcheck = \/-(()),
-      updateSalesforceIdentityId = (sFContactId, identityId) => {
+      sfAuth = () => \/-(SalesforceAuth("token", "url")),
+      updateSalesforceIdentityId = auth => (sFContactId, identityId) => {
         salesforceUpdate = Some((sFContactId, identityId))
         \/-(())
       }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -2,10 +2,10 @@ package com.gu.identityBackfill
 
 import com.gu.identityBackfill.StepsData._
 import com.gu.identityBackfill.Types.{IdentityId, _}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types.FailableOp
 import org.scalatest.{FlatSpec, Matchers}
-
 import scalaz.{-\/, \/-}
 
 class StepsTest extends FlatSpec with Matchers {
@@ -30,7 +30,8 @@ class StepsTest extends FlatSpec with Matchers {
         zuoraUpdate = Some((accountId, identityId))
         \/-(())
       },
-      updateSalesforceIdentityId = (sFContactId, identityId) => {
+      sfAuth = () => \/-(SalesforceAuth("token", "url")),
+      updateSalesforceIdentityId = auth => (sFContactId, identityId) => {
         salesforceUpdate = Some((sFContactId, identityId))
         \/-(())
       }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -2,7 +2,6 @@ package com.gu.identityBackfill
 
 import com.gu.identityBackfill.StepsData._
 import com.gu.identityBackfill.Types.{IdentityId, _}
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types.FailableOp
 import org.scalatest.{FlatSpec, Matchers}
@@ -30,8 +29,8 @@ class StepsTest extends FlatSpec with Matchers {
         zuoraUpdate = Some((accountId, identityId))
         \/-(())
       },
-      sfAuth = () => \/-(SalesforceAuth("token", "url")),
-      updateSalesforceIdentityId = auth => (sFContactId, identityId) => {
+      sfHealthcheck = \/-(()),
+      updateSalesforceIdentityId = (sFContactId, identityId) => {
         salesforceUpdate = Some((sFContactId, identityId))
         \/-(())
       }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticateEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticateEffectsTest.scala
@@ -1,0 +1,34 @@
+package com.gu.identityBackfill.salesforce
+
+import com.gu.effects.{ConfigLoad, RawEffects}
+import com.gu.identityBackfill.Handler.StepsConfig
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.test.EffectsTest
+import com.gu.util.{Config, Stage}
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+import scalaz.syntax.std.either._
+
+class SalesforceAuthenticateEffectsTest extends FlatSpec with Matchers {
+
+  it should "get auth SF correctly" taggedAs EffectsTest in {
+
+    val actual = for {
+      configAttempt <- ConfigLoad.load(Stage("DEV")).toEither.disjunction
+      config <- Config.parseConfig[StepsConfig](configAttempt)
+      identityId <- SalesforceAuthenticate(RawEffects.createDefault.response, config.stepsConfig.sfConfig)
+    } yield {
+      identityId
+    }
+    withClue(s"wrong result: $actual") {
+      actual match {
+        case \/-(SalesforceAuth(token, instanceUrl)) =>
+          token should not be ("")
+          token.length > 20 should be(true)
+          instanceUrl should startWith("https://")
+        case _ => fail(s"wrong result")
+      }
+    }
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticateTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticateTest.scala
@@ -1,0 +1,50 @@
+package com.gu.identityBackfill.salesforce
+
+import com.gu.effects.TestingRawEffects
+import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.{SFConfig, SalesforceAuth}
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+
+class SalesforceAuthenticateTest extends FlatSpec with Matchers {
+
+  it should "get auth SF correctly" in {
+    val effects = new TestingRawEffects(postResponses = SalesforceAuthenticateData.postResponses)
+    val auth = SalesforceAuthenticate(effects.response, SFConfig(
+      "https://sfurl.haha",
+      "clientsfclient",
+      "clientsecretsfsecret",
+      "usernamesf",
+      "passSFpassword",
+      "tokentokenSFtoken"
+    ))
+    val expected = \/-(SalesforceAuth("tokentoken", "https://instance.url"))
+    auth should be(expected)
+
+  }
+
+}
+
+object SalesforceAuthenticateData {
+
+  def postResponses: Map[POSTRequest, HTTPResponse] = {
+
+    val accountQueryResponse: String =
+      s"""
+         |{
+         |    "access_token": "tokentoken",
+         |    "instance_url": "https://instance.url",
+         |    "id": "https://id.sf.com/id/idididididid/ididididid",
+         |    "token_type": "Bearer",
+         |    "issued_at": "101010101010",
+         |    "signature": "bW9uc3RlcnMhCg=="
+         |}
+    """.stripMargin
+
+    Map(
+      POSTRequest("/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password""")
+        -> HTTPResponse(200, accountQueryResponse)
+    )
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/AddIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/AddIdentityIdEffectsTest.scala
@@ -1,4 +1,4 @@
-package manualTest.addIdentityId
+package com.gu.identityBackfill.zuora.addIdentityId
 
 import com.gu.effects.{ConfigLoad, RawEffects}
 import com.gu.identityBackfill.Handler.StepsConfig

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/GetIdentityIdForAccount.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/GetIdentityIdForAccount.scala
@@ -1,10 +1,10 @@
-package manualTest.addIdentityId
+package com.gu.identityBackfill.zuora.addIdentityId
 
 import com.gu.identityBackfill.Types.{AccountId, IdentityId}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraRestRequestMaker}
-import manualTest.addIdentityId.GetIdentityIdForAccount.WireModel.ZuoraAccount
+import com.gu.identityBackfill.zuora.addIdentityId.GetIdentityIdForAccount.WireModel.ZuoraAccount
 import play.api.libs.json.Json
 
 object GetIdentityIdForAccount {

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -97,6 +97,14 @@ object TestingRawEffects {
       |    "identityConfig": {
       |      "baseUrl": "https://ididbaseurl",
       |      "apiToken": "tokentokentokenidentity"
+      |    },
+      |    "sfConfig": {
+      |      "url": "https://sfurl.haha",
+      |      "client_id": "clientsfclient",
+      |      "client_secret": "clientsecretsfsecret",
+      |      "username": "usernamesf",
+      |      "password": "passSFpassword",
+      |      "token": "tokentokenSFtoken"
       |    }
       |  },
       |  "etConfig": {

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -1,5 +1,6 @@
 package com.gu.util.reader
 
+import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.apigateway.ApiGatewayResponse.{badRequest, internalServerError, logger}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import play.api.libs.json.{JsError, JsResult, JsSuccess}
@@ -34,6 +35,16 @@ object Types {
         case JsError(error) => {
           logger.error(s"Error when parsing JSON from API Gateway: $error")
           -\/(badRequest)
+        }
+      }
+    }
+
+    def toFailableOp(error5xx: String): FailableOp[A] = {
+      jsResult match {
+        case JsSuccess(apiGatewayCallout, _) => \/-(apiGatewayCallout)
+        case JsError(error) => {
+          logger.error(s"Error when parsing JSON: $error")
+          -\/(ApiGatewayResponse.internalServerError(error5xx))
         }
       }
     }

--- a/src/main/scala/com/gu/util/exacttarget/EmailSendSteps.scala
+++ b/src/main/scala/com/gu/util/exacttarget/EmailSendSteps.scala
@@ -4,7 +4,7 @@ import com.gu.util.ETConfig.ETSendId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.exacttarget.ETClient.ETClientDeps
 import com.gu.util.exacttarget.EmailSendSteps.logger
-import com.gu.util.exacttarget.SalesforceAuthenticate.{ETImpure, SalesforceAuth}
+import com.gu.util.exacttarget.ExactTargetAuthenticate.{ETImpure, SalesforceAuth}
 import com.gu.util.reader.Types._
 import com.gu.util.{ETConfig, Logging, Stage}
 import okhttp3.{MediaType, Request, RequestBody, Response}
@@ -130,7 +130,7 @@ object ETClient {
 
   def sendEmail(eTClientDeps: ETClientDeps)(emailRequest: EmailRequest): FailableOp[Unit] = {
     for {
-      auth <- SalesforceAuthenticate(ETImpure(eTClientDeps.response, eTClientDeps.etConfig))
+      auth <- ExactTargetAuthenticate(ETImpure(eTClientDeps.response, eTClientDeps.etConfig))
       req <- buildRequestET(ETReq(eTClientDeps.etConfig, auth))(emailRequest.etSendId)
       response <- sendEmailOp(eTClientDeps.response)(req, emailRequest.message)
       _ <- processResponse(response)
@@ -149,7 +149,7 @@ object ETClient {
   def buildRequestET(et: ETReq)(eTSendId: ETSendId): FailableOp[Request.Builder] = {
     val builder = new Request.Builder()
       .header("Authorization", s"Bearer ${et.salesforceAuth.accessToken}")
-      .url(s"${SalesforceAuthenticate.restEndpoint}/messageDefinitionSends/${eTSendId.id}/send")
+      .url(s"${ExactTargetAuthenticate.restEndpoint}/messageDefinitionSends/${eTSendId.id}/send")
     \/.right(builder): FailableOp[Request.Builder]
   }
 

--- a/src/main/scala/com/gu/util/exacttarget/ExactTargetAuthenticate.scala
+++ b/src/main/scala/com/gu/util/exacttarget/ExactTargetAuthenticate.scala
@@ -9,7 +9,7 @@ import play.api.libs.json.{JsPath, JsSuccess, Json, Reads}
 
 import scalaz.{-\/, \/-}
 
-object SalesforceAuthenticate extends Logging {
+object ExactTargetAuthenticate extends Logging {
 
   private val authEndpoint = "https://auth.exacttargetapis.com/v1/requestToken"
   val restEndpoint = "https://www.exacttargetapis.com/messaging/v1"


### PR DESCRIPTION
As part of the work to backfill identity ids into zuora and salesforce, we have a step to log in to salesforce and get a token.

This is the code to do that.

I have also renamed the ET login code as it was called SalesforceAuthenticate before!
I have also moved the effects tests from the manualTest folder into the correct place based on that the test is actually testing.  This means it's more likely that people will remember to add  both types of tests in future.

@pvighi @paulbrown1982 @lmath @jacobwinch take a look please!