### PR TITLE
update identity backfill handler to push identity id into SF

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,12 @@ val scalaSettings = Seq(
       .setPreference(DanglingCloseParenthesis, Force)
       .setPreference(SpacesAroundMultiImports, false)
       .setPreference(NewlineAtEndOfFile, true)
-  }
+  },libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.7" % "provided",
+
+    autoCompilerPlugins := true,
+
+addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7")/*,
+  scalacOptions += "-P:acyclic:force"*/
 )
 
 // fixme this whole file needs splitting down appropriately
@@ -54,7 +59,17 @@ val testSettings = inConfig(EffectsTest)(Defaults.testTasks) ++ inConfig(HealthC
 
 def all(theProject: Project) = theProject.settings(scalaSettings, testSettings).configs(EffectsTest, HealthCheckTest)
 
-lazy val zuora = all(project in file("lib/zuora")).settings(
+lazy val zuora = all(project in file("lib/zuora")).dependsOn(restHttp).settings(
+  libraryDependencies ++= Seq(
+    "com.squareup.okhttp3" % "okhttp" % "3.9.1",
+    "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
+    "org.scalaz" %% "scalaz-core" % "7.2.18",
+    "com.typesafe.play" %% "play-json" % "2.6.8",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  )
+)
+
+lazy val restHttp = all(project in file("lib/restHttp")).settings(
   libraryDependencies ++= Seq(
     "com.squareup.okhttp3" % "okhttp" % "3.9.1",
     "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",

--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,8 @@ val scalaSettings = Seq(
 
     autoCompilerPlugins := true,
 
-addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7")/*,
-  scalacOptions += "-P:acyclic:force"*/
+addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
+  scalacOptions += "-P:acyclic:force"
 )
 
 // fixme this whole file needs splitting down appropriately

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -5,17 +5,14 @@ import java.io.{InputStream, OutputStream}
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.identity.{GetByEmail, IdentityConfig}
-import com.gu.identityBackfill.Types._
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.{SFConfig, SalesforceAuth}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SFConfig
+import com.gu.identityBackfill.salesforce.{SalesforceAuthenticate, UpdateSalesforceIdentityId}
 import com.gu.identityBackfill.zuora.{AddIdentityIdToAccount, CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail}
 import com.gu.util.Config
+import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
-import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
 import play.api.libs.json.{Json, Reads}
-import scalaz.syntax.either._
 
 object Handler {
 
@@ -42,7 +39,7 @@ object Handler {
           CountZuoraAccountsForIdentityId(zuoraDeps),
           AddIdentityIdToAccount(zuoraDeps),
           () => SalesforceAuthenticate(rawEffects.response, config.stepsConfig.sfConfig),
-          UpdateSalesforceIdentityId.apply
+          UpdateSalesforceIdentityId(rawEffects.response)
         )
       }
     ApiGatewayHandler.default[StepsConfig](operation, lambdaIO).run((rawEffects.stage, rawEffects.s3Load(rawEffects.stage)))
@@ -50,8 +47,3 @@ object Handler {
 
 }
 
-object UpdateSalesforceIdentityId {
-  def apply(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
-    ApiGatewayResponse.internalServerError("todo").left
-  }
-}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -5,7 +5,7 @@ import java.io.{InputStream, OutputStream}
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.identity.{GetByEmail, IdentityConfig}
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SFConfig
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.identityBackfill.salesforce.{SalesforceAuthenticate, UpdateSalesforceIdentityId}
 import com.gu.identityBackfill.zuora.{AddIdentityIdToAccount, CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail}
 import com.gu.util.Config
@@ -25,7 +25,7 @@ object Handler {
   case class StepsConfig(
     identityConfig: IdentityConfig,
     zuoraRestConfig: ZuoraRestConfig,
-    sfConfig: SFConfig
+    sfConfig: SFAuthConfig
   )
   implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -71,17 +71,3 @@ object IdentityBackfillSteps extends Logging {
 
 }
 
-object Types {
-
-  case class EmailAddress(value: String)
-  case class IdentityId(value: String)
-  case class SFContactId(value: String)
-  case class AccountId(value: String)
-
-  case class ZuoraAccountIdentitySFContact(
-    accountId: AccountId,
-    identityId: Option[IdentityId],
-    sfContactId: SFContactId
-  )
-
-}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Types.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Types.scala
@@ -1,0 +1,16 @@
+package com.gu.identityBackfill
+
+object Types {
+
+  case class EmailAddress(value: String)
+  case class IdentityId(value: String)
+  case class SFContactId(value: String)
+  case class AccountId(value: String)
+
+  case class ZuoraAccountIdentitySFContact(
+    accountId: AccountId,
+    identityId: Option[IdentityId],
+    sfContactId: SFContactId
+  )
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticate.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticate.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{Json, Reads}
 
 object SalesforceAuthenticate extends Logging {
 
-  case class SFConfig(
+  case class SFAuthConfig(
     url: String,
     client_id: String,
     client_secret: String,
@@ -15,10 +15,11 @@ object SalesforceAuthenticate extends Logging {
     password: String,
     token: String
   )
-  object SFConfig {
-    implicit val reads: Reads[SFConfig] = Json.reads[SFConfig]
+  object SFAuthConfig {
+    implicit val reads: Reads[SFAuthConfig] = Json.reads[SFAuthConfig]
   }
 
+  // the WireResponse model is the same as the domain model, so keep a friendly name
   case class SalesforceAuth(access_token: String, instance_url: String)
   object SalesforceAuth {
     implicit val salesforceAuthReads: Reads[SalesforceAuth] = Json.reads[SalesforceAuth]
@@ -26,14 +27,14 @@ object SalesforceAuthenticate extends Logging {
 
   def apply(
     response: (Request => Response),
-    config: SFConfig
+    config: SFAuthConfig
   ): FailableOp[SalesforceAuth] = {
     val request: Request = buildAuthRequest(config)
     val body = response(request).body().string()
     Json.parse(body).validate[SalesforceAuth].toFailableOp("Failed to authenticate with Salesforce").withLogging("salesforce auth")
   }
 
-  private def buildAuthRequest(config: SFConfig) = {
+  private def buildAuthRequest(config: SFAuthConfig) = {
     import config._
     val builder =
       new Request.Builder()
@@ -47,4 +48,5 @@ object SalesforceAuthenticate extends Logging {
       .build()
     builder.post(formBody).build()
   }
+
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceRestRequestMaker.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceRestRequestMaker.scala
@@ -1,0 +1,23 @@
+package com.gu.identityBackfill.salesforce
+
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.util.Logging
+import com.gu.util.zuora.RestRequestMaker
+import okhttp3.{Request, Response}
+import scalaz.\/-
+
+object SalesforceRestRequestMaker extends Logging {
+
+  def apply(salesforceAuth: SalesforceAuth, response: Request => Response): RestRequestMaker.Requests = {
+    new RestRequestMaker.Requests(
+      Map(
+        "Authorization" -> s"Bearer ${salesforceAuth.access_token}"
+      ),
+      salesforceAuth.instance_url,
+      response,
+      _ => \/-(())
+    )
+  }
+
+}
+

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceRestRequestMaker.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceRestRequestMaker.scala
@@ -10,12 +10,10 @@ object SalesforceRestRequestMaker extends Logging {
 
   def apply(salesforceAuth: SalesforceAuth, response: Request => Response): RestRequestMaker.Requests = {
     new RestRequestMaker.Requests(
-      Map(
-        "Authorization" -> s"Bearer ${salesforceAuth.access_token}"
-      ),
-      salesforceAuth.instance_url,
-      response,
-      _ => \/-(())
+      headers = Map("Authorization" -> s"Bearer ${salesforceAuth.access_token}"),
+      baseUrl = salesforceAuth.instance_url,
+      getResponse = response,
+      jsonIsSuccessful = _ => \/-(())
     )
   }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
@@ -17,7 +17,6 @@ object UpdateSalesforceIdentityId {
   def apply(response: Request => Response)(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
     val patch = SalesforceRestRequestMaker(salesforceAuth, response).patch(WireRequest(identityId.value), s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
     patch.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
-    //    ApiGatewayResponse.internalServerError("todo").left
   }
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
@@ -1,0 +1,23 @@
+package com.gu.identityBackfill.salesforce
+
+import com.gu.identityBackfill.Types.{IdentityId, SFContactId}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.FailableOp
+import okhttp3.{Request, Response}
+import play.api.libs.json.Json
+
+object UpdateSalesforceIdentityId {
+
+  case class WireRequest(IdentityID__c: String)
+  object WireRequest {
+    implicit val writes = Json.writes[WireRequest]
+  }
+
+  def apply(response: Request => Response)(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
+    val patch = SalesforceRestRequestMaker(salesforceAuth, response).patch(WireRequest(identityId.value), s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
+    patch.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
+    //    ApiGatewayResponse.internalServerError("todo").left
+  }
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
@@ -10,9 +10,7 @@ import play.api.libs.json.Json
 object UpdateSalesforceIdentityId {
 
   case class WireRequest(IdentityID__c: String)
-  object WireRequest {
-    implicit val writes = Json.writes[WireRequest]
-  }
+  implicit val writes = Json.writes[WireRequest]
 
   def apply(response: Request => Response)(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] = {
     val patch = SalesforceRestRequestMaker(salesforceAuth, response).patch(WireRequest(identityId.value), s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/AddIdentityIdToAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/AddIdentityIdToAccount.scala
@@ -24,11 +24,9 @@ object AddIdentityIdToAccount {
   }
 
   def apply(zuoraDeps: ZuoraDeps)(accountId: AccountId, identityId: IdentityId): FailableOp[Unit] = {
-    val accounts = for {
-      accountsWithEmail <- ZuoraRestRequestMaker.put[ZuoraAccount, Unit](reqFromIdentityId(identityId), s"accounts/${accountId.value}")
-    } yield ()
+    val accounts = ZuoraRestRequestMaker(zuoraDeps).put[ZuoraAccount, Unit](reqFromIdentityId(identityId), s"accounts/${accountId.value}")
 
-    accounts.run.run(zuoraDeps).leftMap(e => ApiGatewayResponse.internalServerError(e.message))
+    accounts.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
   }
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/AddIdentityIdToAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/AddIdentityIdToAccount.scala
@@ -2,7 +2,6 @@ package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types
 import com.gu.identityBackfill.Types.{AccountId, IdentityId}
-import com.gu.identityBackfill.zuora.AddIdentityIdToAccount.WireModel.ZuoraAccount
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraReaders.unitReads
@@ -10,21 +9,16 @@ import com.gu.util.zuora.{ZuoraDeps, ZuoraRestRequestMaker}
 import play.api.libs.json.Json
 
 object AddIdentityIdToAccount {
-  object WireModel {
 
-    case class ZuoraAccount(
-      IdentityId__c: String
-    )
-    implicit val zaWrites = Json.writes[ZuoraAccount]
+  case class WireRequest(IdentityId__c: String)
+  implicit val writes = Json.writes[WireRequest]
 
-  }
-
-  def reqFromIdentityId(id: Types.IdentityId): ZuoraAccount = {
-    ZuoraAccount(id.value)
+  def reqFromIdentityId(id: Types.IdentityId): WireRequest = {
+    WireRequest(id.value)
   }
 
   def apply(zuoraDeps: ZuoraDeps)(accountId: AccountId, identityId: IdentityId): FailableOp[Unit] = {
-    val accounts = ZuoraRestRequestMaker(zuoraDeps).put[ZuoraAccount, Unit](reqFromIdentityId(identityId), s"accounts/${accountId.value}")
+    val accounts = ZuoraRestRequestMaker(zuoraDeps).put[WireRequest, Unit](reqFromIdentityId(identityId), s"accounts/${accountId.value}")
 
     accounts.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
   }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -1,7 +1,6 @@
 package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types.{AccountId, IdentityId}
-import com.gu.identityBackfill.zuora.CountZuoraAccountsForIdentityId.WireModel.ZuoraAccount
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraQuery}
@@ -10,18 +9,13 @@ import play.api.libs.json.Json
 import scalaz.ListT
 
 object CountZuoraAccountsForIdentityId {
-  object WireModel {
 
-    case class ZuoraAccount(
-      Id: String
-    )
-    implicit val zaReads = Json.reads[ZuoraAccount]
-
-  }
+  case class WireResponse(Id: String)
+  implicit val reads = Json.reads[WireResponse]
 
   def apply(zuoraDeps: ZuoraDeps)(identityId: IdentityId): FailableOp[Int] = {
     val accounts = for {
-      accountsWithEmail <- ListT(ZuoraQuery.getResults[ZuoraAccount](ZuoraQuery.Query(s"SELECT Id FROM Account where IdentityId__c='${identityId.value}'")).map(_.records))
+      accountsWithEmail <- ListT(ZuoraQuery.getResults[WireResponse](ZuoraQuery.Query(s"SELECT Id FROM Account where IdentityId__c='${identityId.value}'")).map(_.records))
     } yield AccountId(accountsWithEmail.Id)
 
     accounts.run.run.run(zuoraDeps).bimap(e => ApiGatewayResponse.internalServerError(e.message), l => l.size)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -1,7 +1,6 @@
 package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types._
-import com.gu.identityBackfill.zuora.GetZuoraAccountsForEmail.WireModel._
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.ZuoraQuery.Query
@@ -12,28 +11,24 @@ import scalaz.ListT
 
 object GetZuoraAccountsForEmail {
 
-  object WireModel {
-
-    case class ZuoraContact(Id: String)
-    implicit val zcReads = Json.reads[ZuoraContact]
-    case class ZuoraAccount(
-      Id: String,
-      IdentityId__c: Option[String],
-      sfContactId__c: String
-    )
-    implicit val zaReads = Json.reads[ZuoraAccount]
-
-  }
+  case class WireResponseContact(Id: String)
+  implicit val readsC = Json.reads[WireResponseContact]
+  case class WireResponseAccount(
+    Id: String,
+    IdentityId__c: Option[String],
+    sfContactId__c: String
+  )
+  implicit val readsA = Json.reads[WireResponseAccount]
 
   def apply(zuoraDeps: ZuoraDeps)(emailAddress: EmailAddress): FailableOp[List[ZuoraAccountIdentitySFContact]] = {
     val accounts = for {
       contactWithEmail <- {
         val contactQuery = Query(s"SELECT Id FROM Contact where WorkEmail='${emailAddress.value}'")
-        ListT(ZuoraQuery.getResults[ZuoraContact](contactQuery).map(_.records))
+        ListT(ZuoraQuery.getResults[WireResponseContact](contactQuery).map(_.records))
       }
       accountsWithEmail <- {
         val accountQuery = Query(s"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='${contactWithEmail.Id}'")
-        ListT(ZuoraQuery.getResults[ZuoraAccount](accountQuery).map(_.records))
+        ListT(ZuoraQuery.getResults[WireResponseAccount](accountQuery).map(_.records))
       }
     } yield ZuoraAccountIdentitySFContact(
       AccountId(accountsWithEmail.Id),

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -38,10 +38,11 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
 
     val expectedResponse =
       s"""
-         |{"statusCode":"500","headers":{"Content-Type":"application/json"},"body":"Failed to process event due to the following error: todo"}
+         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
          |""".stripMargin
     responseString jsonMatches expectedResponse
     requests should be(List(
+      BasicRequest("PATCH", "/services/data/v20.0/sobjects/Contact/00110000011AABBAAB", """{"IdentityID__c":"1234"}"""),
       BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""),
       BasicRequest("PUT", "/accounts/2c92a0fb4a38064e014a3f48f1663ad8", """{"IdentityId__c":"1234"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticateTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticateTest.scala
@@ -2,7 +2,7 @@ package com.gu.identityBackfill.salesforce
 
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.{SFConfig, SalesforceAuth}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.{SFAuthConfig, SalesforceAuth}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 
@@ -10,7 +10,7 @@ class SalesforceAuthenticateTest extends FlatSpec with Matchers {
 
   it should "get auth SF correctly" in {
     val effects = new TestingRawEffects(postResponses = SalesforceAuthenticateData.postResponses)
-    val auth = SalesforceAuthenticate(effects.response, SFConfig(
+    val auth = SalesforceAuthenticate(effects.response, SFAuthConfig(
       "https://sfurl.haha",
       "clientsfclient",
       "clientsecretsfsecret",

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/GetSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/GetSalesforceIdentityId.scala
@@ -1,0 +1,24 @@
+package com.gu.identityBackfill.salesforce.updateSFIdentityId
+
+import com.gu.identityBackfill.Types.{IdentityId, SFContactId}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.identityBackfill.salesforce.SalesforceRestRequestMaker
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.FailableOp
+import okhttp3.{Request, Response}
+import play.api.libs.json.Json
+
+object GetSalesforceIdentityId {
+
+  case class WireResult(IdentityID__c: String)
+  object WireResult {
+    implicit val reads = Json.reads[WireResult]
+  }
+
+  def apply(response: Request => Response)(salesforceAuth: SalesforceAuth)(sFContactId: SFContactId): FailableOp[IdentityId] = {
+    val get = SalesforceRestRequestMaker(salesforceAuth, response)
+    val id = get.get[WireResult](s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
+    id.bimap(e => ApiGatewayResponse.internalServerError(e.message), id => IdentityId(id.IdentityID__c))
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -1,0 +1,36 @@
+package com.gu.identityBackfill.salesforce.updateSFIdentityId
+
+import com.gu.effects.{ConfigLoad, RawEffects}
+import com.gu.identityBackfill.Handler.StepsConfig
+import com.gu.identityBackfill.Types.{IdentityId, SFContactId}
+import com.gu.identityBackfill.salesforce.{SalesforceAuthenticate, UpdateSalesforceIdentityId}
+import com.gu.test.EffectsTest
+import com.gu.util.{Config, Stage}
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+import scalaz.syntax.std.either._
+
+import scala.util.Random
+
+class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
+
+  it should "get auth SF correctly" taggedAs EffectsTest in {
+
+    val unique = s"${Random.nextInt(10000)}"
+    val testContact = SFContactId("003g000000LEwO6AAL")
+
+    val getRealResponse = RawEffects.createDefault.response
+    val actual = for {
+      configAttempt <- ConfigLoad.load(Stage("DEV")).toEither.disjunction
+      config <- Config.parseConfig[StepsConfig](configAttempt)
+      auth <- SalesforceAuthenticate(getRealResponse, config.stepsConfig.sfConfig)
+      authed = UpdateSalesforceIdentityId(getRealResponse)(auth) _
+      _ <- authed(testContact, IdentityId(unique))
+      identityId <- GetSalesforceIdentityId(getRealResponse)(auth)(testContact)
+    } yield identityId
+
+    actual should be(\/-(IdentityId(unique)))
+
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
@@ -1,0 +1,38 @@
+package com.gu.identityBackfill.salesforce.updateSFIdentityId
+
+import com.gu.effects.TestingRawEffects
+import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
+import com.gu.identityBackfill.Types.{IdentityId, SFContactId}
+import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+
+class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
+
+  it should "send the right request for update identity id" in {
+    val effects = new TestingRawEffects(postResponses = UpdateSalesforceIdentityIdData.postResponses)
+    val auth = UpdateSalesforceIdentityId(effects.response)(SalesforceAuth("accesstokentoken", "https://urlsf.hi")) _
+    val actual = auth(SFContactId("contactsf"), IdentityId("identityid"))
+    val expected = \/-(())
+    actual should be(expected)
+
+  }
+
+}
+
+object UpdateSalesforceIdentityIdData {
+
+  def postResponses: Map[POSTRequest, HTTPResponse] = {
+
+    Map(
+      POSTRequest(
+        "/services/data/v20.0/sobjects/Contact/contactsf",
+        """{"IdentityID__c":"identityid"}""",
+        "PATCH"
+      )
+        -> HTTPResponse(204, "")
+    )
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/AddIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/AddIdentityIdEffectsTest.scala
@@ -25,8 +25,9 @@ class AddIdentityIdEffectsTest extends FlatSpec with Matchers {
     val actual = for {
       configAttempt <- ConfigLoad.load(Stage("DEV")).toEither.disjunction
       config <- Config.parseConfig[StepsConfig](configAttempt)
-      _ <- AddIdentityIdToAccount(ZuoraDeps(RawEffects.createDefault.response, config.stepsConfig.zuoraRestConfig))(testAccount, IdentityId(unique))
-      identityId <- GetIdentityIdForAccount(ZuoraDeps(RawEffects.createDefault.response, config.stepsConfig.zuoraRestConfig))(testAccount)
+      zuoraDeps = ZuoraDeps(RawEffects.createDefault.response, config.stepsConfig.zuoraRestConfig)
+      _ <- AddIdentityIdToAccount(zuoraDeps)(testAccount, IdentityId(unique))
+      identityId <- GetIdentityIdForAccount(zuoraDeps)(testAccount)
     } yield {
       identityId
     }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/GetIdentityIdForAccount.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/addIdentityId/GetIdentityIdForAccount.scala
@@ -1,10 +1,10 @@
 package com.gu.identityBackfill.zuora.addIdentityId
 
 import com.gu.identityBackfill.Types.{AccountId, IdentityId}
+import com.gu.identityBackfill.zuora.addIdentityId.GetIdentityIdForAccount.WireModel.ZuoraAccount
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraRestRequestMaker}
-import com.gu.identityBackfill.zuora.addIdentityId.GetIdentityIdForAccount.WireModel.ZuoraAccount
 import play.api.libs.json.Json
 
 object GetIdentityIdForAccount {
@@ -24,10 +24,10 @@ object GetIdentityIdForAccount {
 
   def apply(zuoraDeps: ZuoraDeps)(accountId: AccountId): FailableOp[IdentityId] = {
     val accounts = for {
-      account <- ZuoraRestRequestMaker.get[ZuoraAccount](s"/accounts/${accountId.value}")
+      account <- ZuoraRestRequestMaker(zuoraDeps).get[ZuoraAccount](s"/accounts/${accountId.value}")
     } yield IdentityId(account.basicInfo.IdentityId__c)
 
-    accounts.run.run(zuoraDeps).leftMap(e => ApiGatewayResponse.internalServerError(e.message))
+    accounts.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
   }
 
 }

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -36,11 +36,11 @@ class TestingRawEffects(
       val presetResponse =
         if (req.method() == "GET") {
           responses.get(path) // todo should change to have GETs and POSTs in one list using a Sum type, and have a getUnusedRequests or something at the end to assert they were "used" by the code
-        } else if (req.method() == "POST") {
+        } else {
           val reqBody = body(req.body)
-          logger.info(s"HTTP POST body is $reqBody")
-          postResponses.get(POSTRequest(path, reqBody)).orElse(responses.get(path)) // use get response
-        } else responses.get(path)
+          logger.info(s"HTTP ${req.method} body is $reqBody")
+          postResponses.get(POSTRequest(path, reqBody, req.method)).orElse(responses.get(path)) // use get response
+        }
       val HTTPResponse(code, response) = presetResponse.getOrElse(
         HTTPResponse(defaultCode, """{"success": true}""")
       )
@@ -75,7 +75,7 @@ class TestingRawEffects(
 
 object TestingRawEffects {
 
-  case class POSTRequest(urlPathAndQuery: String, postBody: String)
+  case class POSTRequest(urlPathAndQuery: String, postBody: String, method: String = "POST")
   case class HTTPResponse(code: Int, body: String)
 
   case class BasicRequest(method: String, path: String, body: String)

--- a/lib/handler/src/main/scala/com/gu/util/Logging.scala
+++ b/lib/handler/src/main/scala/com/gu/util/Logging.scala
@@ -1,33 +1,9 @@
 package com.gu.util
 
-import com.gu.util.reader.Types.{WithDepsFailableOp, _}
 import org.apache.log4j.Logger
 
 trait Logging {
 
   val logger = Logger.getLogger(getClass.getName)
-
-  protected implicit class LogImplicit[A, D](configHttpFailableOp: WithDepsFailableOp[D, A]) {
-
-    // this is just a handy method to add logging to the end of any for comprehension
-    def withLogging(message: String): WithDepsFailableOp[D, A] = {
-
-      (configHttpFailableOp.run map {
-        _.withLogging(message)
-      }).toEitherT
-
-    }
-
-  }
-
-  protected implicit class LogImplicit2[A](op: A) {
-
-    // this is just a handy method to add logging to the end of any for comprehension
-    def withLogging(message: String): A = {
-      logger.info(s"$message: continued processing with value: $op")
-      op
-    }
-
-  }
 
 }

--- a/lib/restHttp/src/main/scala/com/gu/util/zuora/Logging.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/zuora/Logging.scala
@@ -1,26 +1,12 @@
-package com.gu.util.zuora.internal
+package com.gu.util.zuora
 
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.internal.Types._
 import org.apache.log4j.Logger
 import scalaz.{-\/, \/-}
 
 trait Logging { // in future maybe put logging into a context so the messages stack together like a stack trace
 
   val logger = Logger.getLogger(getClass.getName)
-
-  protected implicit class LogImplicit[A, D](configHttpFailableOp: WithDepsClientFailableOp[D, A]) {
-
-    // this is just a handy method to add logging to the end of any for comprehension
-    def withLogging(message: String): WithDepsClientFailableOp[D, A] = {
-
-      (configHttpFailableOp.run map {
-        _.withLogging(message)
-      }).toEitherT
-
-    }
-
-  }
 
   protected implicit class LogImplicit2[A](failableOp: ClientFailableOp[A]) {
 

--- a/lib/restHttp/src/main/scala/com/gu/util/zuora/Logging.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/zuora/Logging.scala
@@ -1,29 +1,9 @@
 package com.gu.util.zuora
 
-import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import org.apache.log4j.Logger
-import scalaz.{-\/, \/-}
 
 trait Logging { // in future maybe put logging into a context so the messages stack together like a stack trace
 
   val logger = Logger.getLogger(getClass.getName)
-
-  protected implicit class LogImplicit2[A](failableOp: ClientFailableOp[A]) {
-
-    // this is just a handy method to add logging to the end of any for comprehension
-    def withLogging(message: String): ClientFailableOp[A] = {
-
-      failableOp match {
-        case \/-(continuation) =>
-          logger.info(s"$message: continued processing with value: $continuation")
-          \/-(continuation)
-        case -\/(response) =>
-          logger.error(s"$message: returned here with value: $response")
-          -\/(response) // todo some day make an error object with a backtrace...
-      }
-
-    }
-
-  }
 
 }

--- a/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
@@ -33,6 +33,8 @@ object RestRequestMaker extends Logging {
   }
 
   class Requests(headers: Map[String, String], baseUrl: String, getResponse: Request => Response, jsonIsSuccessful: JsValue => ClientFailableOp[Unit]) {
+    // this can be a class and still be cohesive because every single method in the class needs every single value.  so we are effectively partially
+    // applying everything with these params
 
     def get[RESP: Reads](path: String): ClientFailableOp[RESP] =
       for {

--- a/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
@@ -32,12 +32,12 @@ object RestRequestMaker extends Logging {
     }
   }
 
-  class Requests(headers: Map[String, String], baseUrl: String, getResponse: Request => Response, zuoraIsSuccessful: JsValue => ClientFailableOp[Unit]) {
+  class Requests(headers: Map[String, String], baseUrl: String, getResponse: Request => Response, jsonIsSuccessful: JsValue => ClientFailableOp[Unit]) {
 
     def get[RESP: Reads](path: String): ClientFailableOp[RESP] =
       for {
         bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.get()), getResponse).map(Json.parse)
-        _ <- zuoraIsSuccessful(bodyAsJson)
+        _ <- jsonIsSuccessful(bodyAsJson)
         respModel <- toResult[RESP](bodyAsJson)
       } yield respModel
 
@@ -45,7 +45,7 @@ object RestRequestMaker extends Logging {
       val body = createBody[REQ](req)
       for {
         bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.put(body)), getResponse).map(Json.parse)
-        _ <- zuoraIsSuccessful(bodyAsJson)
+        _ <- jsonIsSuccessful(bodyAsJson)
         respModel <- toResult[RESP](bodyAsJson)
       } yield respModel
     }
@@ -54,7 +54,7 @@ object RestRequestMaker extends Logging {
       val body = createBody[REQ](req)
       for {
         bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.post(body)), getResponse).map(Json.parse)
-        _ <- if (skipCheck) \/-(()) else zuoraIsSuccessful(bodyAsJson)
+        _ <- if (skipCheck) \/-(()) else jsonIsSuccessful(bodyAsJson)
         respModel <- toResult[RESP](bodyAsJson)
       } yield respModel
     }

--- a/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
@@ -1,0 +1,90 @@
+package com.gu.util.zuora
+
+import okhttp3.{MediaType, Request, RequestBody, Response}
+import play.api.libs.json._
+import scalaz.Scalaz._
+import scalaz.{\/, \/-}
+
+object RestRequestMaker extends Logging {
+
+  case class ClientFail(message: String)
+
+  type ClientFailableOp[A] = ClientFail \/ A
+  def httpIsSuccessful(response: Response): ClientFailableOp[Unit] = {
+    if (response.isSuccessful) {
+      ().right
+    } else {
+      val body = response.body.string
+      val truncated = body.take(500) + (if (body.length > 500) "..." else "")
+      logger.error(s"Request to Zuora was unsuccessful, the response was: \n $response\n$truncated")
+      ClientFail("Request to Zuora was unsuccessful").left
+    }
+  }
+
+  def toResult[T: Reads](bodyAsJson: JsValue): ClientFailableOp[T] = {
+    bodyAsJson.validate[T] match {
+      case success: JsSuccess[T] =>
+        success.get.right
+      case error: JsError => {
+        logger.error(s"Failed to convert Zuora response to case case $error. Response body was: \n $bodyAsJson")
+        ClientFail("Error when converting Zuora response to case class").left
+      }
+    }
+  }
+
+  class Requests(headers: Map[String, String], baseUrl: String, getResponse: Request => Response, zuoraIsSuccessful: JsValue => ClientFailableOp[Unit]) {
+
+    def get[RESP: Reads](path: String): ClientFailableOp[RESP] =
+      for {
+        bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.get()), getResponse).map(Json.parse)
+        _ <- zuoraIsSuccessful(bodyAsJson)
+        respModel <- toResult[RESP](bodyAsJson)
+      } yield respModel
+
+    def put[REQ: Writes, RESP: Reads](req: REQ, path: String): ClientFailableOp[RESP] = {
+      val body = createBody[REQ](req)
+      for {
+        bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.put(body)), getResponse).map(Json.parse)
+        _ <- zuoraIsSuccessful(bodyAsJson)
+        respModel <- toResult[RESP](bodyAsJson)
+      } yield respModel
+    }
+
+    def post[REQ: Writes, RESP: Reads](req: REQ, path: String, skipCheck: Boolean = false): ClientFailableOp[RESP] = {
+      val body = createBody[REQ](req)
+      for {
+        bodyAsJson <- sendRequest(buildRequest(headers, baseUrl + path, _.post(body)), getResponse).map(Json.parse)
+        _ <- if (skipCheck) \/-(()) else zuoraIsSuccessful(bodyAsJson)
+        respModel <- toResult[RESP](bodyAsJson)
+      } yield respModel
+    }
+
+    def patch[REQ: Writes](req: REQ, path: String, skipCheck: Boolean = false): ClientFailableOp[Unit] = {
+      val body = createBody[REQ](req)
+      for {
+        _ <- sendRequest(buildRequest(headers, baseUrl + path, _.patch(body)), getResponse)
+      } yield ()
+    }
+
+  }
+
+  def sendRequest(request: Request, getResponse: Request => Response): ClientFailableOp[String] = {
+    logger.info(s"Attempting to do request")
+    val response = getResponse(request)
+    httpIsSuccessful(response).map(_ => response.body.string)
+  }
+
+  def buildRequest(headers: Map[String, String], url: String, addMethod: Request.Builder => Request.Builder): Request = {
+    val builder = headers.foldLeft(new Request.Builder())({
+      case (builder, (header, value)) =>
+        builder.addHeader(header, value)
+    })
+    val withUrl = builder.url(url)
+    addMethod(withUrl).build()
+  }
+
+  private def createBody[REQ: Writes](req: REQ) = {
+    RequestBody.create(MediaType.parse("application/json"), Json.toJson(req).toString)
+  }
+
+}

--- a/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
+++ b/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 import play.api.libs.json._
 import scalaz.{-\/, \/-}
 
-class RestServiceTest extends AsyncFlatSpec {
+class RestRequestMakerTest extends AsyncFlatSpec {
 
   case class BasicAccountInfo(id: String)
   implicit val read = Json.reads[BasicAccountInfo]
@@ -16,20 +16,12 @@ class RestServiceTest extends AsyncFlatSpec {
     override def reads(json: JsValue): JsResult[Unit] = JsSuccess(())
   }
 
-  //  "buildRequest" should "set the apiSecretAccessKey header correctly" in {
-  //    val request = ZuoraRestRequestMaker.buildRequest(fakeZConfig)("route-test").get.build()
-  //    assert(request.header("apiSecretAccessKey") == "fakePassword")
-  //  }
-  //
-  //  "buildRequest" should "set the apiAccessKeyId header correctly" in {
-  //    val request = ZuoraRestRequestMaker.buildRequest(fakeZConfig)("route-test").get.build()
-  //    assert(request.header("apiAccessKeyId") == "fakeUser")
-  //  }
-  //
-  //  "buildRequest" should "construct an appropriate url" in {
-  //    val request = ZuoraRestRequestMaker.buildRequest(fakeZConfig)("route-test").get.build()
-  //    assert(request.url.toString == "https://www.test.com/route-test")
-  //  }
+  "buildRequest" should "set the headers and url correctly" in {
+    val hdr = Map("name" -> "value")
+    val request = RestRequestMaker.buildRequest(hdr, "https://www.test.com/route-test", _.get())
+    assert(request.header("apiSecretAccessKey") == "fakePassword")
+    assert(request.url.toString == "https://www.test.com/route-test")
+  }
 
   // Mocks and helper functions for handleFutureResponse testing
   val dummyJson = Json.parse(

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/Zuora.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/Zuora.scala
@@ -7,28 +7,9 @@ import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraReaders._
 import com.gu.util.zuora.internal.Types._
-import okhttp3.{Request, Response}
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
 import scalaz.Reader
-
-case class ZuoraRestConfig(
-  baseUrl: String,
-  username: String,
-  password: String
-)
-
-object ZuoraRestConfig {
-
-  implicit val zuoraConfigReads: Reads[ZuoraRestConfig] = (
-    (JsPath \ "baseUrl").read[String] and
-    (JsPath \ "username").read[String] and
-    (JsPath \ "password").read[String]
-  )(ZuoraRestConfig.apply _)
-
-}
-
-case class ZuoraDeps(response: Request => Response, config: ZuoraRestConfig)
 
 object ZuoraGetAccountSummary {
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraDeps.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraDeps.scala
@@ -1,0 +1,23 @@
+package com.gu.util.zuora
+
+import okhttp3.{Request, Response}
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+
+case class ZuoraDeps(response: Request => Response, config: ZuoraRestConfig)
+
+case class ZuoraRestConfig(
+  baseUrl: String,
+  username: String,
+  password: String
+)
+
+object ZuoraRestConfig {
+
+  implicit val zuoraConfigReads: Reads[ZuoraRestConfig] = (
+    (JsPath \ "baseUrl").read[String] and
+    (JsPath \ "username").read[String] and
+    (JsPath \ "password").read[String]
+  )(ZuoraRestConfig.apply _)
+
+}

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,9 +1,10 @@
 package com.gu.util.zuora
 
-import com.gu.util.zuora.internal.Types.WithDepsClientFailableOp
-import com.gu.util.zuora.ZuoraRestRequestMaker.post
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
+import com.gu.util.zuora.internal.Types.{WithDepsClientFailableOp, _}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import scalaz.Reader
 
 object ZuoraQuery {
 
@@ -31,6 +32,6 @@ object ZuoraQuery {
 
   // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
   def getResults[QUERYRECORD: Reads](query: Query): WithDepsClientFailableOp[ZuoraDeps, QueryResult[QUERYRECORD]] =
-    post(query, s"action/query")
+    Reader { zuoraDeps: ZuoraDeps => ZuoraRestRequestMaker(zuoraDeps).post(query, s"action/query", true): ClientFailableOp[QueryResult[QUERYRECORD]] }.toEitherT
 
 }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -1,47 +1,26 @@
 package com.gu.util.zuora
 
-import com.gu.util.zuora.internal.Types._
-import com.gu.util.zuora.internal.Types.ClientFailableOp
+import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp}
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraReaders._
-import com.gu.util.zuora.internal.{ClientFail, Logging}
-import okhttp3._
 import play.api.libs.json._
-
 import scalaz.Scalaz._
-import scalaz.{Reader, \/}
 
 object ZuoraRestRequestMaker extends Logging {
 
-  def convertResponseToCaseClass[T: Reads](response: Response): ClientFail \/ T = {
-    for {
-      _ <- httpIsSuccessful(response)
-      bodyAsJson = Json.parse(response.body.string)
-      _ <- zuoraIsSuccessful(bodyAsJson)
-      result <- toResult[T](bodyAsJson)
-    } yield result
-
+  def apply(zuoraDeps: ZuoraDeps): RestRequestMaker.Requests = {
+    import zuoraDeps._
+    new RestRequestMaker.Requests(
+      Map(
+        "apiSecretAccessKey" -> config.password,
+        "apiAccessKeyId" -> config.username
+      ),
+      config.baseUrl + "/", //TODO shouldn't have to add it
+      response,
+      zuoraIsSuccessful
+    )
   }
 
-  def convertResponseToCaseClassNoSuccessField[T: Reads](response: Response): ClientFail \/ T = {
-    for {
-      _ <- httpIsSuccessful(response)
-      bodyAsJson = Json.parse(response.body.string)
-      result <- toResult[T](bodyAsJson)
-    } yield result
-
-  }
-
-  def httpIsSuccessful(response: Response): ClientFailableOp[Unit] = {
-    if (response.isSuccessful) {
-      ().right
-    } else {
-      val body = response.body.string
-      val truncated = body.take(500) + (if (body.length > 500) "..." else "")
-      logger.error(s"Request to Zuora was unsuccessful, the response was: \n $response\n$truncated")
-      ClientFail("Request to Zuora was unsuccessful").left
-    }
-  }
   def zuoraIsSuccessful(bodyAsJson: JsValue): ClientFailableOp[Unit] = {
 
     bodyAsJson.validate[ZuoraCommonFields] match {
@@ -56,47 +35,6 @@ object ZuoraRestRequestMaker extends Logging {
       }
     }
   }
-  def toResult[T: Reads](bodyAsJson: JsValue): ClientFailableOp[T] = {
-    bodyAsJson.validate[T] match {
-      case success: JsSuccess[T] =>
-        success.get.right
-      case error: JsError => {
-        logger.error(s"Failed to convert Zuora response to case case $error. Response body was: \n $bodyAsJson")
-        ClientFail("Error when converting Zuora response to case class").left
-      }
-    }
-  }
-
-  def get[RESP: Reads](path: String): WithDepsClientFailableOp[ZuoraDeps, RESP] =
-    Reader { zuoraDeps: ZuoraDeps =>
-      val request = buildRequest(zuoraDeps.config)(path).get().build()
-      logger.info(s"Getting $path from Zuora")
-      val response = zuoraDeps.response(request)
-      convertResponseToCaseClass[RESP](response)
-    }.toEitherT
-
-  def put[REQ: Writes, RESP: Reads](req: REQ, path: String): WithDepsClientFailableOp[ZuoraDeps, RESP] =
-    Reader { zuoraDeps: ZuoraDeps =>
-      val body = RequestBody.create(MediaType.parse("application/json"), Json.toJson(req).toString)
-      val request = buildRequest(zuoraDeps.config)(path).put(body).build()
-      logger.info(s"Attempting to PUT $path with the following command: $req")
-      val response = zuoraDeps.response(request)
-      convertResponseToCaseClass[RESP](response)
-    }.toEitherT
-
-  def post[REQ: Writes, RESP: Reads](req: REQ, path: String): WithDepsClientFailableOp[ZuoraDeps, RESP] =
-    Reader { zuoraDeps: ZuoraDeps =>
-      val body = RequestBody.create(MediaType.parse("application/json"), Json.toJson(req).toString)
-      val request = buildRequest(zuoraDeps.config)(path).post(body).build()
-      logger.info(s"Attempting to POST $path with the following command: $req")
-      val response = zuoraDeps.response(request)
-      convertResponseToCaseClassNoSuccessField[RESP](response)
-    }.toEitherT
-
-  def buildRequest(config: ZuoraRestConfig)(route: String): Request.Builder =
-    new Request.Builder()
-      .addHeader("apiSecretAccessKey", config.password)
-      .addHeader("apiAccessKeyId", config.username)
-      .url(s"${config.baseUrl}/$route")
 
 }
+

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -11,13 +11,13 @@ object ZuoraRestRequestMaker extends Logging {
   def apply(zuoraDeps: ZuoraDeps): RestRequestMaker.Requests = {
     import zuoraDeps._
     new RestRequestMaker.Requests(
-      Map(
+      headers = Map(
         "apiSecretAccessKey" -> config.password,
         "apiAccessKeyId" -> config.username
       ),
-      config.baseUrl + "/", //TODO shouldn't have to add it
-      response,
-      zuoraIsSuccessful
+      baseUrl = config.baseUrl + "/", //TODO shouldn't have to add it
+      getResponse = response,
+      jsonIsSuccessful = zuoraIsSuccessful
     )
   }
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/internal/Types.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/internal/Types.scala
@@ -1,10 +1,10 @@
 package com.gu.util.zuora.internal
 
-import scalaz.{EitherT, Reader, \/}
+import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp}
+import scalaz.{EitherT, Reader}
 
 object Types {
 
-  type ClientFailableOp[A] = ClientFail \/ A
   // EitherT's first type parameter is a higher kinded type with single arity
   // unfortunately we want to stack a reader into it, which takes two type parameters
   // we can get around this by using a type lambda to define a new anonymous type constructor with 1 arity (the other parameter comes from outside)
@@ -21,5 +21,3 @@ object Types {
   }
 
 }
-
-case class ClientFail(message: String)

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -14,21 +14,6 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
 
   val fakeZConfig = ZuoraRestConfig("https://www.test.com", "fakeUser", "fakePassword")
 
-  //  "buildRequest" should "set the apiSecretAccessKey header correctly" in {
-  //    val request = ZuoraRestRequestMaker.buildRequest(fakeZConfig)("route-test").get.build()
-  //    assert(request.header("apiSecretAccessKey") == "fakePassword")
-  //  }
-  //
-  //  "buildRequest" should "set the apiAccessKeyId header correctly" in {
-  //    val request = ZuoraRestRequestMaker.buildRequest(fakeZConfig)("route-test").get.build()
-  //    assert(request.header("apiAccessKeyId") == "fakeUser")
-  //  }
-  //
-  //  "buildRequest" should "construct an appropriate url" in {
-  //    val request = ZuoraRestRequestMaker.buildRequest(fakeZConfig)("route-test").get.build()
-  //    assert(request.url.toString == "https://www.test.com/route-test")
-  //  }
-
   // Mocks and helper functions for handleFutureResponse testing
   val dummyJson = Json.parse(
     """{

--- a/src/main/scala/com/gu/autoCancel/AutoCancel.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancel.scala
@@ -1,11 +1,11 @@
 package com.gu.autoCancel
 
-import com.gu.util.{Logging, ZuoraToApiGateway}
-import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.ZuoraModels.SubscriptionId
 import java.time.LocalDate
 
+import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraModels.SubscriptionId
 import com.gu.util.zuora.{ZuoraCancelSubscription, ZuoraDeps, ZuoraDisableAutoPay, ZuoraUpdateCancellationReason}
+import com.gu.util.{Logging, ZuoraToApiGateway}
 
 object AutoCancel extends Logging {
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelInputFilter.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelInputFilter.scala
@@ -2,7 +2,7 @@ package com.gu.autoCancel
 
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.noActionRequired
-import com.gu.util.reader.Types.FailableOp
+import com.gu.util.reader.Types._
 
 import scalaz.{-\/, \/-}
 

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -12,12 +12,11 @@ import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget.{EmailRequest, EmailSendSteps}
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
-import com.gu.util.zuora.internal.Types.ClientFailableOp
 import com.gu.util.zuora.{ZuoraDeps, ZuoraGetInvoiceTransactions}
 import okhttp3.{Request, Response}
 import play.api.libs.json.Json
-
 import scalaz.syntax.std.option._
 import scalaz.{-\/, \/-}
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -3,6 +3,7 @@ package com.gu.stripeCustomerSourceUpdated
 import com.gu.stripeCustomerSourceUpdated.StripeRequestSignatureChecker.verifyRequest
 import com.gu.stripeCustomerSourceUpdated.zuora.{CreatePaymentMethod, SetDefaultPaymentMethod, ZuoraQueryPaymentMethod}
 import com.gu.util._
+import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse, StripeAccount}

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/StripeSignatureChecker.scala
@@ -1,8 +1,7 @@
 package com.gu.stripeCustomerSourceUpdated
 
-import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.logger
 import com.gu.util.apigateway.StripeAccount
-import com.gu.util.{StripeConfig, StripeSecretKey}
+import com.gu.util.{Logging, StripeConfig, StripeSecretKey}
 import com.stripe.exception.SignatureVerificationException
 import com.stripe.net.Webhook.Signature
 
@@ -10,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 
 case class StripeDeps(config: StripeConfig, signatureChecker: SignatureChecker)
 
-object StripeRequestSignatureChecker {
+object StripeRequestSignatureChecker extends Logging {
   def verifyRequest(stripeDeps: StripeDeps, headers: Map[String, String], payload: String, stripeAccount: Option[StripeAccount]): Boolean = {
     val signatureHeader: Option[String] = headers.get("Stripe-Signature")
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/CreatePaymentMethod.scala
@@ -2,11 +2,11 @@ package com.gu.stripeCustomerSourceUpdated.zuora
 
 import com.gu.stripeCustomerSourceUpdated._
 import com.gu.util.ZuoraToApiGateway
-import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraAccount.{AccountId, NumConsecutiveFailures, PaymentMethodId}
-import com.gu.util.zuora.ZuoraDeps
-import com.gu.util.zuora.ZuoraRestRequestMaker.post
+import com.gu.util.zuora.{ZuoraDeps, ZuoraRestRequestMaker}
 import play.api.libs.json.{JsPath, Json, Reads, Writes}
+import scalaz.Reader
 
 object CreatePaymentMethod {
 
@@ -52,6 +52,6 @@ object CreatePaymentMethod {
   case class CreatePaymentMethodResult(id: PaymentMethodId)
 
   def createPaymentMethod(request: CreateStripePaymentMethod): WithDepsFailableOp[ZuoraDeps, CreatePaymentMethodResult] =
-    post[CreateStripePaymentMethod, CreatePaymentMethodResult](request, s"object/payment-method").leftMap(ZuoraToApiGateway.fromClientFail)
+    Reader { zuoraDeps: ZuoraDeps => ZuoraRestRequestMaker(zuoraDeps).post[CreateStripePaymentMethod, CreatePaymentMethodResult](request, s"object/payment-method").leftMap(ZuoraToApiGateway.fromClientFail) }.toEitherT
 
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/CreatePaymentMethod.scala
@@ -31,6 +31,7 @@ object CreatePaymentMethod {
 
   }
 
+  // FIXME create WireRequest/Response and converter layer to replace the custom writes and reads
   implicit val writes = new Writes[CreateStripePaymentMethod] {
     def writes(command: CreateStripePaymentMethod) = Json.obj(
       "AccountId" -> command.accountId.value,

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/SetDefaultPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/SetDefaultPaymentMethod.scala
@@ -1,12 +1,12 @@
 package com.gu.stripeCustomerSourceUpdated.zuora
 
 import com.gu.util.ZuoraToApiGateway
-import com.gu.util.reader.Types.WithDepsFailableOp
+import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraAccount.{AccountId, PaymentMethodId}
-import com.gu.util.zuora.ZuoraDeps
+import com.gu.util.zuora.{ZuoraDeps, ZuoraRestRequestMaker}
 import com.gu.util.zuora.ZuoraReaders.unitReads
-import com.gu.util.zuora.ZuoraRestRequestMaker.put
 import play.api.libs.json.{Json, Writes}
+import scalaz.Reader
 
 object SetDefaultPaymentMethod {
 
@@ -19,6 +19,6 @@ object SetDefaultPaymentMethod {
   }
 
   def setDefaultPaymentMethod(accountId: AccountId, paymentMethodId: PaymentMethodId): WithDepsFailableOp[ZuoraDeps, Unit] =
-    put(SetDefaultPaymentMethod(paymentMethodId), s"object/account/${accountId.value}").leftMap(ZuoraToApiGateway.fromClientFail)
+    Reader { zuoraDeps: ZuoraDeps => ZuoraRestRequestMaker(zuoraDeps).put(SetDefaultPaymentMethod(paymentMethodId), s"object/account/${accountId.value}").leftMap(ZuoraToApiGateway.fromClientFail) }.toEitherT
 
 }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/SetDefaultPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/SetDefaultPaymentMethod.scala
@@ -12,6 +12,7 @@ object SetDefaultPaymentMethod {
 
   case class SetDefaultPaymentMethod(paymentMethodId: PaymentMethodId)
 
+  // FIXME create WireRequest and converter layer to replace the custom writes
   implicit val writes = new Writes[SetDefaultPaymentMethod] {
     def writes(subscriptionUpdate: SetDefaultPaymentMethod) = Json.obj(
       "DefaultPaymentMethodId" -> subscriptionUpdate.paymentMethodId

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
@@ -18,6 +18,7 @@ object ZuoraQueryPaymentMethod extends Logging {
     AccountId: AccountId,
     NumConsecutiveFailures: NumConsecutiveFailures
   )
+  // FIXME create WireRequest/Response and converter layer to replace the custom writes and reads
   implicit val QueryRecordR: Format[PaymentMethodFields] = Json.format[PaymentMethodFields]
 
   case class AccountPaymentMethodIds(accountId: AccountId, paymentMethods: NonEmptyList[PaymentMethodFields])

--- a/src/main/scala/com/gu/util/ZuoraToApiGateway.scala
+++ b/src/main/scala/com/gu/util/ZuoraToApiGateway.scala
@@ -2,7 +2,7 @@ package com.gu.util
 
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.zuora.internal.ClientFail
+import com.gu.util.zuora.RestRequestMaker.ClientFail
 
 object ZuoraToApiGateway {
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -7,8 +7,9 @@ import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.stripeCustomerSourceUpdated.{StripeDeps, StripeSignatureChecker}
 import com.gu.util.ETConfig.{ETSendId, ETSendIds}
 import com.gu.util._
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice}
-import com.gu.util.zuora.internal.Types.{ClientFailableOp, WithDepsClientFailableOp, _}
+import com.gu.util.zuora.internal.Types._
 import com.gu.util.zuora.{ZuoraDeps, ZuoraRestConfig}
 import org.scalatest.Matchers
 import play.api.libs.json.Json

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -4,6 +4,7 @@ import com.gu.effects.{ConfigLoad, RawEffects}
 import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
+import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraRestConfig
 import com.gu.util.{Config, Logging, Stage}
 import scalaz.syntax.std.either._


### PR DESCRIPTION
This is part of the code to link existing identity accounts into zuora/sf subs.

This PR adds the final step to add the identity id into salesforce.

I have split the zuora rest request maker into a rest request maker and reused most of the code for the SF one (as they are both using http/json)  I also took that chance to get rid of some of the Reader monad

I can deploy to code successfully and the healthchecks are passing

@paulbrown1982 @lmath comments please