### PR TITLE
return friendly message if identity account not round

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticate.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/SalesforceAuthenticate.scala
@@ -31,7 +31,7 @@ object SalesforceAuthenticate extends Logging {
   ): FailableOp[SalesforceAuth] = {
     val request: Request = buildAuthRequest(config)
     val body = response(request).body().string()
-    Json.parse(body).validate[SalesforceAuth].toFailableOp("Failed to authenticate with Salesforce").withLogging("salesforce auth")
+    Json.parse(body).validate[SalesforceAuth].toFailableOp("Failed to authenticate with Salesforce").withLogging(s"salesforce auth for $body")
   }
 
   private def buildAuthRequest(config: SFAuthConfig) = {

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -2,10 +2,10 @@ package com.gu.identity
 
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.HTTPResponse
+import com.gu.identity.GetByEmail.NotFound
 import com.gu.identityBackfill.Types.{EmailAddress, IdentityId}
 import org.scalatest.{FlatSpec, Matchers}
-
-import scalaz.{\/, \/-}
+import scalaz.{-\/, \/, \/-}
 
 class GetByEmailTest extends FlatSpec with Matchers {
 
@@ -17,6 +17,16 @@ class GetByEmailTest extends FlatSpec with Matchers {
     val actual: \/[GetByEmail.ApiError, IdentityId] = GetByEmail(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken"))(EmailAddress("email@address"))
 
     actual should be(\/-(IdentityId("1234")))
+  }
+
+  it should "get not found" in {
+    val testingRawEffects = new TestingRawEffects(
+      responses = NotFoundTestData.responses
+    )
+
+    val actual: \/[GetByEmail.ApiError, IdentityId] = GetByEmail(testingRawEffects.rawEffects.response, IdentityConfig("http://baseurl", "apitoken"))(EmailAddress("email@address"))
+
+    actual should be(-\/(NotFound))
   }
 
 }
@@ -43,6 +53,26 @@ object TestData {
       |            "usernameLowerCase": "johnduffell2"
       |        }
       |    }
+      |}
+    """.stripMargin
+
+}
+
+object NotFoundTestData {
+
+  def responses: Map[String, HTTPResponse] = Map(
+    "/user?emailAddress=email@address" -> HTTPResponse(404, TestData.dummyIdentityResponse)
+  )
+  val dummyIdentityResponse: String =
+    """
+      |{
+      |    "status": "error",
+      |    "errors": [
+      |        {
+      |            "message": "Not found",
+      |            "description": "Resource not found"
+      |        }
+      |    ]
       |}
     """.stripMargin
 


### PR DESCRIPTION
when identity backfilling, the first check is does that email user have an identity account.

At present, the lambda returns a 500 error containing `Failed to process event due to the following error: ApiError(failed http with 404)`

This turns it into a 404 explaining "user doesn't have identity"
![image](https://user-images.githubusercontent.com/7304387/38102134-43e58d66-337a-11e8-9f44-f5c7c41b1521.png)


@paulbrown1982 @lmath just a small fix