### PR TITLE
add code coverage to the build

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,7 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 
 resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.12")


### PR DESCRIPTION
I have added coverage plugin so when we do a build it should do code coverage as well.

Although code coverage is a terrible metric (as you can have great coverage and bad tests, or you can have lower coverage and everything be robust and split up well) but at least it should keep things in mind.  It also won't cover the effectsTest:test because they need you to get a membership janus credential before you can run.

You can look at the codacy output here, I'm sure we need to tweak things to make it reflect what we're more interested in, also ignore some issues we don't care about e.g. field names on data models set up by zuora.
https://app.codacy.com/app/johnduffell/zuora-auto-cancel/dashboard

@pvighi @lmath @jacobwinch @paulbrown1982 