### PR TITLE
Revert "add code coverage to the build"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,3 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 
 resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-
-addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.12")


### PR DESCRIPTION
Reverts guardian/zuora-auto-cancel#60

java.lang.ExceptionInInitializerError: java.lang.ExceptionInInitializerError
java.lang.ExceptionInInitializerError
at com.gu.identityBackfill.Handler$.<init>(Handler.scala:30)
at com.gu.identityBackfill.Handler$.<clinit>(Handler.scala)
at com.gu.identityBackfill.Handler.apply(Handler.scala)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
Caused by: java.io.FileNotFoundException: /opt/teamcity/buildAgent/work/68c0bc54e533b89e/lib/zuora/target/scala-2.12/scoverage-data/scoverage.measurements.1 (No such file or directory)
at java.io.FileOutputStream.open0(Native Method)
at java.io.FileOutputStream.open(FileOutputStream.java:270)
at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
at java.io.FileWriter.<init>(FileWriter.java:107)
at scoverage.Invoker$.$anonfun$invoked$1(Invoker.scala:42)
at scala.collection.concurrent.TrieMap.getOrElseUpdate(TrieMap.scala:903)
at scoverage.Invoker$.invoked(Invoker.scala:42)
at com.gu.util.zuora.ZuoraRestConfig$.<init>(ZuoraDeps.scala:21)
at com.gu.util.zuora.ZuoraRestConfig$.<clinit>(ZuoraDeps.scala)
... 7 more