### PR TITLE
[WIP]: Override jackson-databind version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ These tests do not (YET!) run automatically.
 If you deploy to PROD without checking this, the lambdas will deploy but not actually work.
 
 You can run the tests that hit external services by running `sbt effectsTest:test`.
-This would need suitable AWS credentials to get hold of the config.
-
+This would need suitable AWS credentials to get hold of the config as well as config file under .aws with the content:
+```
+[default]
+region = eu-west-1
+```
 You can tag your integration new tests with `taggedAs EffectsTest`.  This ignores them from the standard `sbt test`.
 
 ### Testing post deployment to CODE/PROD

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,8 @@ lazy val zuora = all(project in file("lib/zuora")).dependsOn(restHttp).settings(
     "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
     "org.scalaz" %% "scalaz-core" % "7.2.18",
     "com.typesafe.play" %% "play-json" % "2.6.9",
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
   )
 )
 
@@ -97,7 +98,8 @@ lazy val effects = all(project in file("lib/effects")).dependsOn(handler).settin
     "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
     "org.scalaz" %% "scalaz-core" % "7.2.18",
     "com.typesafe.play" %% "play-json" % "2.6.9",
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
   )
 )
 
@@ -139,7 +141,8 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.18",
   "com.typesafe.play" %% "play-json" % "2.6.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.stripe" % "stripe-java" % "5.28.0"
+  "com.stripe" % "stripe-java" % "5.28.0",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
 )
 
 initialize := {

--- a/handlers/identity-backfill/build.sbt
+++ b/handlers/identity-backfill/build.sbt
@@ -20,5 +20,6 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "3.9.1",
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.typesafe.play" %% "play-json" % "2.6.9",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.12")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
Vulnerability: CVE-2017-7525 

It's a tricky one as it's affecting jackson-databind as a separate lib and they have solved it as a micro-patch, better explained here:

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8

_At this point branch is not open any more (that is, no more full patch releases are planned). As usual, micro-patches possible after this point for individual components: these may be made for critical security or stability issues.
Following micro-patches have been released:
2.8.11.1 (11-Feb-2018)
#1872: `NullPointerException` in `SubTypeValidator.validateSubType` when
  validating Spring interface
 (reported by Rob W)
#1899: Another two gadgets to exploit default typing issue in jackson-databind
 (reported by OneSourceCat@github)
#1931: Two more `c3p0` gadgets to exploit default typing issue_

Into the PlayFramework scope is affecting:
play
play-json
	jackson-datatype-jsr310 - DEPRECATED last commit: Feb 4, 2017 
	jackson-datatype-jdk8 - DEPRECATED last commit: Nov 3, 2016

Both jackson-datatype-jsr310 and jackson-datatype-jdk8 are deprecated and there is not an updated version including the jackson-databind fix.

For play and play-json looks like they will include the new version of jackson-databind (full jackson dependencies) for the next play version (2.7).

Therefore the best way of removing the vulnerability is overriding jackson-databind as it's including just three minor changes onto a minor release, which we can assume it will 100% compatible with the other dependencies.
