### PR TITLE
make 5xx alarm less sensitive

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -270,9 +270,9 @@ Resources:
         EvaluationPeriods: 1
         MetricName: 5XXError
         Namespace: AWS/ApiGateway
-        Period: 3600
+        Period: 300
         Statistic: Sum
-        Threshold: 5
+        Threshold: 10
         TreatMissingData: notBreaching
 
     4xxApiAlarm:


### PR DESCRIPTION
At the moment we are alarming due to timeouts in ET which happen randomly.
This isn't a real timeout, it seems like the request is being lost.
As the level is generally not too high I'm turning the alarm down for now.
@svillafe this should be OK for now 
cc @jacobwinch @pvighi @paulbrown1982 

@mario-galic if you have any idea about the ET auth failing to respond from your work on sending the repermissioning emails, that might be useful for us here!