### PR TITLE
Allow "effects" tests to run in intellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ If there's any code in either that you feel could be unit tested, it should prob
 ## Quality matters
 The testing story is not perfect at the moment!  You are responsible for getting your own changes into production safely.  However there are a few common situations you will encounter:
 
+If you just run `sbt test` it will try to run all the tests, including the tagged ones.  You may want `sbt local:test`
+
 ### code only changes
-You can be confident when making code only changes.  Run `sbt test` to run code only tests (ignores other tests).
+You can be confident when making code only changes.  Run `sbt local:test` to run code only tests (ignores other tests).
 They will automatically run on your build of your branch and when you merge to master.
 
 Add your new tests in the normal way, and don't forget to "Run with Coverage" in IntelliJ.
@@ -48,13 +50,13 @@ Add your new tests in the normal way, and don't forget to "Run with Coverage" in
 These tests do not (YET!) run automatically.
 If you deploy to PROD without checking this, the lambdas will deploy but not actually work.
 
-You can run the tests that hit external services by running `sbt effectsTest:test`.
+You can run the tests that hit external services by running `sbt effects:test`.
 This would need suitable AWS credentials to get hold of the config as well as config file under .aws with the content:
 ```
 [default]
 region = eu-west-1
 ```
-You can tag your integration new tests with `taggedAs EffectsTest`.  This ignores them from the standard `sbt test`.
+You can tag your integration new tests with `taggedAs EffectsTest`.  This ignores them from the standard `sbt local:test`.
 
 ### Testing post deployment to CODE/PROD
 After deploy you can't relax until you know an HTTP request will hit your lambda, and that your lambda can access any external services.

--- a/build.sbt
+++ b/build.sbt
@@ -38,25 +38,23 @@ addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
 
 // fixme this whole file needs splitting down appropriately
 
-lazy val EffectsTest = config("effectsTest") extend(Test) describedAs("run the edge tests")
+lazy val LocalTest = config("local") extend(Test) describedAs("run the unit/local tests")
+lazy val EffectsTest = config("effects") extend(Test) describedAs("run the edge tests")
 lazy val HealthCheckTest = config("healthCheck") extend(Test) describedAs("run the health checks against prod/code")
-val testSettings = inConfig(EffectsTest)(Defaults.testTasks) ++ inConfig(HealthCheckTest)(Defaults.testTasks) ++ Seq(
-  testOptions in Test += Tests.Argument("-l", "com.gu.test.EffectsTest"),
-  testOptions in Test += Tests.Argument("-l", "com.gu.test.HealthCheck"),
+val testSettings =
+  inConfig(EffectsTest)(Defaults.testTasks) ++
+    inConfig(HealthCheckTest)(Defaults.testTasks) ++
+    inConfig(LocalTest)(Defaults.testTasks) ++
+    Seq(
+      testOptions in LocalTest += Tests.Argument("-l", "com.gu.test.EffectsTest"),
+      testOptions in LocalTest += Tests.Argument("-l", "com.gu.test.HealthCheck"),
 
-  //  configs(EffectsTest),
+      testOptions in EffectsTest += Tests.Argument("-n", "com.gu.test.EffectsTest"),
 
-  testOptions in EffectsTest -= Tests.Argument("-l", "com.gu.test.EffectsTest"),
-  testOptions in EffectsTest -= Tests.Argument("-l", "com.gu.test.HealthCheck"),
-  testOptions in EffectsTest += Tests.Argument("-n", "com.gu.test.EffectsTest"),
-  //  configs(HealthCheckTest),
+      testOptions in HealthCheckTest += Tests.Argument("-n", "com.gu.test.HealthCheck")
+    )
 
-  testOptions in HealthCheckTest -= Tests.Argument("-l", "com.gu.test.EffectsTest"),
-  testOptions in HealthCheckTest -= Tests.Argument("-l", "com.gu.test.HealthCheck"),
-  testOptions in HealthCheckTest += Tests.Argument("-n", "com.gu.test.HealthCheck")
-)
-
-def all(theProject: Project) = theProject.settings(scalaSettings, testSettings).configs(EffectsTest, HealthCheckTest)
+def all(theProject: Project) = theProject.settings(scalaSettings, testSettings).configs(EffectsTest, HealthCheckTest, LocalTest)
 
 lazy val zuora = all(project in file("lib/zuora")).dependsOn(restHttp).settings(
   libraryDependencies ++= Seq(


### PR DESCRIPTION
@pvighi was experiencing unreliability when running the EffectsTests from intellij.
It's important that we can use intellij to run tests, if we want to be able to rely on the tests when making changes in future.  Testing needs to be as easy as possible.

Intellij will still run all the tests if you run at the top level, you would have to add the `-l com.gu.test.EffectsTest` parameter yourslefnsomehow.

I have a strong feeling it's because I messed with the initial "test" task so I have made it so we run `local:test` to run the tests that work in our code only, then `effect:test` to run the external services tests.  `heathCheck:test` is still there as before.

I have also updated the docs so things aren't too confusing.
@pvighi @jacobwinch @lmath @paulbrown1982 does that seem reasonable?

PS I need to make teamcity run local:test as part of the build before I merge, otherwise it tries to run them all, whcih won't work without membership credentials.