### PR TITLE
if identity is not validated, stop processing

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
@@ -1,7 +1,7 @@
 package com.gu.identityBackfill
 
 import com.gu.identity.GetByEmail
-import com.gu.identity.GetByEmail.NotFound
+import com.gu.identity.GetByEmail.{NotFound, NotValidated, OtherError}
 import com.gu.identityBackfill.Types.{EmailAddress, IdentityId, SFContactId, ZuoraAccountIdentitySFContact}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types._
@@ -20,7 +20,8 @@ object PreReqCheck {
     for {
       identityId <- getByEmail(emailAddress).leftMap({
         case NotFound => ApiGatewayResponse.notFound("user doesn't have identity")
-        case unknownError => ApiGatewayResponse.internalServerError(unknownError.toString)
+        case NotValidated => ApiGatewayResponse.notFound("identity email not validated")
+        case OtherError(unknownError) => ApiGatewayResponse.internalServerError(unknownError)
       }).withLogging("GetByEmail")
       zuoraAccountForEmail <- getSingleZuoraAccountForEmail(emailAddress)
       _ <- noZuoraAccountsForIdentityId(identityId)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
@@ -1,6 +1,6 @@
 package com.gu.identityBackfill
 
-import com.gu.identity.GetByEmail.NotFound
+import com.gu.identity.GetByEmail.{NotFound, NotValidated}
 import com.gu.identityBackfill.PreReqCheck.PreReqResult
 import com.gu.identityBackfill.Types.{IdentityId, _}
 import com.gu.util.apigateway.ApiGatewayResponse
@@ -69,6 +69,20 @@ class PreReqCheckTest extends FlatSpec with Matchers {
       )(EmailAddress("email@address"))
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("user doesn't have identity"))
+    result should be(expectedResult)
+  }
+
+  it should "stop processing if it finds a non validated identity account" in {
+
+    val result =
+      PreReqCheck(
+        email => -\/(NotValidated),
+        email => fail("shouldn't be called 1"),
+        identityId => fail("shouldn't be called 2"),
+        _ => fail("shouldn't be called 3")
+      )(EmailAddress("email@address"))
+
+    val expectedResult = -\/(ApiGatewayResponse.notFound("identity email not validated"))
     result should be(expectedResult)
   }
 


### PR DESCRIPTION
This is a new piece of code to avoid linking identity ids with non validated emails.  This avoids the risk of syncing the address of a real customer to someone who has created a fake account.

@pvighi @paulbrown1982 @lmath @jacobwinch 