### PR TITLE
make sub expiry fix behave more like CAS

### DIFF
--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -32,13 +32,13 @@ object Handler extends Logging {
 
         val emergencyTokens = EmergencyTokens(config.stepsConfig.emergencyTokens)
         val zuoraRequests = ZuoraRestRequestMaker(rawEffects.response, config.stepsConfig.zuoraRestConfig)
-        def today() = rawEffects.now().toLocalDate
+        val today = () => rawEffects.now().toLocalDate
         DigitalSubscriptionExpirySteps(
           getEmergencyTokenExpiry = GetTokenExpiry(emergencyTokens),
           getSubscription = GetSubscription(zuoraRequests),
           setActivationDate = SetActivationDate(zuoraRequests, rawEffects.now),
           getAccountSummary = GetAccountSummary(zuoraRequests),
-          getSubscriptionExpiry = GetSubscriptionExpiry(today _),
+          getSubscriptionExpiry = GetSubscriptionExpiry(today),
           skipActivationDateUpdate = SkipActivationDateUpdate.apply
         )
       }

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -38,7 +38,7 @@ object Handler extends Logging {
           getSubscription = GetSubscription(zuoraRequests),
           setActivationDate = SetActivationDate(zuoraRequests, rawEffects.now),
           getAccountSummary = GetAccountSummary(zuoraRequests),
-          getSubscriptionExpiry = GetSubscriptionExpiry(today),
+          getSubscriptionExpiry = GetSubscriptionExpiry(today _),
           skipActivationDateUpdate = SkipActivationDateUpdate.apply
         )
       }

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
@@ -1,6 +1,6 @@
 package com.gu.digitalSubscriptionExpiry.zuora
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 
 import com.gu.digitalSubscriptionExpiry._
 import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
@@ -40,9 +40,11 @@ object GetSubscriptionExpiry {
 
     def isActiveDigipack(charge: RatePlanCharge) = isDigipackName(charge.name) && !charge.effectiveEndDate.isBefore(dateToCheck) && !charge.effectiveStartDate.isAfter(dateToCheck)
 
-    val activeDigipackCharges = subscription.ratePlans.map(_.ratePlanCharges).flatten.filter(isActiveDigipack)
+    val hasActiveDigipackCharges = subscription.ratePlans.map(_.ratePlanCharges).flatten.exists(isActiveDigipack)
 
-    if (activeDigipackCharges.isEmpty) None else Some(activeDigipackCharges.map(_.effectiveEndDate).max)
+    if (hasActiveDigipackCharges) {
+      Some(subscription.endDate.plusDays(1))
+    } else None
   }
 
   def apply(today: () => LocalDate)(providedPassword: String, subscription: SubscriptionResult, accountSummary: AccountSummaryResult): FailableOp[Unit] =

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
@@ -52,7 +52,7 @@ class DigitalSubscriptionExpiryHandlerEffectsTest extends FlatSpec with Matchers
 
     val expectedResponse =
       """
-             |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"{\n  \"expiry\" : {\n    \"expiryDate\" : \"2018-11-29\",\n    \"expiryType\" : \"sub\",\n    \"content\" : \"SevenDay\"\n  }\n}"}
+             |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"{\n  \"expiry\" : {\n    \"expiryDate\" : \"2018-11-30\",\n    \"expiryType\" : \"sub\",\n    \"content\" : \"SevenDay\"\n  }\n}"}
              |""".stripMargin
     responseString jsonMatches expectedResponse
   }
@@ -75,7 +75,7 @@ class DigitalSubscriptionExpiryHandlerEffectsTest extends FlatSpec with Matchers
 
     val expectedResponse =
       """
-        |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"{\n  \"expiry\" : {\n    \"expiryDate\" : \"2019-04-16\",\n    \"expiryType\" : \"sub\",\n    \"content\" : \"SevenDay\"\n  }\n}"}
+        |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"{\n  \"expiry\" : {\n    \"expiryDate\" : \"2019-04-17\",\n    \"expiryType\" : \"sub\",\n    \"content\" : \"SevenDay\"\n  }\n}"}
         |""".stripMargin
     responseString jsonMatches expectedResponse
   }

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
@@ -11,9 +11,9 @@ import org.scalatest.Matchers._
 import scalaz.-\/
 
 class GetSubscriptionExpiryTest extends FlatSpec {
-  val lastWeek = LocalDate.now().minusWeeks(1)
-  val nextWeek = lastWeek.plusWeeks(2)
-
+  val lastWeek = LocalDate.of(2018, 4, 11)
+  val nextWeek = LocalDate.of(2018, 4, 25)
+  val subEndDate = LocalDate.of(2018, 4, 20)
   val digitalPack = SubscriptionResult(
     id = SubscriptionId("subId"),
     name = SubscriptionName("subName"),
@@ -21,7 +21,7 @@ class GetSubscriptionExpiryTest extends FlatSpec {
     casActivationDate = None,
     customerAcceptanceDate = lastWeek,
     startDate = lastWeek,
-    endDate = nextWeek,
+    endDate = subEndDate,
     ratePlans = List(RatePlan("Digital Pack", List(RatePlanCharge("Digital Pack Monthly", lastWeek, nextWeek))))
   )
 
@@ -39,7 +39,7 @@ class GetSubscriptionExpiryTest extends FlatSpec {
 
   val expectedResponse = {
     val expiry = SuccessResponse(Expiry(
-      expiryDate = nextWeek,
+      expiryDate = subEndDate.plusDays(1),
       expiryType = ExpiryType.SUB,
       subscriptionCode = None,
       provider = None
@@ -48,7 +48,8 @@ class GetSubscriptionExpiryTest extends FlatSpec {
   }
 
   val notFoundResponse = -\/(apiResponse(ErrorResponse("Unknown subscriber", -90), "404"))
-  val today: () => LocalDate = LocalDate.now _
+  val today: () => LocalDate = () => LocalDate.of(2018, 4, 18)
+
   it should "return the expiry date for a subscription using billing last name" in {
     val actualResponse = GetSubscriptionExpiry(today)("billingLastName", digitalPack, accountSummary)
     actualResponse shouldEqual expectedResponse
@@ -95,7 +96,7 @@ class GetSubscriptionExpiryTest extends FlatSpec {
       casActivationDate = None,
       customerAcceptanceDate = lastWeek,
       startDate = lastWeek,
-      endDate = nextWeek,
+      endDate = subEndDate,
       ratePlans = List(RatePlan("Weekend+", charges))
     )
 
@@ -119,7 +120,7 @@ class GetSubscriptionExpiryTest extends FlatSpec {
       casActivationDate = None,
       customerAcceptanceDate = lastWeek,
       startDate = lastWeek,
-      endDate = nextWeek,
+      endDate = subEndDate,
       ratePlans = List(RatePlan("Weekend+", charges))
     )
 


### PR DESCRIPTION
Use the rateplan charges just to see if there is an active digipack in the sub but return the sub term end instead of the effective end date of the charge.
Also add 1 to the date in the response