### PR TITLE
Add catalog-service lambda resources and boilerplate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,7 @@ val testDep = test % "test->test"
 lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggregate(
   `identity-backfill`,
   `digital-subscription-expiry`,
+  `catalog-service`,
   zuora,
   effects
 ).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,9 @@ lazy val `identity-backfill` = all(project in file("handlers/identity-backfill")
 lazy val `digital-subscription-expiry` = all(project in file("handlers/digital-subscription-expiry"))
   .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
+lazy val `catalog-service` = all(project in file("handlers/catalog-service"))
+  .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+
 assemblyJarName := "zuora-auto-cancel.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/handlers/catalog-service/README.md
+++ b/handlers/catalog-service/README.md
@@ -1,0 +1,4 @@
+# catalog-service
+This lambda reads the product catalog from Zuora on a schedule and writes it into an S3 bucket.
+
+This means that applications can use the product catalog without requiring API credentials for Zuora. 

--- a/handlers/catalog-service/build.sbt
+++ b/handlers/catalog-service/build.sbt
@@ -1,0 +1,26 @@
+// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
+// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
+name := "catalog-service"
+description:= "Download the Zuora Catalog and store the JSON in S3"
+
+scalacOptions += "-Ypartial-unification"
+
+assemblyJarName := "catalog-service.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Catalog Service"
+riffRaffArtifactResources += (file("handlers/catalog-service/cfn.yaml"), "cfn/cfn.yaml")
+
+libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.265",
+  "log4j" % "log4j" % "1.2.17",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+)
+
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases")
+)

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Reads the product catalog from Zuora and stores it in S3
+
+Parameters:
+    Stage:
+        Description: Stage name
+        Type: String
+        AllowedValues:
+            - PROD
+            - CODE
+        Default: CODE
+
+Resources:
+    CatalogServiceRole:
+        Type: AWS::IAM::Role
+        Properties:
+            AssumeRolePolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Principal:
+                          Service:
+                             - lambda.amazonaws.com
+                      Action:
+                          - sts:AssumeRole
+            Path: /
+            Policies:
+                - PolicyName: LambdaPolicy
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action:
+                            - logs:CreateLogGroup
+                            - logs:CreateLogStream
+                            - logs:PutLogEvents
+                            - lambda:InvokeFunction
+                            Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/catalog-service-${Stage}:log-stream:*"
+                - PolicyName: ReadPrivateCredentials
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action: s3:GetObject
+                            Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/${Stage}/*
+
+    CatalogServiceLambda:
+        Type: AWS::Lambda::Function
+        Properties:
+            Description: Reads the product catalog from Zuora and stores it in S3
+            FunctionName:
+                !Sub catalog-service-${Stage}
+            Code:
+                S3Bucket: subscriptions-dist
+                S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
+            Handler: com.gu.catalogService.Handler::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+            Role:
+                !GetAtt CatalogServiceRole.Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - CatalogServiceRole
+
+    CatalogServiceLambdaInvokePermission:
+        Type: AWS::Lambda::Permission
+        Properties:
+            Action: lambda:invokeFunction
+            FunctionName: !Sub catalog-service-${Stage}
+            Principal: events.amazonaws.com
+            SourceArn: !GetAtt CatalogServiceScheduler.Arn
+        DependsOn:
+        - CatalogServiceLambda
+        - CatalogServiceScheduler
+
+    CatalogServiceScheduler:
+        Type: "AWS::Events::Rule"
+        Properties:
+            Description: Triggers the Catalog Service Lambda on a schedule
+            Name: !Sub catalog-service-scheduler-${Stage}
+            ScheduleExpression: rate(5 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
+            Targets:
+              - Arn: !GetAtt CatalogServiceLambda.Arn
+                Id: !Sub catalog-service-lambda-${Stage}
+        DependsOn:
+        - CatalogServiceLambda

--- a/handlers/catalog-service/riff-raff.yaml
+++ b/handlers/catalog-service/riff-raff.yaml
@@ -9,8 +9,6 @@ deployments:
     app: catalog-service
     parameters:
       templatePath: cfn.yaml
-      cloudFormationStackName: catalog-service-
-      prependStackToCloudFormationStackName: false
 
   catalog-service:
     type: aws-lambda

--- a/handlers/catalog-service/riff-raff.yaml
+++ b/handlers/catalog-service/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+- subscriptions
+regions:
+- eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: catalog-service
+    parameters:
+      templatePath: cfn.yaml
+
+  catalog-service:
+    type: aws-lambda
+    parameters:
+      fileName: catalog-service.jar
+      bucket: subscriptions-dist
+      prefixStack: false
+      functionNames:
+      - catalog-service-
+    dependencies: [cfn]

--- a/handlers/catalog-service/riff-raff.yaml
+++ b/handlers/catalog-service/riff-raff.yaml
@@ -7,9 +7,9 @@ deployments:
   cfn:
     type: cloud-formation
     app: catalog-service
-    cloudFormationStackName: catalog-service-
     parameters:
       templatePath: cfn.yaml
+      cloudFormationStackName: catalog-service-
 
   catalog-service:
     type: aws-lambda

--- a/handlers/catalog-service/riff-raff.yaml
+++ b/handlers/catalog-service/riff-raff.yaml
@@ -7,6 +7,7 @@ deployments:
   cfn:
     type: cloud-formation
     app: catalog-service
+    cloudFormationStackName: catalog-service-
     parameters:
       templatePath: cfn.yaml
 

--- a/handlers/catalog-service/riff-raff.yaml
+++ b/handlers/catalog-service/riff-raff.yaml
@@ -10,6 +10,7 @@ deployments:
     parameters:
       templatePath: cfn.yaml
       cloudFormationStackName: catalog-service-
+      prependStackToCloudFormationStackName: false
 
   catalog-service:
     type: aws-lambda

--- a/handlers/catalog-service/src/main/resources/log4j.properties
+++ b/handlers/catalog-service/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log = .
+log4j.rootLogger = INFO, LAMBDA
+
+# Define the LAMBDA Appender
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
@@ -1,0 +1,15 @@
+package com.gu.catalogService
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.util.Logging
+import java.io.{InputStream, OutputStream}
+
+object Handler extends Logging {
+
+  // this is the entry point
+  // it's referenced by the cloudformation so make sure you keep it in step
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    logger.info(s"Starting point for Catalog Service lambda")
+  }
+
+}


### PR DESCRIPTION
This PR is in support of: 
https://trello.com/c/6TubuHKI/359-find-another-way-to-get-the-zuora-catalog-so-that-zuora-credentials-can-be-removed-from-the-promo-code-tool-e-2

Currently this just creates the AWS resources and sets things up so that we can deploy the new lambda with riff-raff.

Opening the PR now so people can feed back on some basic questions (e.g. Does this lambda even belong in this repo? Which stack should it belong to?)