### PR TITLE
support accounts with null postcodes in Digital subscription expiry calls

### DIFF
--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummary.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummary.scala
@@ -13,18 +13,18 @@ object GetAccountSummary {
   case class AccountSummaryResult(
     accountId: AccountId,
     billToLastName: String,
-    billToPostcode: String,
+    billToPostcode: Option[String],
     soldToLastName: String,
-    soldToPostcode: String
+    soldToPostcode: Option[String]
   )
 
   implicit val reads: Reads[AccountSummaryResult] =
     (
       (__ \ "basicInfo" \ "id").read[String].map(AccountId.apply) and
       (__ \ "billToContact" \ "lastName").read[String] and
-      (__ \ "billToContact" \ "zipCode").read[String] and
+      (__ \ "billToContact" \ "zipCode").readNullable[String] and
       (__ \ "soldToContact" \ "lastName").read[String] and
-      (__ \ "soldToContact" \ "zipCode").read[String]
+      (__ \ "soldToContact" \ "zipCode").readNullable[String]
     )(AccountSummaryResult.apply _)
 
   def apply(requests: Requests)(accountId: AccountId): FailableOp[AccountSummaryResult] =

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
@@ -15,11 +15,12 @@ object GetSubscriptionExpiry {
     def format(str: String): String = str.filter(_.isLetterOrDigit).toLowerCase
 
     val candidates = Seq(
-      format(accountSummary.billToPostcode),
-      format(accountSummary.billToLastName),
-      format(accountSummary.soldToLastName),
-      format(accountSummary.soldToPostcode)
-    )
+      accountSummary.billToPostcode,
+      Some(accountSummary.billToLastName),
+      Some(accountSummary.soldToLastName),
+      accountSummary.soldToPostcode
+    ).flatten.map(format)
+
     val formattedPassword = format(password)
 
     candidates.contains(formattedPassword)

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -50,9 +50,9 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
       val summary = AccountSummaryResult(
         accountId = AccountId("someAccountId"),
         billToLastName = "someBillToLastName",
-        billToPostcode = "someBilltoPostCode",
+        billToPostcode = Some("someBilltoPostCode"),
         soldToLastName = "someSoldToLastName",
-        soldToPostcode = "someSoldtoPostCode"
+        soldToPostcode = Some("someSoldtoPostCode")
       )
       \/-(summary)
     }

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/AccountSummaryResultDeserialiseTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/AccountSummaryResultDeserialiseTest.scala
@@ -1,0 +1,159 @@
+package com.gu.digitalSubscriptionExpiry.zuora
+
+import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.{AccountId, AccountSummaryResult}
+import main.scala.com.gu.digitalSubscriptionExpiry.DigitalSubscriptionExpiryRequest
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import play.api.libs.json.{JsResult, JsSuccess, Json}
+
+class AccountSummaryResultDeserialiseTest extends FlatSpec {
+
+  it should "deserialise correctly Account with null postcode" in {
+
+    val expected: JsResult[AccountSummaryResult] = JsSuccess(
+      AccountSummaryResult(
+        accountId = AccountId("testId"),
+        billToLastName = "billingLastName",
+        billToPostcode = None,
+        soldToLastName = "soldToLastName",
+        soldToPostcode = None
+      )
+
+    )
+
+    val testAccount = getTestAccount(None, None)
+    val event: JsResult[AccountSummaryResult] = Json.parse(testAccount).validate[AccountSummaryResult]
+
+    event should be(expected)
+  }
+
+  it should "deserialise correctly Account with empty string postcode" in {
+
+    val expected: JsResult[AccountSummaryResult] = JsSuccess(
+      AccountSummaryResult(
+        accountId = AccountId("testId"),
+        billToLastName = "billingLastName",
+        billToPostcode = Some(""),
+        soldToLastName = "soldToLastName",
+        soldToPostcode = Some("")
+      )
+
+    )
+
+    val testAccount = getTestAccount(Some(""), Some(""))
+    val event: JsResult[AccountSummaryResult] = Json.parse(testAccount).validate[AccountSummaryResult]
+
+    event should be(expected)
+  }
+
+  it should "deserialise correctly Account with postcode" in {
+
+    val expected: JsResult[AccountSummaryResult] = JsSuccess(
+      AccountSummaryResult(
+        accountId = AccountId("testId"),
+        billToLastName = "billingLastName",
+        billToPostcode = Some("billtoPostcodeValue"),
+        soldToLastName = "soldToLastName",
+        soldToPostcode = Some("SoldToPostcodeValue")
+      )
+
+    )
+
+    val testAccount = getTestAccount(
+      billToPostcode = Some("billtoPostcodeValue"),
+      soldToPostcode = Some("SoldToPostcodeValue")
+    )
+    val event: JsResult[AccountSummaryResult] = Json.parse(testAccount).validate[AccountSummaryResult]
+
+    event should be(expected)
+  }
+
+  def getTestAccount(billToPostcode :Option[String] = None, soldToPostcode: Option[String])  = {
+    def toFieldValue(o :Option[String]) = o.map( s => '"' + s + '"').getOrElse("null")
+
+    s"""
+      {
+       |    "basicInfo": {
+       |        "id": "testId",
+       |        "name": "testName",
+       |        "accountNumber": "TestAccountNumber",
+       |        "notes": null,
+       |        "status": "Active",
+       |        "crmId": "someID",
+       |        "batch": "Batch1",
+       |        "invoiceTemplateId": "templateID",
+       |        "communicationProfileId": null,
+       |        "IdentityId__c": "12344",
+       |        "sfContactId__c": "00xdxE00000NKaRgQAL",
+       |        "CCURN__c": null,
+       |        "NonStandardDataReason__c": null,
+       |        "salesRep": null,
+       |        "parentId": null
+       |    },
+       |    "billingAndPayment": {
+       |        "billCycleDay": 16,
+       |        "currency": "GBP",
+       |        "paymentTerm": "Due Upon Receipt",
+       |        "paymentGateway": "Stripe 2",
+       |        "invoiceDeliveryPrefsPrint": false,
+       |        "invoiceDeliveryPrefsEmail": true,
+       |        "additionalEmailAddresses": []
+       |    },
+       |    "metrics": {
+       |        "balance": 0,
+       |        "totalInvoiceBalance": 0,
+       |        "creditBalance": 0,
+       |        "contractedMrr": 29.2
+       |    },
+       |    "billToContact": {
+       |        "address1": "123 fake st",
+       |        "address2": "",
+       |        "city": "fakeville",
+       |        "country": "United Kingdom",
+       |        "county": "",
+       |        "fax": "",
+       |        "firstName": "billingFirstName",
+       |        "homePhone": "",
+       |        "lastName": "billingLastName",
+       |        "mobilePhone": "",
+       |        "nickname": "",
+       |        "otherPhone": "",
+       |        "otherPhoneType": "Work",
+       |        "personalEmail": "",
+       |        "state": "",
+       |        "taxRegion": "",
+       |        "workEmail": "test.testerson@gu.com",
+       |        "workPhone": "",
+       |        "zipCode": ${toFieldValue(billToPostcode)},
+       |        "SpecialDeliveryInstructions__c": null,
+       |        "Title__c": "Mr"
+       |    },
+       |    "soldToContact": {
+       |        "address1": "123 fake st",
+       |        "address2": "",
+       |        "city": "fakeville",
+       |        "country": "United Kingdom",
+       |        "county": "",
+       |        "fax": "",
+       |        "firstName": "soldToFirstName",
+       |        "homePhone": "",
+       |        "lastName": "soldToLastName",
+       |        "mobilePhone": "",
+       |        "nickname": "",
+       |        "otherPhone": "",
+       |        "otherPhoneType": "Work",
+       |        "personalEmail": "",
+       |        "state": "",
+       |        "taxRegion": "",
+       |        "workEmail": "test.testerson@gu.com",
+       |        "workPhone": "",
+       |        "zipCode": ${toFieldValue(soldToPostcode)},
+       |        "SpecialDeliveryInstructions__c": null,
+       |        "Title__c": "Mr"
+       |    },
+       |    "taxInfo": null,
+       |    "success": true
+       |}
+      """.stripMargin
+  }
+}

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummaryEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetAccountSummaryEffectsTest.scala
@@ -27,9 +27,9 @@ class GetAccountSummaryEffectsTest extends FlatSpec with Matchers {
     val expected = AccountSummaryResult(
       accountId = testAccountId,
       billToLastName = "Brown",
-      billToPostcode = "SW13 8EB",
+      billToPostcode = Some("SW13 8EB"),
       soldToLastName = "Brown",
-      soldToPostcode = "SW13 8EB"
+      soldToPostcode = Some("SW13 8EB")
     )
 
     actual should be(\/-(expected))

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
@@ -32,9 +32,9 @@ class GetSubscriptionExpiryTest extends FlatSpec {
   val accountSummary = AccountSummaryResult(
     accountId = AccountId("accountId"),
     billToLastName = "billingLastName",
-    billToPostcode = "bill 123",
+    billToPostcode = Some("bill 123"),
     soldToLastName = "SoldLastName",
-    soldToPostcode = "123 sold"
+    soldToPostcode = Some("123 sold")
   )
 
   val expectedResponse = {


### PR DESCRIPTION
There are several Zuora accounts with null postcodes. The /subs call in digitalSubscriptionExpiry will fail for those.

We initially missed this since clearing the postcode value from the Zuora console will result in a "" value instead of null. We could reproduce this in dev and UAT by setting the value explicitly to null in the zuora API.