### PR TITLE
Use wraparound-aware emergency token encoder

### DIFF
--- a/handlers/digital-subscription-expiry/build.sbt
+++ b/handlers/digital-subscription-expiry/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
-  "com.gu" %% "content-authorisation-common" % "0.4-SNAPSHOT"
+  "com.gu" %% "content-authorisation-common" % "0.4"
 )
 
 resolvers ++= Seq(

--- a/handlers/digital-subscription-expiry/build.sbt
+++ b/handlers/digital-subscription-expiry/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
-  "com.gu" %% "content-authorisation-common" % "0.3"
+  "com.gu" %% "content-authorisation-common" % "0.4-SNAPSHOT"
 )
 
 resolvers ++= Seq(

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -34,7 +34,7 @@ object Handler extends Logging {
         val zuoraRequests = ZuoraRestRequestMaker(rawEffects.response, config.stepsConfig.zuoraRestConfig)
         val today = () => rawEffects.now().toLocalDate
         DigitalSubscriptionExpirySteps(
-          getEmergencyTokenExpiry = GetTokenExpiry(emergencyTokens),
+          getEmergencyTokenExpiry = GetTokenExpiry(emergencyTokens, today),
           getSubscription = GetSubscription(zuoraRequests),
           setActivationDate = SetActivationDate(zuoraRequests, rawEffects.now),
           getAccountSummary = GetAccountSummary(zuoraRequests),

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiry.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiry.scala
@@ -1,5 +1,7 @@
 package com.gu.digitalSubscriptionExpiry.emergencyToken
 
+import java.time.LocalDate
+
 import com.gu.cas.Valid
 import com.gu.digitalSubscriptionExpiry.DigitalSubscriptionExpirySteps.logger
 import TokenPayloadImplicits._
@@ -11,7 +13,7 @@ import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
 import scala.util.{Success, Try}
 
 object GetTokenExpiry {
-  def apply(emergencyTokens: EmergencyTokens)(subscriberId: String): FailableOp[Unit] = {
+  def apply(emergencyTokens: EmergencyTokens, today: () => LocalDate)(subscriberId: String): FailableOp[Unit] = {
 
     val upperCaseSubId = subscriberId.toUpperCase
     if (!upperCaseSubId.startsWith(emergencyTokens.prefix)) {
@@ -23,9 +25,9 @@ object GetTokenExpiry {
 
         case Success(Valid(payload)) =>
           logger.info(s"subscriber id:'$upperCaseSubId' resolves to $payload")
-          logger.info(s"subscriber id:'$upperCaseSubId' was created on ${payload.creationDate}")
+          logger.info(s"subscriber id:'$upperCaseSubId' was created on day of era: ${payload.creationDateOffset}")
           val expiry = Expiry(
-            expiryDate = payload.expiryDate,
+            expiryDate = payload.jExpiryDate(today()),
             expiryType = ExpiryType.SUB,
             subscriptionCode = Some(payload.subscriptionCode),
             provider = Some(emergencyTokens.prefix)

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/TokenPayloadOps.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/TokenPayloadOps.scala
@@ -2,12 +2,13 @@ package com.gu.digitalSubscriptionExpiry.emergencyToken
 
 import com.gu.cas.{Guardian, SevenDay, SubscriptionCode, TokenPayload}
 import java.time.LocalDate
+import org.joda.time.{LocalDate => JodaDate}
 
 object TokenPayloadImplicits {
 
   implicit class TokenPayloadOps(payload: TokenPayload) {
-    def expiryDate: LocalDate = {
-      val jodaExpiryDate = payload.creationDate.plus(payload.period).plusDays(1)
+    def jExpiryDate(today: LocalDate): LocalDate = {
+      val jodaExpiryDate = payload.expiryDate(new JodaDate(today.getYear, today.getMonth.getValue, today.getDayOfMonth))
       LocalDate.of(jodaExpiryDate.getYear, jodaExpiryDate.getMonthOfYear, jodaExpiryDate.getDayOfMonth)
     }
   }

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
@@ -13,16 +13,16 @@ class GetTokenExpiryTest extends FlatSpec with Matchers {
 
   val getTokenExpiry = {
     val codec = PrefixedTokens(secretKey = "secret", emergencySubscriberAuthPrefix = "G99")
-    GetTokenExpiry(EmergencyTokens("G99", codec))(_)
+    GetTokenExpiry(EmergencyTokens("G99", codec), () => LocalDate.of(2018, 5, 1))(_)
   }
 
   it should "return right for invalid token" in {
     getTokenExpiry("invalidToken").shouldBe(\/-(()))
   }
-  it should "read valid token" in {
+  it should "read valid token in the second era" in {
 
     val expiry = Expiry(
-      expiryDate = LocalDate.of(2017, 7, 21),
+      expiryDate = LocalDate.of(2018, 5, 23),
       expiryType = ExpiryType.SUB,
       subscriptionCode = Some(SevenDay),
       provider = Some("G99")
@@ -31,7 +31,21 @@ class GetTokenExpiryTest extends FlatSpec with Matchers {
     val responseBody = Json.prettyPrint(Json.toJson(SuccessResponse(expiry)))
     val expectedResponse = -\/(ApiResponse("200", new Headers, responseBody))
 
-    getTokenExpiry("G99IZXCEZLYF").shouldBe(expectedResponse)
+    getTokenExpiry("G99HXJLJHOCN").shouldBe(expectedResponse)
+  }
+  it should "read valid token overlapping the eras" in {
+
+    val expiry = Expiry(
+      expiryDate = LocalDate.of(2018, 5, 21),
+      expiryType = ExpiryType.SUB,
+      subscriptionCode = Some(SevenDay),
+      provider = Some("G99")
+    )
+
+    val responseBody = Json.prettyPrint(Json.toJson(SuccessResponse(expiry)))
+    val expectedResponse = -\/(ApiResponse("200", new Headers, responseBody))
+
+    getTokenExpiry("G99DPZBLIVIIAP").shouldBe(expectedResponse)
   }
 }
 

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
@@ -21,31 +21,29 @@ class GetTokenExpiryTest extends FlatSpec with Matchers {
   }
   it should "read valid token in the second era" in {
 
-    val expiry = Expiry(
-      expiryDate = LocalDate.of(2018, 5, 23),
-      expiryType = ExpiryType.SUB,
-      subscriptionCode = Some(SevenDay),
-      provider = Some("G99")
-    )
-
-    val responseBody = Json.prettyPrint(Json.toJson(SuccessResponse(expiry)))
-    val expectedResponse = -\/(ApiResponse("200", new Headers, responseBody))
+    val expectedResponse: -\/[ApiResponse] =
+      expectedExpiryForDate(LocalDate.of(2018, 5, 23))
 
     getTokenExpiry("G99HXJLJHOCN").shouldBe(expectedResponse)
   }
   it should "read valid token overlapping the eras" in {
 
+    val expectedResponse: -\/[ApiResponse] =
+      expectedExpiryForDate(LocalDate.of(2018, 5, 21))
+
+    getTokenExpiry("G99DPZBLIVIIAP").shouldBe(expectedResponse)
+  }
+
+  private def expectedExpiryForDate(expiryDate: LocalDate): -\/[ApiResponse] = {
     val expiry = Expiry(
-      expiryDate = LocalDate.of(2018, 5, 21),
+      expiryDate = expiryDate,
       expiryType = ExpiryType.SUB,
       subscriptionCode = Some(SevenDay),
       provider = Some("G99")
     )
 
     val responseBody = Json.prettyPrint(Json.toJson(SuccessResponse(expiry)))
-    val expectedResponse = -\/(ApiResponse("200", new Headers, responseBody))
-
-    getTokenExpiry("G99DPZBLIVIIAP").shouldBe(expectedResponse)
+    -\/(ApiResponse("200", new Headers, responseBody))
   }
 }
 


### PR DESCRIPTION
This uses the wraparound aware emergency token provider in https://github.com/guardian/content-authorisation-common/pull/5
@pvighi @paulbrown1982 @jacobwinch 
One of the effects Tests are failing, but Patricio has a fix in a PR