### PR TITLE
add functionality to check the reader type is direct or empty

### DIFF
--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/AccountSummaryResultDeserialiseTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/AccountSummaryResultDeserialiseTest.scala
@@ -68,8 +68,8 @@ class AccountSummaryResultDeserialiseTest extends FlatSpec {
     event should be(expected)
   }
 
-  def getTestAccount(billToPostcode :Option[String] = None, soldToPostcode: Option[String])  = {
-    def toFieldValue(o :Option[String]) = o.map( s => '"' + s + '"').getOrElse("null")
+  def getTestAccount(billToPostcode: Option[String] = None, soldToPostcode: Option[String]) = {
+    def toFieldValue(o: Option[String]) = o.map(s => '"' + s + '"').getOrElse("null")
 
     s"""
       {

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -5,17 +5,18 @@ import java.io.{InputStream, OutputStream}
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.identity.{GetByEmail, IdentityConfig}
+import com.gu.identityBackfill.ResponseMaker._
 import com.gu.identityBackfill.Types.{EmailAddress, IdentityId}
 import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
 import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.identityBackfill.salesforce._
-import com.gu.identityBackfill.zuora.{AddIdentityIdToAccount, CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail}
+import com.gu.identityBackfill.zuora.{AddIdentityIdToAccount, CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail, GetZuoraSubTypeForAccount}
 import com.gu.util.Config
+import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.RestRequestMaker.Requests
-import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
+import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import play.api.libs.json.{Json, Reads}
 import scalaz.\/
 
@@ -38,21 +39,22 @@ object Handler {
     def operation: Config[StepsConfig] => Operation =
       config => {
         val zuoraRequests = ZuoraRestRequestMaker(rawEffects.response, config.stepsConfig.zuoraRestConfig)
+        val zuoraQuerier = ZuoraQuery(zuoraRequests)
         val getByEmail: EmailAddress => \/[GetByEmail.ApiError, IdentityId] = GetByEmail(rawEffects.response, config.stepsConfig.identityConfig)
-        val countZuoraAccounts: IdentityId => FailableOp[Int] = CountZuoraAccountsForIdentityId(zuoraRequests)
+        val countZuoraAccounts: IdentityId => ClientFailableOp[Int] = CountZuoraAccountsForIdentityId(zuoraQuerier)
         lazy val sfRequests: FailableOp[Requests] = SalesforceAuthenticate(rawEffects.response, config.stepsConfig.sfConfig)
 
-        // todo make the zuora one like this too, also "map" the lefts to an api gateway response in one place, not in the for comps everywhere
         Operation(
           steps = IdentityBackfillSteps(
             PreReqCheck(
               getByEmail,
-              PreReqCheck.getSingleZuoraAccountForEmail(GetZuoraAccountsForEmail(zuoraRequests)),
-              PreReqCheck.noZuoraAccountsForIdentityId(countZuoraAccounts),
-              SyncableSFToIdentity(sfRequests, RecordTypeId("01220000000VB52AAG"))
+              GetZuoraAccountsForEmail(zuoraQuerier)_ andThen PreReqCheck.getSingleZuoraAccountForEmail,
+              countZuoraAccounts andThen PreReqCheck.noZuoraAccountsForIdentityId,
+              GetZuoraSubTypeForAccount(zuoraQuerier)_ andThen PreReqCheck.acceptableReaderType,
+              todo => sfRequests.flatMap(sfRequests => SyncableSFToIdentity(sfRequests, RecordTypeId("01220000000VB52AAG"))(todo))
             ),
             AddIdentityIdToAccount(zuoraRequests),
-            UpdateSalesforceIdentityId(sfRequests)
+            (c, d) => sfRequests.flatMap(sfRequests => UpdateSalesforceIdentityId(sfRequests)(c, d).nonSuccessToError)
           ),
           healthcheck = () => Healthcheck(
             getByEmail,
@@ -69,12 +71,12 @@ object Handler {
 object Healthcheck {
   def apply(
     getByEmail: EmailAddress => \/[GetByEmail.ApiError, IdentityId],
-    countZuoraAccountsForIdentityId: IdentityId => FailableOp[Int],
+    countZuoraAccountsForIdentityId: IdentityId => ClientFailableOp[Int],
     sfAuth: => FailableOp[Any],
   ): FailableOp[Unit] =
     for {
-      identityId <- getByEmail(EmailAddress("john.duffell@guardian.co.uk")).leftMap(a => ApiGatewayResponse.internalServerError(a.toString)).withLogging("healthcheck getByEmail")
-      _ <- countZuoraAccountsForIdentityId(identityId)
+      identityId <- getByEmail(EmailAddress("john.duffell@guardian.co.uk")).nonSuccessToError.withLogging("healthcheck getByEmail")
+      _ <- countZuoraAccountsForIdentityId(identityId).nonSuccessToError
       _ <- sfAuth
     } yield ()
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -85,8 +85,8 @@ object Handler {
 
   def updateSalesforceIdentityId(sfRequests: => FailableOp[Requests])(sFContactId: Types.SFContactId, identityId: IdentityId): FailableOp[Unit] = for {
     sfRequests <- sfRequests
-    x <- UpdateSalesforceIdentityId(sfRequests)(sFContactId, identityId).nonSuccessToError
-  } yield x
+    _ <- UpdateSalesforceIdentityId(sfRequests)(sFContactId, identityId).nonSuccessToError
+  } yield ()
 
 }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -30,7 +30,7 @@ object IdentityBackfillSteps extends Logging {
   def apply(
     preReqCheck: EmailAddress => FailableOp[PreReqResult],
     updateZuoraIdentityId: (AccountId, IdentityId) => ClientFailableOp[Unit],
-    updateSalesforceIdentityId: ((SFContactId, IdentityId)) => FailableOp[Unit]
+    updateSalesforceIdentityId: (SFContactId, IdentityId) => FailableOp[Unit]
   )(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
 
     for {
@@ -39,7 +39,7 @@ object IdentityBackfillSteps extends Logging {
       preReq <- preReqCheck(fromRequest(request))
       _ <- dryRunAbort(request).withLogging("dryrun aborter")
       _ <- updateZuoraIdentityId(preReq.zuoraAccountId, preReq.requiredIdentityId).nonSuccessToError
-      _ <- updateSalesforceIdentityId((preReq.sFContactId, preReq.requiredIdentityId))
+      _ <- updateSalesforceIdentityId(preReq.sFContactId, preReq.requiredIdentityId)
       // need to remember which ones we updated?
     } yield ()
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -4,10 +4,12 @@ import com.gu.identityBackfill.IdentityBackfillSteps.WireModel.IdentityBackfillR
 import com.gu.identityBackfill.PreReqCheck.PreReqResult
 import com.gu.identityBackfill.Types._
 import com.gu.util.Logging
-import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse, ResponseModels}
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import play.api.libs.json.{Json, Reads}
-import scalaz.{-\/, \/-}
+import scalaz.{-\/, \/, \/-}
+import ResponseMaker._
 
 object IdentityBackfillSteps extends Logging {
 
@@ -27,16 +29,16 @@ object IdentityBackfillSteps extends Logging {
 
   def apply(
     preReqCheck: EmailAddress => FailableOp[PreReqResult],
-    updateZuoraIdentityId: (AccountId, IdentityId) => FailableOp[Unit],
+    updateZuoraIdentityId: (AccountId, IdentityId) => ClientFailableOp[Unit],
     updateSalesforceIdentityId: (SFContactId, IdentityId) => FailableOp[Unit]
-  )(apiGatewayRequest: ApiGatewayRequest) = {
+  )(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
 
     for {
       request <- Json.parse(apiGatewayRequest.body).validate[IdentityBackfillRequest]
         .toFailableOp.withLogging("identity id backfill request")
       preReq <- preReqCheck(fromRequest(request))
       _ <- dryRunAbort(request).withLogging("dryrun aborter")
-      _ <- updateZuoraIdentityId(preReq.zuoraAccountId, preReq.requiredIdentityId)
+      _ <- updateZuoraIdentityId(preReq.zuoraAccountId, preReq.requiredIdentityId).nonSuccessToError
       _ <- updateSalesforceIdentityId(preReq.sFContactId, preReq.requiredIdentityId)
       // need to remember which ones we updated?
     } yield ()

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -30,7 +30,7 @@ object IdentityBackfillSteps extends Logging {
   def apply(
     preReqCheck: EmailAddress => FailableOp[PreReqResult],
     updateZuoraIdentityId: (AccountId, IdentityId) => ClientFailableOp[Unit],
-    updateSalesforceIdentityId: (SFContactId, IdentityId) => FailableOp[Unit]
+    updateSalesforceIdentityId: ((SFContactId, IdentityId)) => FailableOp[Unit]
   )(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
 
     for {
@@ -39,7 +39,7 @@ object IdentityBackfillSteps extends Logging {
       preReq <- preReqCheck(fromRequest(request))
       _ <- dryRunAbort(request).withLogging("dryrun aborter")
       _ <- updateZuoraIdentityId(preReq.zuoraAccountId, preReq.requiredIdentityId).nonSuccessToError
-      _ <- updateSalesforceIdentityId(preReq.sFContactId, preReq.requiredIdentityId)
+      _ <- updateSalesforceIdentityId((preReq.sFContactId, preReq.requiredIdentityId))
       // need to remember which ones we updated?
     } yield ()
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -2,14 +2,14 @@ package com.gu.identityBackfill
 
 import com.gu.identityBackfill.IdentityBackfillSteps.WireModel.IdentityBackfillRequest
 import com.gu.identityBackfill.PreReqCheck.PreReqResult
+import com.gu.identityBackfill.ResponseMaker._
 import com.gu.identityBackfill.Types._
 import com.gu.util.Logging
-import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse, ResponseModels}
+import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import play.api.libs.json.{Json, Reads}
-import scalaz.{-\/, \/, \/-}
-import ResponseMaker._
+import scalaz.{-\/, \/-}
 
 object IdentityBackfillSteps extends Logging {
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
@@ -5,7 +5,7 @@ import com.gu.identity.GetByEmail.{NotFound, NotValidated, OtherError}
 import com.gu.identityBackfill.ResponseMaker._
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount
-import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount.{NoReaderType, ReaderTypeValue}
+import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount.ReaderType.{NoReaderType, ReaderTypeValue}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
@@ -2,9 +2,15 @@ package com.gu.identityBackfill
 
 import com.gu.identity.GetByEmail
 import com.gu.identity.GetByEmail.{NotFound, NotValidated, OtherError}
-import com.gu.identityBackfill.Types.{EmailAddress, IdentityId, SFContactId, ZuoraAccountIdentitySFContact}
+import com.gu.identityBackfill.ResponseMaker._
+import com.gu.identityBackfill.Types._
+import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount
+import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount.{NoReaderType, ReaderTypeValue}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
+import scalaz.std.list._
+import scalaz.syntax.traverse._
 import scalaz.{-\/, \/, \/-}
 
 object PreReqCheck {
@@ -15,8 +21,9 @@ object PreReqCheck {
     getByEmail: EmailAddress => \/[GetByEmail.ApiError, IdentityId],
     getSingleZuoraAccountForEmail: EmailAddress => FailableOp[ZuoraAccountIdentitySFContact],
     noZuoraAccountsForIdentityId: IdentityId => FailableOp[Unit],
+    zuoraSubType: AccountId => FailableOp[Unit],
     syncableSFToIdentity: SFContactId => FailableOp[Unit]
-  )(emailAddress: EmailAddress) = {
+  )(emailAddress: EmailAddress): FailableOp[PreReqResult] = {
     for {
       identityId <- getByEmail(emailAddress).leftMap({
         case NotFound => ApiGatewayResponse.notFound("user doesn't have identity")
@@ -30,19 +37,19 @@ object PreReqCheck {
   }
 
   def noZuoraAccountsForIdentityId(
-    countZuoraAccountsForIdentityId: IdentityId => FailableOp[Int]
-  )(identityId: IdentityId) = {
+    countZuoraAccountsForIdentityId: ClientFailableOp[Int]
+  ): FailableOp[Unit] = {
     for {
-      zuoraAccountsForIdentityId <- countZuoraAccountsForIdentityId(identityId)
+      zuoraAccountsForIdentityId <- countZuoraAccountsForIdentityId.nonSuccessToError
       _ <- if (zuoraAccountsForIdentityId == 0) \/-(()) else -\/(ApiGatewayResponse.notFound("already used that identity id"))
     } yield ()
   }
 
   def getSingleZuoraAccountForEmail(
-    getZuoraAccountsForEmail: EmailAddress => FailableOp[List[ZuoraAccountIdentitySFContact]]
-  )(emailAddress: EmailAddress) = {
+    getZuoraAccountsForEmail: ClientFailableOp[List[ZuoraAccountIdentitySFContact]]
+  ): FailableOp[ZuoraAccountIdentitySFContact] = {
     for {
-      zuoraAccountsForEmail <- getZuoraAccountsForEmail(emailAddress)
+      zuoraAccountsForEmail <- getZuoraAccountsForEmail.nonSuccessToError
       zuoraAccountForEmail <- zuoraAccountsForEmail match {
         case one :: Nil => \/-(one);
         case _ => -\/(ApiGatewayResponse.notFound("should have exactly one zuora account per email at this stage"))
@@ -52,6 +59,18 @@ object PreReqCheck {
         case _ => -\/(ApiGatewayResponse.notFound("the account we found was already populated with an identity id"))
       }
     } yield zuoraAccountForEmail
+  }
+
+  def acceptableReaderType(function: ClientFailableOp[List[GetZuoraSubTypeForAccount.ReaderType]]): FailableOp[Unit] = {
+    for {
+      readerTypes <- function.nonSuccessToError
+      _ <- readerTypes.traverseU {
+        case NoReaderType => \/-(())
+        case ReaderTypeValue("Direct") => \/-(())
+        case ReaderTypeValue(readerType) => -\/(ApiGatewayResponse.notFound(s"had a reader type: $readerType")) // it's bad
+      }.map { _: List[Unit] => () }
+
+    } yield ()
   }
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/ResponseMaker.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/ResponseMaker.scala
@@ -1,0 +1,21 @@
+package com.gu.identityBackfill
+
+import com.gu.identity.GetByEmail
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.FailableOp
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
+import scalaz.\/
+
+object ResponseMaker {
+
+  implicit class HttpApiGatewayOps[SUCCESS](clientFailableOp: ClientFailableOp[SUCCESS]) {
+    def nonSuccessToError: FailableOp[SUCCESS] =
+      clientFailableOp.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
+  }
+
+  implicit class ApiErrorApiGatewayOps[SUCCESS](clientFailableOp: \/[GetByEmail.ApiError, SUCCESS]) {
+    def nonSuccessToError: FailableOp[SUCCESS] =
+      clientFailableOp.leftMap(e => ApiGatewayResponse.internalServerError(e.toString))
+  }
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
@@ -47,8 +47,9 @@ object ContactSyncCheck {
 
 object SyncableSFToIdentity {
   def apply(
-    sfRequests: RestRequestMaker.Requests,
     standardRecordType: RecordTypeId
+  )(
+    sfRequests: RestRequestMaker.Requests
   )(
     sFContactId: SFContactId
   ) =

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
@@ -1,11 +1,12 @@
 package com.gu.identityBackfill.salesforce
 
 import com.gu.i18n.CountryGroup
+import com.gu.identityBackfill.ResponseMaker._
 import com.gu.identityBackfill.Types.SFContactId
 import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
 import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.reader.Types.FailableOp
 import com.gu.util.zuora.RestRequestMaker
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import play.api.libs.json.Json
 import scalaz.{-\/, \/-}
 
@@ -19,10 +20,8 @@ object GetSFContactSyncCheckFields {
   )
   implicit val reads = Json.reads[ContactSyncCheckFields]
 
-  def apply(sfRequests: RestRequestMaker.Requests)(sFContactId: SFContactId): FailableOp[ContactSyncCheckFields] = {
-    val get = sfRequests.get[ContactSyncCheckFields](s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
-    get.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
-  }
+  def apply(sfRequests: RestRequestMaker.Requests)(sFContactId: SFContactId): ClientFailableOp[ContactSyncCheckFields] =
+    sfRequests.get[ContactSyncCheckFields](s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
 
 }
 
@@ -48,14 +47,13 @@ object ContactSyncCheck {
 
 object SyncableSFToIdentity {
   def apply(
-    maybeSFRequests: FailableOp[RestRequestMaker.Requests],
+    sfRequests: RestRequestMaker.Requests,
     standardRecordType: RecordTypeId
   )(
     sFContactId: SFContactId
   ) =
     for {
-      sfRequests <- maybeSFRequests
-      fields <- GetSFContactSyncCheckFields.apply(sfRequests)(sFContactId)
+      fields <- GetSFContactSyncCheckFields(sfRequests)(sFContactId).nonSuccessToError
       _ <- if (ContactSyncCheck.apply(standardRecordType)(fields))
         \/-(())
       else

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/UpdateSalesforceIdentityId.scala
@@ -1,9 +1,7 @@
 package com.gu.identityBackfill.salesforce
 
 import com.gu.identityBackfill.Types.{IdentityId, SFContactId}
-import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.RestRequestMaker.Requests
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
 import play.api.libs.json.Json
 
 object UpdateSalesforceIdentityId {
@@ -11,10 +9,7 @@ object UpdateSalesforceIdentityId {
   case class WireRequest(IdentityID__c: String)
   implicit val writes = Json.writes[WireRequest]
 
-  def apply(maybeSFRequests: FailableOp[Requests])(sFContactId: SFContactId, identityId: IdentityId): FailableOp[Unit] =
-    maybeSFRequests.flatMap { sfRequests =>
-      val patch = sfRequests.patch(WireRequest(identityId.value), s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
-      patch.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
-    }
+  def apply(sfRequests: Requests)(sFContactId: SFContactId, identityId: IdentityId): ClientFailableOp[Unit] =
+    sfRequests.patch(WireRequest(identityId.value), s"/services/data/v20.0/sobjects/Contact/${sFContactId.value}")
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/AddIdentityIdToAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/AddIdentityIdToAccount.scala
@@ -2,9 +2,7 @@ package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types
 import com.gu.identityBackfill.Types.{AccountId, IdentityId}
-import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.RestRequestMaker.Requests
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
 import com.gu.util.zuora.ZuoraReaders.unitReads
 import play.api.libs.json.Json
 
@@ -17,10 +15,7 @@ object AddIdentityIdToAccount {
     WireRequest(id.value)
   }
 
-  def apply(requests: Requests)(accountId: AccountId, identityId: IdentityId): FailableOp[Unit] = {
-    val accounts = requests.put[WireRequest, Unit](reqFromIdentityId(identityId), s"accounts/${accountId.value}")
-
-    accounts.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
-  }
+  def apply(requests: Requests)(accountId: AccountId, identityId: IdentityId): ClientFailableOp[Unit] =
+    requests.put[WireRequest, Unit](reqFromIdentityId(identityId), s"accounts/${accountId.value}")
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -1,11 +1,8 @@
 package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types._
-import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.reader.Types.FailableOp
-import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
-import com.gu.util.zuora.ZuoraQuery
-import com.gu.util.zuora.ZuoraQuery.Query
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
+import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
 import play.api.libs.json.Json
 import scalaz.ListT
 
@@ -20,15 +17,15 @@ object GetZuoraAccountsForEmail {
   )
   implicit val readsA = Json.reads[WireResponseAccount]
 
-  def apply(requests: Requests)(emailAddress: EmailAddress): FailableOp[List[ZuoraAccountIdentitySFContact]] = {
+  def apply(zuoraQuerier: ZuoraQuerier)(emailAddress: EmailAddress): ClientFailableOp[List[ZuoraAccountIdentitySFContact]] = {
     val accounts = for {
       contactWithEmail <- {
         val contactQuery = Query(s"SELECT Id FROM Contact where WorkEmail='${emailAddress.value}'")
-        ListT(ZuoraQuery.getResults[WireResponseContact](requests)(contactQuery).map(_.records))
+        ListT(zuoraQuerier[WireResponseContact](contactQuery).map(_.records))
       }
       accountsWithEmail <- {
         val accountQuery = Query(s"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='${contactWithEmail.Id}'")
-        ListT[ClientFailableOp, WireResponseAccount](ZuoraQuery.getResults[WireResponseAccount](requests)(accountQuery).map(_.records))
+        ListT[ClientFailableOp, WireResponseAccount](zuoraQuerier[WireResponseAccount](accountQuery).map(_.records))
       }
     } yield ZuoraAccountIdentitySFContact(
       AccountId(accountsWithEmail.Id),
@@ -36,7 +33,7 @@ object GetZuoraAccountsForEmail {
       SFContactId(accountsWithEmail.sfContactId__c)
     )
 
-    accounts.run.leftMap(e => ApiGatewayResponse.internalServerError(e.message))
+    accounts.run
   }
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
@@ -1,6 +1,7 @@
 package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types._
+import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount.ReaderType.{NoReaderType, ReaderTypeValue}
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
 import play.api.libs.json.Json
@@ -11,8 +12,13 @@ object GetZuoraSubTypeForAccount {
   implicit val reads = Json.reads[WireResponse]
 
   sealed trait ReaderType
-  case object NoReaderType extends ReaderType
-  case class ReaderTypeValue(value: String) extends ReaderType
+  object ReaderType {
+
+    case object NoReaderType extends ReaderType
+
+    case class ReaderTypeValue(value: String) extends ReaderType
+
+  }
 
   def apply(zuoraQuerier: ZuoraQuerier)(accountId: AccountId): ClientFailableOp[List[ReaderType]] = {
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
@@ -1,0 +1,24 @@
+package com.gu.identityBackfill.zuora
+
+import com.gu.identityBackfill.Types._
+import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
+import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
+import play.api.libs.json.Json
+
+object GetZuoraSubTypeForAccount {
+
+  case class WireResponse(ReaderType__c: Option[String])
+  implicit val reads = Json.reads[WireResponse]
+
+  sealed trait ReaderType
+  case object NoReaderType extends ReaderType
+  case class ReaderTypeValue(value: String) extends ReaderType
+
+  def apply(zuoraQuerier: ZuoraQuerier)(accountId: AccountId): ClientFailableOp[List[ReaderType]] = {
+
+    val contactQuery = Query(s"SELECT ReaderType__c FROM Subscription where AccountId='${accountId.value}'")
+    zuoraQuerier[WireResponse](contactQuery).map(_.records.map(_.ReaderType__c.map(ReaderTypeValue.apply).getOrElse(NoReaderType)))
+
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
@@ -16,6 +16,7 @@ class PreReqCheckTest extends FlatSpec with Matchers {
         email => \/-(IdentityId("asdf")),
         email => \/-(ZuoraAccountIdentitySFContact(AccountId("acc"), None, SFContactId("sf"))),
         identityId => \/-(()),
+        _ => \/-(()),
         _ => \/-(())
       )(EmailAddress("email@address"))
 
@@ -26,7 +27,7 @@ class PreReqCheckTest extends FlatSpec with Matchers {
   it should "stop processing if it finds there is a zuora account already for the identity id" in {
 
     val result =
-      PreReqCheck.noZuoraAccountsForIdentityId(countZuoraAccountsForIdentityId = _ => \/-(1))(IdentityId("asdf"))
+      PreReqCheck.noZuoraAccountsForIdentityId(countZuoraAccountsForIdentityId = \/-(1))
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("already used that identity id"))
     result should be(expectedResult)
@@ -35,12 +36,13 @@ class PreReqCheckTest extends FlatSpec with Matchers {
   it should "stop processing if the zuora account for the given email already has an identity id" in {
 
     val result =
-      PreReqCheck.getSingleZuoraAccountForEmail(email =>
+      PreReqCheck.getSingleZuoraAccountForEmail(
         \/-(List(ZuoraAccountIdentitySFContact(
           AccountId("acc"),
           Some(IdentityId("haha")),
           SFContactId("sf")
-        ))))(EmailAddress("email@address"))
+        )))
+      )
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("the account we found was already populated with an identity id"))
     result should be(expectedResult)
@@ -49,10 +51,10 @@ class PreReqCheckTest extends FlatSpec with Matchers {
   it should "stop processing if there are multiple zuora accounts with the same email address" in {
 
     val result =
-      PreReqCheck.getSingleZuoraAccountForEmail(email => {
+      PreReqCheck.getSingleZuoraAccountForEmail({
         val contactWithoutIdentity = ZuoraAccountIdentitySFContact(AccountId("acc"), None, SFContactId("sf"))
         \/-(List(contactWithoutIdentity, contactWithoutIdentity))
-      })(EmailAddress("email@address"))
+      })
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("should have exactly one zuora account per email at this stage"))
     result should be(expectedResult)
@@ -65,7 +67,8 @@ class PreReqCheckTest extends FlatSpec with Matchers {
         email => -\/(NotFound),
         email => fail("shouldn't be called 1"),
         identityId => fail("shouldn't be called 2"),
-        _ => fail("shouldn't be called 3")
+        _ => fail("shouldn't be called 3"),
+        _ => fail("shouldn't be called 4")
       )(EmailAddress("email@address"))
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("user doesn't have identity"))
@@ -79,7 +82,8 @@ class PreReqCheckTest extends FlatSpec with Matchers {
         email => -\/(NotValidated),
         email => fail("shouldn't be called 1"),
         identityId => fail("shouldn't be called 2"),
-        _ => fail("shouldn't be called 3")
+        _ => fail("shouldn't be called 3"),
+        _ => fail("shouldn't be called 4")
       )(EmailAddress("email@address"))
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("identity email not validated"))

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -29,8 +29,8 @@ class StepsTest extends FlatSpec with Matchers {
           zuoraUpdate = Some((accountId, identityId))
           \/-(())
         },
-        updateSalesforceIdentityId = (sFContactId, identityId) => {
-          salesforceUpdate = Some((sFContactId, identityId))
+        updateSalesforceIdentityId = sFContactIdIdentityId => {
+          salesforceUpdate = Some(sFContactIdIdentityId)
           \/-(())
         }
       )

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -29,8 +29,8 @@ class StepsTest extends FlatSpec with Matchers {
           zuoraUpdate = Some((accountId, identityId))
           \/-(())
         },
-        updateSalesforceIdentityId = sFContactIdIdentityId => {
-          salesforceUpdate = Some(sFContactIdIdentityId)
+        updateSalesforceIdentityId = (sFContactId, identityId) => {
+          salesforceUpdate = Some((sFContactId, identityId))
           \/-(())
         }
       )

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
@@ -18,7 +18,7 @@ class GetSFContactSyncCheckFieldsTest extends FlatSpec with Matchers {
       effects.response
     )) _
     val actual = auth(SFContactId("00110000011AABBAAB"))
-    val expected = \/-(ContactSyncCheckFields(Some("01220000000VB52AAG"), "123", "Testing", Some("United Kingdom")))
+    val expected = \/-(ContactSyncCheckFields(Some("STANDARD_TEST_DUMMY"), "123", "Testing", Some("United Kingdom")))
     actual should be(expected)
 
   }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
@@ -50,7 +50,7 @@ object GetSFContactSyncCheckFieldsTest {
       |    "FirstName": "Testing",
       |    "Salutation": null,
       |    "Name": "Testing 123",
-      |    "RecordTypeId": "01220000000VB52AAG",
+      |    "RecordTypeId": "STANDARD_TEST_DUMMY",
       |    "OtherStreet": null,
       |    "OtherCity": null,
       |    "OtherState": null,

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -18,7 +18,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
 
     val actual = for {
       auth <- DevSFEffects(RawEffects.createDefault)
-      authed = UpdateSalesforceIdentityId(\/-(auth)) _
+      authed = UpdateSalesforceIdentityId(auth) _
       _ <- authed(testContact, IdentityId(unique))
       identityId <- GetSalesforceIdentityId(auth)(testContact)
     } yield identityId

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
@@ -12,10 +12,10 @@ class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
 
   it should "send the right request for update identity id" in {
     val effects = new TestingRawEffects(postResponses = UpdateSalesforceIdentityIdData.postResponses)
-    val auth = UpdateSalesforceIdentityId(\/-(SalesforceRestRequestMaker(
+    val auth = UpdateSalesforceIdentityId(SalesforceRestRequestMaker(
       SalesforceAuth("accesstokentoken", "https://urlsf.hi"),
       effects.response
-    ))) _
+    )) _
     val actual = auth(SFContactId("contactsf"), IdentityId("identityid"))
     val expected = \/-(())
     actual should be(expected)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
@@ -11,7 +11,8 @@ class CountZuoraAccountsForIdentityIdTest extends FlatSpec with Matchers {
 
   it should "get one result for an identity id if there already is one" in {
     val effects = new TestingRawEffects(postResponses = CountZuoraAccountsForIdentityIdData.postResponses(true))
-    val get = CountZuoraAccountsForIdentityId(ZuoraQuery(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass")))) _
+    val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
+    val get = CountZuoraAccountsForIdentityId(ZuoraQuery(requestMaker)) _
     val contacts = get(IdentityId("1234"))
     val expected = \/-(1)
     contacts should be(expected)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
@@ -3,7 +3,7 @@ package com.gu.identityBackfill.zuora
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.identityBackfill.Types._
-import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 
@@ -11,7 +11,7 @@ class CountZuoraAccountsForIdentityIdTest extends FlatSpec with Matchers {
 
   it should "get one result for an identity id if there already is one" in {
     val effects = new TestingRawEffects(postResponses = CountZuoraAccountsForIdentityIdData.postResponses(true))
-    val get = CountZuoraAccountsForIdentityId(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
+    val get = CountZuoraAccountsForIdentityId(ZuoraQuery(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass")))) _
     val contacts = get(IdentityId("1234"))
     val expected = \/-(1)
     contacts should be(expected)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -11,9 +11,16 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
 
   it should "get the accounts for an email with identity" in {
     val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(true))
-    val get = GetZuoraAccountsForEmail(ZuoraQuery(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass")))) _
+    val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
+    val get = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker)) _
     val contacts = get(EmailAddress("email@address"))
-    val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), Some(IdentityId("10101010")), SFContactId("00110000011AABBAAB"))))
+    val expected = \/-(List(
+      ZuoraAccountIdentitySFContact(
+        AccountId("2c92a0fb4a38064e014a3f48f1663ad8"),
+        Some(IdentityId("10101010")),
+        SFContactId("00110000011AABBAAB")
+      )
+    ))
     contacts should be(expected)
   }
 
@@ -22,7 +29,9 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
     val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
     val get = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker)) _
     val contacts = get(EmailAddress("email@address"))
-    val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))))
+    val expected = \/-(List(
+      ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))
+    ))
     contacts should be(expected)
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -12,8 +12,7 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
   it should "get the accounts for an email with identity" in {
     val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(true))
     val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
-    val get = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker)) _
-    val contacts = get(EmailAddress("email@address"))
+    val contacts = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker))(EmailAddress("email@address"))
     val expected = \/-(List(
       ZuoraAccountIdentitySFContact(
         AccountId("2c92a0fb4a38064e014a3f48f1663ad8"),
@@ -27,8 +26,7 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
   it should "get the accounts for an email without identity" in {
     val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(false))
     val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
-    val get = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker)) _
-    val contacts = get(EmailAddress("email@address"))
+    val contacts = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker))(EmailAddress("email@address"))
     val expected = \/-(List(
       ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))
     ))

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -3,7 +3,7 @@ package com.gu.identityBackfill.zuora
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.identityBackfill.Types._
-import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
+import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 
@@ -11,7 +11,7 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
 
   it should "get the accounts for an email with identity" in {
     val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(true))
-    val get = GetZuoraAccountsForEmail(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
+    val get = GetZuoraAccountsForEmail(ZuoraQuery(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass")))) _
     val contacts = get(EmailAddress("email@address"))
     val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), Some(IdentityId("10101010")), SFContactId("00110000011AABBAAB"))))
     contacts should be(expected)
@@ -19,7 +19,7 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
 
   it should "get the accounts for an email without identity" in {
     val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(false))
-    val get = GetZuoraAccountsForEmail(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))) _
+    val get = GetZuoraAccountsForEmail(ZuoraQuery(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass")))) _
     val contacts = get(EmailAddress("email@address"))
     val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))))
     contacts should be(expected)

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -19,7 +19,8 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
 
   it should "get the accounts for an email without identity" in {
     val effects = new TestingRawEffects(postResponses = GetZuoraAccountsForEmailData.postResponses(false))
-    val get = GetZuoraAccountsForEmail(ZuoraQuery(ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass")))) _
+    val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
+    val get = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker)) _
     val contacts = get(EmailAddress("email@address"))
     val expected = \/-(List(ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))))
     contacts should be(expected)

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -29,7 +29,19 @@ object ZuoraQuery {
   implicit val wQueryMoreReq: Writes[QueryMoreReq] = Json.writes[QueryMoreReq]
 
   // https://www.zuora.com/developer/api-reference/#operation/Action_POSTquery
+  @deprecated("use the partial application version below")
   def getResults[QUERYRECORD: Reads](requests: Requests)(query: Query): ClientFailableOp[QueryResult[QUERYRECORD]] =
     requests.post(query, s"action/query", true): ClientFailableOp[QueryResult[QUERYRECORD]]
 
+  // in order to allow partial application, we need to use a trait
+  def apply(requests: Requests): ZuoraQuerier = new ZuoraQuerier {
+    def apply[QUERYRECORD: Reads](query: Query): ClientFailableOp[QueryResult[QUERYRECORD]] =
+      requests.post(query, s"action/query", true): ClientFailableOp[QueryResult[QUERYRECORD]]
+  }
+
+  trait ZuoraQuerier {
+    // this is a single function that can be partially applied, but it has to be a trait because type parameters are needed
+    // don't add any extra methods to this trait
+    def apply[QUERYRECORD: Reads](query: ZuoraQuery.Query): ClientFailableOp[QueryResult[QUERYRECORD]]
+  }
 }

--- a/src/test/scala/manualTest/EmailClientSystemTest.scala
+++ b/src/test/scala/manualTest/EmailClientSystemTest.scala
@@ -1,11 +1,11 @@
 package manualTest
 
 import com.gu.effects.{ConfigLoad, RawEffects}
+import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.ETConfig.ETSendIds
 import com.gu.util.exacttarget.EmailSendSteps.EmailSendStepsDeps
 import com.gu.util.exacttarget._
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraRestConfig
 import com.gu.util.{Config, Logging, Stage}
 import scalaz.syntax.std.either._
 
@@ -50,7 +50,7 @@ object EmailClientSystemTest extends App with Logging {
 
   for {
     configAttempt <- ConfigLoad.load(Stage("DEV")).toEither.disjunction.withLogging("fromFile")
-    config <- Config.parseConfig[ZuoraRestConfig](configAttempt)
+    config <- Config.parseConfig[StepsConfig](configAttempt)
     deps = EmailSendStepsDeps.default(Stage("CODE"), RawEffects.createDefault.response, config.etConfig)
     etSendIds = config.etConfig.etSendIDs
   } yield Seq(


### PR DESCRIPTION
We are currently linking as many identity ids to SF/zuora subs as possible.  This has been done as a first pass for digital pack/news paper, but also should be done for guardian weeklyl

The added complication of guardian weekly, is that some of the subs are agents.
This is where there is an SF account with multiple related contacts.  Each zuora subscription points to the same SF billing account but a different delivery related contact.  The zuora subscription (and SF sub) should have a ReaderType field saying Agent.

These accounts are not eligible to be linked to identity, because although the agent may have an email address, the individual zuora accounts aren't eligible to be managed online (their relationship is specifically managed by a team offline?)

This PR adds an extra check to the linking process that the zuora subscription for the account isn't marked as Agent.

Refactorings:
at the same time I took the chance to make a zuoraQuerier which is created during dependency injection.  This has simplified some of the tests.
I have also removed all the leftMap code from the various operations, as it makes it harder than it should be to simply define what some rest operaiton is.  I have moved the type massaging code to implicitly defined class methods, which seems better.  How to organise them is a bit of an open question, as the for comprehensions need to make sense, also we don't want loads of untestable, super specific type wrangling code.

@pvighi @paulbrown1982 @jacobwinch 