### PR TITLE
Make the catalog service multi-environment 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,8 +119,10 @@ lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggreg
   `identity-backfill`,
   `digital-subscription-expiry`,
   `catalog-service`,
+  effects,
+  handler,
+  restHttp,
   zuora,
-  effects
 ).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `identity-backfill` = all(project in file("handlers/identity-backfill")) // when using the "project identity-backfill" command it uses the lazy val name

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -150,6 +150,7 @@ Resources:
 
     CatalogS3Bucket:
         Type: "AWS::S3::Bucket"
+        Condition: CreateProdOnlyResources
         Properties:
             AccessControl: Private
             BucketName: gu-zuora-catalog

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -14,14 +14,21 @@ Mappings:
     StageVariables:
         CODE:
             ReadableS3Buckets:
+              - arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/DEV/*
               - arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/CODE/*
             WriteableS3Buckets:
               - arn:aws:s3:::gu-zuora-catalog/CODE/*
         PROD:
             ReadableS3Buckets:
+              - arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/DEV/*
+              - arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/CODE/*
               - arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/PROD/*
             WriteableS3Buckets:
               - arn:aws:s3:::gu-zuora-catalog/PROD/*
+
+Conditions:
+    CreateCodeOnlyResources: !Equals [ !Ref Stage, CODE ]
+    CreateProdOnlyResources: !Equals [ !Ref Stage, PROD ]
 
 Resources:
     CatalogServiceRole:
@@ -57,12 +64,13 @@ Resources:
                             Action: s3:PutObject
                             Resource: !FindInMap [StageVariables, !Ref Stage, WriteableS3Buckets]
 
-    CatalogServiceLambda:
+    PRODCatalogServiceLambda:
         Type: AWS::Lambda::Function
+        Condition: CreateProdResources
         Properties:
-            Description: Reads the product catalog from Zuora and stores it in S3
+            Description: Reads the product catalog from PROD Zuora and stores it in S3
             FunctionName:
-                !Sub catalog-service-${Stage}
+                !Sub catalog-service-${Stage}-zuora-prod
             Code:
                 S3Bucket: subscriptions-dist
                 S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
@@ -70,6 +78,7 @@ Resources:
             Environment:
                 Variables:
                   Stage: !Ref Stage
+                  ZuoraEnvironment: PROD
             Role:
                 !GetAtt CatalogServiceRole.Arn
             MemorySize: 1536
@@ -78,28 +87,117 @@ Resources:
         DependsOn:
         - CatalogServiceRole
 
-    CatalogServiceLambdaInvokePermission:
+    UATCatalogServiceLambda:
+        Type: AWS::Lambda::Function
+        Properties:
+            Description: Reads the product catalog from UAT Zuora and stores it in S3
+            FunctionName:
+                !Sub catalog-service-${Stage}-zuora-uat
+            Code:
+                S3Bucket: subscriptions-dist
+                S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
+            Handler: com.gu.catalogService.Handler::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+                  ZuoraEnvironment: UAT
+            Role:
+                !GetAtt CatalogServiceRole.Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - CatalogServiceRole
+
+    DEVCatalogServiceLambda:
+        Type: AWS::Lambda::Function
+        Properties:
+            Description: Reads the product catalog from DEV Zuora and stores it in S3
+            FunctionName:
+                !Sub catalog-service-${Stage}-zuora-dev
+            Code:
+                S3Bucket: subscriptions-dist
+                S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
+            Handler: com.gu.catalogService.Handler::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+                  ZuoraEnvironment: DEV
+            Role:
+                !GetAtt CatalogServiceRole.Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - CatalogServiceRole
+
+    PRODCatalogServiceLambdaInvokePermission:
         Type: AWS::Lambda::Permission
         Properties:
             Action: lambda:invokeFunction
-            FunctionName: !Sub catalog-service-${Stage}
+            FunctionName: !Ref PRODCatalogServiceLambda
             Principal: events.amazonaws.com
             SourceArn: !GetAtt CatalogServiceScheduler.Arn
         DependsOn:
-        - CatalogServiceLambda
+        - PRODCatalogServiceLambda
         - CatalogServiceScheduler
 
-    CatalogServiceScheduler:
-        Type: "AWS::Events::Rule"
+    UATCatalogServiceLambdaInvokePermission:
+        Type: AWS::Lambda::Permission
         Properties:
-            Description: Triggers the Catalog Service Lambda on a schedule
-            Name: !Sub catalog-service-scheduler-${Stage}
-            ScheduleExpression: rate(5 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
-            Targets:
-              - Arn: !GetAtt CatalogServiceLambda.Arn
-                Id: !Sub catalog-service-lambda-${Stage}
+            Action: lambda:invokeFunction
+            FunctionName: !Ref UATCatalogServiceLambda
+            Principal: events.amazonaws.com
+            SourceArn: !GetAtt CatalogServiceScheduler.Arn
         DependsOn:
-        - CatalogServiceLambda
+        - UATCatalogServiceLambda
+        - CatalogServiceScheduler
+
+    DEVCatalogServiceLambdaInvokePermission:
+        Type: AWS::Lambda::Permission
+        Properties:
+            Action: lambda:invokeFunction
+            FunctionName: !Ref DEVCatalogServiceLambda
+            Principal: events.amazonaws.com
+            SourceArn: !GetAtt CatalogServiceScheduler.Arn
+        DependsOn:
+        - DEVCatalogServiceLambda
+        - CatalogServiceScheduler
+
+    ProdCatalogServiceScheduler:
+        Type: "AWS::Events::Rule"
+        Condition: CreateProdResources
+        Properties:
+            Description: Triggers the PROD Catalog Service Lambdas on a schedule
+            Name: !Sub catalog-service-scheduler-${Stage}
+            ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
+            Targets:
+              - Arn: !GetAtt PRODCatalogServiceLambda.Arn
+                Id: !Sub PRODCatalogServiceLambda
+              - Arn: !GetAtt UATCatalogServiceLambda.Arn
+                Id: !Ref UATCatalogServiceLambda
+              - Arn: !GetAtt DEVCatalogServiceLambda.Arn
+                Id: !Ref DEVCatalogServiceLambda
+        DependsOn:
+        - PRODCatalogServiceLambda
+        - UATCatalogServiceLambda
+        - DEVCatalogServiceLambda
+
+    CodeCatalogServiceScheduler:
+        Type: "AWS::Events::Rule"
+        Condition: CreateCodeResources
+        Properties:
+            Description: Triggers the CODE Catalog Service Lambdas on a schedule
+            Name: !Sub catalog-service-scheduler-${Stage}
+            ScheduleExpression: rate(30 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
+            Targets:
+              - Arn: !GetAtt UATCatalogServiceLambda.Arn
+                Id: !Ref UATCatalogServiceLambda
+              - Arn: !GetAtt DEVCatalogServiceLambda.Arn
+                Id: !Ref DEVCatalogServiceLambda
+        DependsOn:
+        - UATCatalogServiceLambda
+        - DEVCatalogServiceLambda
 
     CatalogS3Bucket:
         Type: "AWS::S3::Bucket"

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -132,7 +132,7 @@ Resources:
     CatalogServiceScheduler:
         Type: "AWS::Events::Rule"
         Properties:
-            Description: Triggers the Catalog Service Lambdas on a schedule
+            Description: Triggers the DEV and UAT Catalog Service Lambdas on a schedule
             Name: !Sub catalog-service-scheduler-${Stage}
             ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
             Targets:
@@ -193,8 +193,9 @@ Resources:
 
     ProdCatalogServiceScheduler:
         Type: "AWS::Events::Rule"
+        Condition: CreateProdOnlyResources
         Properties:
-            Description: Triggers the Catalog Service Lambdas on a schedule
+            Description: Triggers the PROD Catalog Service Lambda on a schedule
             Name: !Sub catalog-service-scheduler-${Stage}
             ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
             Targets:

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -66,7 +66,7 @@ Resources:
 
     PRODCatalogServiceLambda:
         Type: AWS::Lambda::Function
-        Condition: CreateProdResources
+        Condition: CreateProdOnlyResources
         Properties:
             Description: Reads the product catalog from PROD Zuora and stores it in S3
             FunctionName:
@@ -133,6 +133,7 @@ Resources:
 
     PRODCatalogServiceLambdaInvokePermission:
         Type: AWS::Lambda::Permission
+        Condition: CreateProdOnlyResources
         Properties:
             Action: lambda:invokeFunction
             FunctionName: !Ref PRODCatalogServiceLambda
@@ -164,32 +165,12 @@ Resources:
         - DEVCatalogServiceLambda
         - CatalogServiceScheduler
 
-    ProdCatalogServiceScheduler:
+    CatalogServiceScheduler:
         Type: "AWS::Events::Rule"
-        Condition: CreateProdResources
         Properties:
-            Description: Triggers the PROD Catalog Service Lambdas on a schedule
+            Description: Triggers the Catalog Service Lambdas on a schedule
             Name: !Sub catalog-service-scheduler-${Stage}
             ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
-            Targets:
-              - Arn: !GetAtt PRODCatalogServiceLambda.Arn
-                Id: !Sub PRODCatalogServiceLambda
-              - Arn: !GetAtt UATCatalogServiceLambda.Arn
-                Id: !Ref UATCatalogServiceLambda
-              - Arn: !GetAtt DEVCatalogServiceLambda.Arn
-                Id: !Ref DEVCatalogServiceLambda
-        DependsOn:
-        - PRODCatalogServiceLambda
-        - UATCatalogServiceLambda
-        - DEVCatalogServiceLambda
-
-    CodeCatalogServiceScheduler:
-        Type: "AWS::Events::Rule"
-        Condition: CreateCodeResources
-        Properties:
-            Description: Triggers the CODE Catalog Service Lambdas on a schedule
-            Name: !Sub catalog-service-scheduler-${Stage}
-            ScheduleExpression: rate(30 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
             Targets:
               - Arn: !GetAtt UATCatalogServiceLambda.Arn
                 Id: !Ref UATCatalogServiceLambda

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -68,7 +68,7 @@ Resources:
         Properties:
             Description: Reads the product catalog from UAT Zuora and stores it in S3
             FunctionName:
-                !Sub catalog-service-${Stage}-zuora-uat
+                !Sub catalog-service-zuora-uat-${Stage}
             Code:
                 S3Bucket: subscriptions-dist
                 S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
@@ -90,7 +90,7 @@ Resources:
         Properties:
             Description: Reads the product catalog from DEV Zuora and stores it in S3
             FunctionName:
-                !Sub catalog-service-${Stage}-zuora-dev
+                !Sub catalog-service-zuora-dev-${Stage}
             Code:
                 S3Bucket: subscriptions-dist
                 S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
@@ -153,16 +153,12 @@ Resources:
               Status: Enabled
         DeletionPolicy: Retain
 
-
-    ### PROD only resources (only the PROD lambdas should be able to access Production Zuora) ###
-
     PRODCatalogServiceLambda:
         Type: AWS::Lambda::Function
-        Condition: CreateProdOnlyResources
         Properties:
             Description: Reads the product catalog from PROD Zuora and stores it in S3
             FunctionName:
-                !Sub catalog-service-${Stage}-zuora-prod
+                !Sub catalog-service-zuora-prod-${Stage}
             Code:
                 S3Bucket: subscriptions-dist
                 S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
@@ -179,6 +175,8 @@ Resources:
         DependsOn:
         - CatalogServiceRole
 
+    ### PROD only resources (only the PROD lambdas should be able to access Production Zuora) ###
+
     PRODCatalogServiceLambdaInvokePermission:
         Type: AWS::Lambda::Permission
         Condition: CreateProdOnlyResources
@@ -186,10 +184,10 @@ Resources:
             Action: lambda:invokeFunction
             FunctionName: !Ref PRODCatalogServiceLambda
             Principal: events.amazonaws.com
-            SourceArn: !GetAtt CatalogServiceScheduler.Arn
+            SourceArn: !GetAtt ProdCatalogServiceScheduler.Arn
         DependsOn:
         - PRODCatalogServiceLambda
-        - CatalogServiceScheduler
+        - ProdCatalogServiceScheduler
 
     ProdCatalogServiceScheduler:
         Type: "AWS::Events::Rule"

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -175,8 +175,6 @@ Resources:
         DependsOn:
         - CatalogServiceRole
 
-    ### PROD only resources (only the PROD lambdas should be able to access Production Zuora) ###
-
     PRODCatalogServiceLambdaInvokePermission:
         Type: AWS::Lambda::Permission
         Condition: CreateProdOnlyResources

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -137,7 +137,7 @@ Resources:
         Type: "AWS::Events::Rule"
         Properties:
             Description: Triggers the DEV and UAT Catalog Service Lambdas on a schedule
-            Name: !Sub catalog-service-scheduler-${Stage}
+            Name: !Sub catalog-service-scheduler-zuora-dev-and-uat-${Stage}
             ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
             Targets:
             - Arn: !GetAtt UATCatalogServiceLambda.Arn
@@ -197,7 +197,7 @@ Resources:
         Condition: CreateProdOnlyResources
         Properties:
             Description: Triggers the PROD Catalog Service Lambda on a schedule
-            Name: !Sub catalog-service-scheduler-${Stage}
+            Name: !Sub catalog-service-scheduler-zuora-prod-${Stage}
             ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
             Targets:
             - Arn: !GetAtt PRODCatalogServiceLambda.Arn

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -27,7 +27,6 @@ Mappings:
               - arn:aws:s3:::gu-zuora-catalog/PROD/*
 
 Conditions:
-    CreateCodeOnlyResources: !Equals [ !Ref Stage, CODE ]
     CreateProdOnlyResources: !Equals [ !Ref Stage, PROD ]
 
 Resources:
@@ -63,29 +62,6 @@ Resources:
                           - Effect: Allow
                             Action: s3:PutObject
                             Resource: !FindInMap [StageVariables, !Ref Stage, WriteableS3Buckets]
-
-    PRODCatalogServiceLambda:
-        Type: AWS::Lambda::Function
-        Condition: CreateProdOnlyResources
-        Properties:
-            Description: Reads the product catalog from PROD Zuora and stores it in S3
-            FunctionName:
-                !Sub catalog-service-${Stage}-zuora-prod
-            Code:
-                S3Bucket: subscriptions-dist
-                S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
-            Handler: com.gu.catalogService.Handler::apply
-            Environment:
-                Variables:
-                  Stage: !Ref Stage
-                  ZuoraEnvironment: PROD
-            Role:
-                !GetAtt CatalogServiceRole.Arn
-            MemorySize: 1536
-            Runtime: java8
-            Timeout: 300
-        DependsOn:
-        - CatalogServiceRole
 
     UATCatalogServiceLambda:
         Type: AWS::Lambda::Function
@@ -131,18 +107,6 @@ Resources:
         DependsOn:
         - CatalogServiceRole
 
-    PRODCatalogServiceLambdaInvokePermission:
-        Type: AWS::Lambda::Permission
-        Condition: CreateProdOnlyResources
-        Properties:
-            Action: lambda:invokeFunction
-            FunctionName: !Ref PRODCatalogServiceLambda
-            Principal: events.amazonaws.com
-            SourceArn: !GetAtt CatalogServiceScheduler.Arn
-        DependsOn:
-        - PRODCatalogServiceLambda
-        - CatalogServiceScheduler
-
     UATCatalogServiceLambdaInvokePermission:
         Type: AWS::Lambda::Permission
         Properties:
@@ -172,10 +136,10 @@ Resources:
             Name: !Sub catalog-service-scheduler-${Stage}
             ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
             Targets:
-              - Arn: !GetAtt UATCatalogServiceLambda.Arn
-                Id: !Ref UATCatalogServiceLambda
-              - Arn: !GetAtt DEVCatalogServiceLambda.Arn
-                Id: !Ref DEVCatalogServiceLambda
+            - Arn: !GetAtt UATCatalogServiceLambda.Arn
+              Id: !Ref UATCatalogServiceLambda
+            - Arn: !GetAtt DEVCatalogServiceLambda.Arn
+              Id: !Ref DEVCatalogServiceLambda
         DependsOn:
         - UATCatalogServiceLambda
         - DEVCatalogServiceLambda
@@ -188,3 +152,53 @@ Resources:
             VersioningConfiguration:
               Status: Enabled
         DeletionPolicy: Retain
+
+
+    ### PROD only resources (only the PROD lambdas should be able to access Production Zuora) ###
+
+    PRODCatalogServiceLambda:
+        Type: AWS::Lambda::Function
+        Condition: CreateProdOnlyResources
+        Properties:
+            Description: Reads the product catalog from PROD Zuora and stores it in S3
+            FunctionName:
+                !Sub catalog-service-${Stage}-zuora-prod
+            Code:
+                S3Bucket: subscriptions-dist
+                S3Key: !Sub subscriptions/${Stage}/catalog-service/catalog-service.jar
+            Handler: com.gu.catalogService.Handler::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+                  ZuoraEnvironment: PROD
+            Role:
+                !GetAtt CatalogServiceRole.Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - CatalogServiceRole
+
+    PRODCatalogServiceLambdaInvokePermission:
+        Type: AWS::Lambda::Permission
+        Condition: CreateProdOnlyResources
+        Properties:
+            Action: lambda:invokeFunction
+            FunctionName: !Ref PRODCatalogServiceLambda
+            Principal: events.amazonaws.com
+            SourceArn: !GetAtt CatalogServiceScheduler.Arn
+        DependsOn:
+        - PRODCatalogServiceLambda
+        - CatalogServiceScheduler
+
+    ProdCatalogServiceScheduler:
+        Type: "AWS::Events::Rule"
+        Properties:
+            Description: Triggers the Catalog Service Lambdas on a schedule
+            Name: !Sub catalog-service-scheduler-${Stage}
+            ScheduleExpression: rate(10 minutes) #https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions
+            Targets:
+            - Arn: !GetAtt PRODCatalogServiceLambda.Arn
+              Id: !Sub PRODCatalogServiceLambda
+        DependsOn:
+        - PRODCatalogServiceLambda

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -52,7 +52,11 @@ Resources:
                             - logs:CreateLogStream
                             - logs:PutLogEvents
                             - lambda:InvokeFunction
-                            Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/catalog-service-${Stage}:log-stream:*"
+                            Resource:
+                            - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/catalog-service-zuora-dev-${Stage}:log-stream:*
+                            - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/catalog-service-zuora-uat-${Stage}:log-stream:*
+                            - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/catalog-service-zuora-prod-${Stage}:log-stream:*
+
                 - PolicyName: ReadPrivateCredentials
                   PolicyDocument:
                       Statement:

--- a/handlers/catalog-service/riff-raff.yaml
+++ b/handlers/catalog-service/riff-raff.yaml
@@ -17,5 +17,7 @@ deployments:
       bucket: subscriptions-dist
       prefixStack: false
       functionNames:
-      - catalog-service-
+      - catalog-service-zuora-dev-
+      - catalog-service-zuora-uat-
+      - catalog-service-zuora-prod-
     dependencies: [cfn]

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
@@ -5,11 +5,12 @@ import com.gu.effects.RawEffects
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import com.gu.util.Logging
-import com.gu.util.config.{LoadConfig, Stage}
+import com.gu.util.config.ConfigReads.ConfigFailure
+import com.gu.util.config.{LoadConfig, Stage, ZuoraEnvironment}
 import okhttp3.{Request, Response}
 import play.api.libs.json.{Json, Reads}
-
 import scala.util.Try
+import scalaz.\/
 
 object Handler extends Logging {
 
@@ -19,22 +20,23 @@ object Handler extends Logging {
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
   def apply(): Unit = {
-    runWithEffects(RawEffects.response, RawEffects.stage, RawEffects.s3Load, RawEffects.s3Write)
+    runWithEffects(RawEffects.response, RawEffects.stage, RawEffects.zuoraEnvironment, RawEffects.s3Load, RawEffects.s3Write)
   }
 
   // this does the wiring except side effects but not any decisions, so can be used for an end to end test
   def runWithEffects(
     response: Request => Response,
     stage: Stage,
-    s3Load: Stage => Try[String],
+    zuoraEnvironment: ZuoraEnvironment,
+    s3Load: Stage => ConfigFailure \/ String,
     s3Write: PutObjectRequest => Try[PutObjectResult]
   ): Unit = {
 
     val attempt = for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(stage)).withLogging("loaded config").leftMap(_.body)
+      config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(zuoraEnvironment.stageToLoad), false).withLogging("loaded config").leftMap(_.error)
       zuoraRequests = ZuoraRestRequestMaker(response, config.stepsConfig.zuoraRestConfig)
       fetchCatalogAttempt <- ZuoraReadCatalog(zuoraRequests).leftMap(_.message)
-      uploadCatalogAttempt <- S3UploadCatalog(stage, fetchCatalogAttempt, s3Write)
+      uploadCatalogAttempt <- S3UploadCatalog(stage, zuoraEnvironment, fetchCatalogAttempt, s3Write)
     } yield ()
 
     attempt.fold(failureReason => throw CatalogServiceException(failureReason), identity)

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
@@ -33,7 +33,7 @@ object Handler extends Logging {
   ): Unit = {
 
     val attempt = for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(zuoraEnvironment.stageToLoad), false)
+      config <- LoadConfig.default[StepsConfig](implicitly)(zuoraEnvironment.stageToLoad, s3Load(zuoraEnvironment.stageToLoad))
         .withLogging("loaded config")
         .leftMap(_.error)
       zuoraRequests = ZuoraRestRequestMaker(response, config.stepsConfig.zuoraRestConfig)

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/Handler.scala
@@ -33,7 +33,9 @@ object Handler extends Logging {
   ): Unit = {
 
     val attempt = for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(zuoraEnvironment.stageToLoad), false).withLogging("loaded config").leftMap(_.error)
+      config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(zuoraEnvironment.stageToLoad), false)
+        .withLogging("loaded config")
+        .leftMap(_.error)
       zuoraRequests = ZuoraRestRequestMaker(response, config.stepsConfig.zuoraRestConfig)
       fetchCatalogAttempt <- ZuoraReadCatalog(zuoraRequests).leftMap(_.message)
       uploadCatalogAttempt <- S3UploadCatalog(stage, zuoraEnvironment, fetchCatalogAttempt, s3Write)

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/S3UploadCatalog.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/S3UploadCatalog.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, InputStream}
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.amazonaws.util.IOUtils
 import com.gu.util.Logging
-import com.gu.util.config.Stage
+import com.gu.util.config.{Stage, ZuoraEnvironment}
 import scala.util.Try
 import scalaz.{-\/, \/, \/-}
 
@@ -12,6 +12,7 @@ object S3UploadCatalog extends Logging {
 
   def apply(
     stage: Stage,
+    zuoraEnvironment: ZuoraEnvironment,
     catalog: String,
     s3Write: PutObjectRequest => Try[PutObjectResult]
   ): String \/ PutObjectResult = {
@@ -20,7 +21,7 @@ object S3UploadCatalog extends Logging {
     val bytes = IOUtils.toByteArray(stream)
     val uploadMetadata = new ObjectMetadata()
     uploadMetadata.setContentLength(bytes.length.toLong)
-    val putRequest = new PutObjectRequest(s"gu-zuora-catalog/${stage.value}", "catalog.json", new ByteArrayInputStream(bytes), uploadMetadata)
+    val putRequest = new PutObjectRequest(s"gu-zuora-catalog/${stage.value}/Zuora-${zuoraEnvironment.value}", "catalog.json", new ByteArrayInputStream(bytes), uploadMetadata)
     val uploadAttempt = for {
       result <- s3Write(putRequest)
     } yield {

--- a/handlers/catalog-service/src/main/scala/com/gu/catalogService/S3UploadCatalog.scala
+++ b/handlers/catalog-service/src/main/scala/com/gu/catalogService/S3UploadCatalog.scala
@@ -21,7 +21,12 @@ object S3UploadCatalog extends Logging {
     val bytes = IOUtils.toByteArray(stream)
     val uploadMetadata = new ObjectMetadata()
     uploadMetadata.setContentLength(bytes.length.toLong)
-    val putRequest = new PutObjectRequest(s"gu-zuora-catalog/${stage.value}/Zuora-${zuoraEnvironment.value}", "catalog.json", new ByteArrayInputStream(bytes), uploadMetadata)
+    val putRequest = new PutObjectRequest(
+      s"gu-zuora-catalog/${stage.value}/Zuora-${zuoraEnvironment.value}",
+      "catalog.json",
+      new ByteArrayInputStream(bytes),
+      uploadMetadata
+    )
     val uploadAttempt = for {
       result <- s3Write(putRequest)
     } yield {

--- a/handlers/catalog-service/src/test/scala/com/gu/catalogService/CatalogServiceStepsTest.scala
+++ b/handlers/catalog-service/src/test/scala/com/gu/catalogService/CatalogServiceStepsTest.scala
@@ -2,9 +2,9 @@ package com.gu.catalogService
 
 import com.gu.catalogService.Handler.CatalogServiceException
 import com.gu.effects.TestingRawEffects
+import com.gu.util.config.ConfigReads.ConfigFailure
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.util.Failure
+import scalaz.-\/
 
 class CatalogServiceStepsTest extends FlatSpec with Matchers {
 
@@ -15,8 +15,9 @@ class CatalogServiceStepsTest extends FlatSpec with Matchers {
     a[CatalogServiceException] should be thrownBy {
       Handler.runWithEffects(
         successfulResponseEffects.response,
-        successfulResponseEffects.rawEffects.stage,
-        _ => Failure(new NullPointerException),
+        successfulResponseEffects.stage,
+        successfulResponseEffects.zuoraEnvironment,
+        _ => -\/(ConfigFailure("broken config load")),
         TestingRawEffects.successfulS3Upload
       )
     }
@@ -26,7 +27,8 @@ class CatalogServiceStepsTest extends FlatSpec with Matchers {
     a[CatalogServiceException] should be thrownBy {
       Handler.runWithEffects(
         failureResponseEffects.response,
-        failureResponseEffects.rawEffects.stage,
+        successfulResponseEffects.stage,
+        successfulResponseEffects.zuoraEnvironment,
         failureResponseEffects.rawEffects.s3Load,
         TestingRawEffects.successfulS3Upload
       )
@@ -37,7 +39,8 @@ class CatalogServiceStepsTest extends FlatSpec with Matchers {
     a[CatalogServiceException] should be thrownBy {
       Handler.runWithEffects(
         successfulResponseEffects.response,
-        successfulResponseEffects.rawEffects.stage,
+        successfulResponseEffects.stage,
+        successfulResponseEffects.zuoraEnvironment,
         successfulResponseEffects.rawEffects.s3Load,
         TestingRawEffects.failedS3Upload
       )

--- a/handlers/catalog-service/src/test/scala/com/gu/catalogService/S3UploadCatalogTest.scala
+++ b/handlers/catalog-service/src/test/scala/com/gu/catalogService/S3UploadCatalogTest.scala
@@ -4,17 +4,17 @@ import java.util.Date
 import com.gu.effects.{AwsS3, UploadToS3}
 import com.gu.test.EffectsTest
 import com.gu.util.Logging
-import com.gu.util.config.Stage
+import com.gu.util.config.{Stage, ZuoraEnvironment}
 import org.scalatest.FlatSpec
 import scala.util.Try
 
 class S3UploadCatalogEffectsTest extends FlatSpec with Logging {
 
-  def getLatestCatalogTimestamp: Try[Date] = Try(AwsS3.client.getObjectMetadata("gu-zuora-catalog/EffectsTest", "catalog.json").getLastModified)
+  def getLatestCatalogTimestamp: Try[Date] = Try(AwsS3.client.getObjectMetadata("gu-zuora-catalog/EffectsTest/Zuora-FakeEnv", "catalog.json").getLastModified)
 
   "S3UploadCatalog" should "upload a file" taggedAs EffectsTest in {
     val readBefore = getLatestCatalogTimestamp
-    S3UploadCatalog(Stage("EffectsTest"), """{"catalog":"myProducts"}""", UploadToS3.putObject)
+    S3UploadCatalog(Stage("EffectsTest"), ZuoraEnvironment("FakeEnv"), """{"catalog":"myProducts"}""", UploadToS3.putObject)
     val readAfter = getLatestCatalogTimestamp
     val compareDates = for {
       beforeUpload <- readBefore

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -47,7 +47,8 @@ object Handler extends Logging {
       }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+        .toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -47,7 +47,7 @@ object Handler extends Logging {
       }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
         .toFailableOp("load config")
       configuredOp = operation(config)
 

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -2,7 +2,6 @@ package com.gu.digitalSubscriptionExpiry
 
 import java.io.{InputStream, OutputStream}
 import java.time.LocalDateTime
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.digitalSubscriptionExpiry.emergencyToken.{EmergencyTokens, EmergencyTokensConfig, GetTokenExpiry}
 import com.gu.digitalSubscriptionExpiry.zuora._
@@ -12,6 +11,7 @@ import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import com.gu.util.Logging
 import com.gu.util.config.{Config, LoadConfig}
+import com.gu.util.reader.Types._
 import okhttp3.{Request, Response}
 import play.api.libs.json.{Json, Reads}
 
@@ -47,7 +47,7 @@ object Handler extends Logging {
       }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -1,7 +1,6 @@
 package com.gu.identityBackfill
 
 import java.io.{InputStream, OutputStream}
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.identity.{GetByEmail, IdentityConfig}
@@ -67,7 +66,7 @@ object Handler {
       }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig] (implicitly) (rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
+      config <- LoadConfig.default[StepsConfig] (implicitly) (rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -66,7 +66,7 @@ object Handler {
       }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig] (implicitly) (rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
+      config <- LoadConfig.default[StepsConfig] (implicitly) (rawEffects.stage, rawEffects.s3Load(rawEffects.stage)).toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
@@ -7,7 +7,6 @@ import com.amazonaws.services.s3.model.{GetObjectRequest, PutObjectRequest, PutO
 import com.gu.util.Logging
 import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.Stage
-
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 import scalaz.{-\/, \/, \/-}

--- a/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
@@ -5,9 +5,11 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{GetObjectRequest, PutObjectRequest, PutObjectResult, S3ObjectInputStream}
 import com.gu.util.Logging
+import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.Stage
 import scala.io.Source
 import scala.util.{Failure, Try}
+import scalaz.{-\/, \/, \/-}
 
 object S3ConfigLoad extends Logging {
 
@@ -15,7 +17,7 @@ object S3ConfigLoad extends Logging {
   // with this, you can upload the new config with a new name
   val version = "4"
 
-  def load(stage: Stage): Try[String] = {
+  def load(stage: Stage): ConfigFailure \/ String = {
     val key =
       if (stage.value == "DEV")
         s"payment-failure-lambdas.private.json"
@@ -24,11 +26,11 @@ object S3ConfigLoad extends Logging {
     load(stage, key)
   }
 
-  def load(stage: Stage, key: String): Try[String] = {
+  def load(stage: Stage, key: String): ConfigFailure \/ String = {
     logger.info(s"Attempting to load config in $stage")
     val bucket = s"gu-reader-revenue-private/membership/payment-failure-lambdas/${stage.value}"
     val request = new GetObjectRequest(bucket, key)
-    GetFromS3.fetchString(request)
+    GetFromS3.fetchString(request).fold(_ => -\/(ConfigFailure("Failed to load config from S3")), conf => \/-(conf))
   }
 
 }

--- a/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/AwsS3.scala
@@ -7,8 +7,9 @@ import com.amazonaws.services.s3.model.{GetObjectRequest, PutObjectRequest, PutO
 import com.gu.util.Logging
 import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.Stage
+
 import scala.io.Source
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 import scalaz.{-\/, \/, \/-}
 
 object S3ConfigLoad extends Logging {
@@ -30,7 +31,12 @@ object S3ConfigLoad extends Logging {
     logger.info(s"Attempting to load config in $stage")
     val bucket = s"gu-reader-revenue-private/membership/payment-failure-lambdas/${stage.value}"
     val request = new GetObjectRequest(bucket, key)
-    GetFromS3.fetchString(request).fold(_ => -\/(ConfigFailure("Failed to load config from S3")), conf => \/-(conf))
+    GetFromS3.fetchString(request) match {
+      case Success(conf) => \/-(conf)
+      case Failure(ex) =>
+        logger.error(s"Failed to load config", ex)
+        -\/(ConfigFailure("Failed to load config from S3"))
+    }
   }
 
 }

--- a/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
@@ -3,13 +3,15 @@ package com.gu.effects
 import okhttp3.{Request, Response}
 import java.time.LocalDateTime
 import com.amazonaws.services.s3.model.{PutObjectRequest, PutObjectResult}
-import com.gu.util.config.Stage
+import com.gu.util.config.ConfigReads.ConfigFailure
+import com.gu.util.config.{Stage, ZuoraEnvironment}
 import scala.util.Try
+import scalaz.\/
 
 // this is turning into a big object and is not cohesive, don't add anything else
 case class RawEffects(
   stage: Stage,
-  s3Load: Stage => Try[String]
+  s3Load: Stage => ConfigFailure \/ String
 )
 
 object RawEffects {
@@ -21,9 +23,10 @@ object RawEffects {
   }
 
   val stage = Stage(Option(System.getenv("Stage")).filter(_ != "").getOrElse("DEV"))
+  val zuoraEnvironment = ZuoraEnvironment(Option(System.getenv("Stage")).filter(_ != "").getOrElse("DEV"))
 
   val response: Request => Response = Http.response
-  def s3Load: Stage => Try[String] = S3ConfigLoad.load
+  def s3Load: Stage => ConfigFailure \/ String = S3ConfigLoad.load
   def s3Write: PutObjectRequest => Try[PutObjectResult] = UploadToS3.putObject
   def now = () => LocalDateTime.now
 

--- a/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/RawEffects.scala
@@ -23,7 +23,7 @@ object RawEffects {
   }
 
   val stage = Stage(Option(System.getenv("Stage")).filter(_ != "").getOrElse("DEV"))
-  val zuoraEnvironment = ZuoraEnvironment(Option(System.getenv("Stage")).filter(_ != "").getOrElse("DEV"))
+  val zuoraEnvironment = ZuoraEnvironment(Option(System.getenv("ZuoraEnvironment")).filter(_ != "").getOrElse("DEV"))
 
   val response: Request => Response = Http.response
   def s3Load: Stage => ConfigFailure \/ String = S3ConfigLoad.load

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -6,12 +6,12 @@ import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.gu.effects.TestingRawEffects._
 import com.gu.util.Logging
-import com.gu.util.config.Stage
+import com.gu.util.config.{Stage, ZuoraEnvironment}
 import okhttp3._
 import okhttp3.internal.Util.UTF_8
 import okio.Buffer
-
 import scala.util.{Failure, Success}
+import scalaz.\/-
 
 class TestingRawEffects(
   val isProd: Boolean = false,
@@ -23,6 +23,8 @@ class TestingRawEffects(
   var requests: List[Request] = Nil // !
 
   val stage = Stage(if (isProd) "PROD" else "DEV")
+
+  val zuoraEnvironment = ZuoraEnvironment(if (isProd) "PROD" else "DEV")
 
   def requestsAttempted: List[BasicRequest] = requests.map { request =>
     val buffer = new Buffer()
@@ -73,7 +75,7 @@ class TestingRawEffects(
     requests.map(req => (req.method, req.url.encodedPath) -> Option(req.body).map(body)).toMap
   }
 
-  val rawEffects = RawEffects(stage, _ => Success(codeConfig))
+  val rawEffects = RawEffects(stage, _ => \/-(codeConfig))
 
 }
 

--- a/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
@@ -1,5 +1,6 @@
 package com.gu.util.config
 
+import com.gu.util.Logging
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -85,11 +86,15 @@ case class Stage(value: String) extends AnyVal {
   def isProd: Boolean = value == "PROD"
 }
 
-case class ZuoraEnvironment(value: String) {
+case class ZuoraEnvironment(value: String) extends Logging {
+
   def stageToLoad: Stage = value match {
     case "PROD" => Stage("PROD")
     case "UAT" => Stage("CODE")
-    case _ => Stage("DEV")
+    case "DEV" => Stage("DEV")
+    case _ =>
+      logger.error("Unknown Zuora environment specified, falling back to DEV")
+      Stage("DEV")
   }
 }
 

--- a/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
@@ -89,7 +89,7 @@ case class ZuoraEnvironment(value: String) {
   def stageToLoad: Stage = value match {
     case "PROD" => Stage("PROD")
     case "UAT" => Stage("CODE")
-    case "DEV" => Stage("DEV")
+    case _ => Stage("DEV")
   }
 }
 

--- a/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
@@ -85,6 +85,14 @@ case class Stage(value: String) extends AnyVal {
   def isProd: Boolean = value == "PROD"
 }
 
+case class ZuoraEnvironment(value: String) {
+  def stageToLoad: Stage = value match {
+    case "PROD" => Stage("PROD")
+    case "UAT" => Stage("CODE")
+    case "DEV" => Stage("DEV")
+  }
+}
+
 object ConfigReads {
 
   implicit def configReads[StepsConfig: Reads]: Reads[Config[StepsConfig]] = (
@@ -95,6 +103,6 @@ object ConfigReads {
     (JsPath \ "stripe").read[StripeConfig]
   )(Config.apply[StepsConfig] _)
 
-  case class ConfigFailure(error: JsError)
+  case class ConfigFailure(error: String)
 
 }

--- a/lib/handler/src/main/scala/com/gu/util/config/LoadConfig.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/LoadConfig.scala
@@ -1,35 +1,37 @@
 package com.gu.util.config
 
 import com.gu.util.Logging
-import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.ConfigReads.configReads
-import com.gu.util.reader.Types._
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
-import scala.util.Try
 import scalaz.{-\/, \/, \/-}
 
 object LoadConfig extends Logging {
 
-  def default[StepsConfig: Reads]: (Stage, Try[String]) => FailableOp[Config[StepsConfig]] =
+  def default[StepsConfig: Reads]: (Stage, ConfigFailure \/ String, Boolean) => ConfigFailure \/ Config[StepsConfig] =
     apply[StepsConfig](parseConfig[StepsConfig])
 
   def apply[StepsConfig](parseConfig: String => ConfigFailure \/ Config[StepsConfig])(
     stage: Stage,
-    s3Load: Try[String]
-  ): FailableOp[Config[StepsConfig]] = {
+    s3Load: ConfigFailure \/ String,
+    shouldCrossCheckStage: Boolean = true
+  ): ConfigFailure \/ Config[StepsConfig] = {
     logger.info(s"${this.getClass} Lambda is starting up in $stage")
     for {
-      textConfig <- s3Load.toFailableOp("load config from s3")
-      config <- parseConfig(textConfig).toFailableOp("parse config file")
-      _ <- if (stage == config.stage)
-        \/-(())
-      else
-        -\/(ApiGatewayResponse.internalServerError(s"running in $stage with config from ${config.stage}"))
+      textConfig <- s3Load
+      config <- parseConfig(textConfig)
+      _ <- safetyCheck(shouldCrossCheckStage, stage, config.stage)
     } yield config
   }
 
-  def parseConfig[StepsConfig: Reads](jsonConfig: String): \/[ConfigFailure, Config[StepsConfig]] = {
+  def safetyCheck(shouldCompare: Boolean, stageFromEnv: Stage, stageFromConfigFile: Stage) = {
+    if (shouldCompare && stageFromEnv != stageFromConfigFile)
+      -\/(ConfigFailure(s"Attempting to run in $stageFromEnv with config from $stageFromConfigFile"))
+    else
+      \/-(())
+  }
+
+  def parseConfig[StepsConfig: Reads](jsonConfig: String): ConfigFailure \/ Config[StepsConfig] = {
     Json.fromJson[Config[StepsConfig]](Json.parse(jsonConfig)) match {
       case validConfig: JsSuccess[Config[StepsConfig]] =>
         logger.info(s"Successfully parsed JSON config")
@@ -37,7 +39,7 @@ object LoadConfig extends Logging {
       case error: JsError =>
         logger.error(s"Failed to parse JSON config")
         logger.warn(s"Failed to parse JSON config: $error")
-        -\/(ConfigFailure(error))
+        -\/(ConfigFailure(error.toString))
     }
   }
 

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
@@ -1,6 +1,5 @@
-package com.gu.util
+package com.gu.util.apigateway
 
-import com.gu.util.apigateway.ApiGatewayRequest
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import play.api.libs.json.{JsResult, JsSuccess, Json}

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/AuthTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/AuthTest.scala
@@ -1,7 +1,6 @@
-package com.gu.util
+package com.gu.util.apigateway
 
 import com.gu.util.apigateway.Auth._
-import com.gu.util.apigateway.{ApiGatewayRequest, RequestAuth}
 import com.gu.util.config.TrustedApiConfig
 import org.scalatest.FlatSpec
 import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}

--- a/lib/handler/src/test/scala/com/gu/util/config/LoadConfigTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/config/LoadConfigTest.scala
@@ -20,18 +20,13 @@ class LoadConfigTest extends FlatSpec with Matchers {
     ))
   }
 
-  "loader" should "succeed if the stage from the environment matches the stage in the config file" in {
-    val confAttempt = LoadConfig.default[String](implicitly)(Stage("DEV"), \/-(devConfig), true)
+  "loader" should "succeed if the expected stage provided matches the stage in the config file" in {
+    val confAttempt = LoadConfig.default[String](implicitly)(Stage("DEV"), \/-(devConfig))
     assert(confAttempt.isRight)
   }
 
-  "loader" should "succeed if the config comparison is overridden, regardless of whether the stages match" in {
-    val confAttempt = LoadConfig.default[String](implicitly)(Stage("PROD"), \/-(devConfig), false)
-    assert(confAttempt.isRight)
-  }
-
-  "loader" should "fail if the stages from the environment and the config file do not match, and the safety check is configured" in {
-    val confAttempt = LoadConfig.default[String](implicitly)(Stage("PROD"), \/-(devConfig), true)
+  "loader" should "fail if the stage in the config file differs from the expected stage provided" in {
+    val confAttempt = LoadConfig.default[String](implicitly)(Stage("PROD"), \/-(devConfig))
     assert(confAttempt.isLeft)
   }
 

--- a/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
+++ b/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
@@ -17,7 +17,7 @@ class RestRequestMakerTest extends AsyncFlatSpec {
   }
 
   "buildRequest" should "set the headers and url correctly" in {
-    val hdr = Map("name" -> "value")
+    val hdr = Map("apiSecretAccessKey" -> "fakePassword")
     val request = RestRequestMaker.buildRequest(hdr, "https://www.test.com/route-test", _.get())
     assert(request.header("apiSecretAccessKey") == "fakePassword")
     assert(request.url.toString == "https://www.test.com/route-test")

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -12,6 +12,7 @@ import com.gu.util.exacttarget.{ETClient, EmailSendSteps, FilterEmail}
 import com.gu.util.zuora.{ZuoraGetAccountSummary, ZuoraGetInvoiceTransactions, ZuoraRestRequestMaker}
 import com.gu.util.Logging
 import com.gu.util.config.{Config, LoadConfig}
+import com.gu.util.reader.Types._
 import okhttp3.{Request, Response}
 
 object AutoCancelHandler extends App with Logging {
@@ -32,7 +33,7 @@ object AutoCancelHandler extends App with Logging {
     }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
       configuredOp = operation(config)
     } yield (config, configuredOp))
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -33,7 +33,8 @@ object AutoCancelHandler extends App with Logging {
     }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+        .toFailableOp("load config")
       configuredOp = operation(config)
     } yield (config, configuredOp))
 

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -33,7 +33,7 @@ object AutoCancelHandler extends App with Logging {
     }
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
         .toFailableOp("load config")
       configuredOp = operation(config)
     } yield (config, configuredOp))

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -26,7 +26,7 @@ object Lambda {
       )
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
         .toFailableOp("load config")
       configuredOp = operation(config)
 

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -26,7 +26,8 @@ object Lambda {
       )
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+        .toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -1,7 +1,6 @@
 package com.gu.paymentFailure
 
 import java.io.{InputStream, OutputStream}
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
@@ -9,6 +8,7 @@ import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.config.{Config, LoadConfig}
 import com.gu.util.exacttarget.{ETClient, EmailSendSteps, FilterEmail}
+import com.gu.util.reader.Types._
 import com.gu.util.zuora.{ZuoraGetInvoiceTransactions, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
 
@@ -26,7 +26,7 @@ object Lambda {
       )
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -1,13 +1,13 @@
 package com.gu.stripeCustomerSourceUpdated
 
 import java.io.{InputStream, OutputStream}
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.config.{Config, LoadConfig}
+import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraRestRequestMaker
 import okhttp3.{Request, Response}
 
@@ -21,7 +21,7 @@ object Lambda {
       )
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -21,7 +21,7 @@ object Lambda {
       )
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage))
         .toFailableOp("load config")
       configuredOp = operation(config)
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -21,7 +21,8 @@ object Lambda {
       )
 
     ApiGatewayHandler[StepsConfig](lambdaIO)(for {
-      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true).toFailableOp("load config")
+      config <- LoadConfig.default[StepsConfig](implicitly)(rawEffects.stage, rawEffects.s3Load(rawEffects.stage), true)
+        .toFailableOp("load config")
       configuredOp = operation(config)
 
     } yield (config, configuredOp))


### PR DESCRIPTION
This PR creates a separate lambda function for each environment. This is so that a failing lambda (due to DEV/UAT Zuora downtime) does not affect the PROD service. 

