### PR TITLE
Add identity-retention lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggreg
   `identity-backfill`,
   `digital-subscription-expiry`,
   `catalog-service`,
+  `identity-retention`,
   effects,
   handler,
   restHttp,
@@ -132,6 +133,9 @@ lazy val `digital-subscription-expiry` = all(project in file("handlers/digital-s
   .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `catalog-service` = all(project in file("handlers/catalog-service"))
+  .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+
+lazy val `identity-retention` = all(project in file("handlers/identity-retention"))
   .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 assemblyJarName := "zuora-auto-cancel.jar"

--- a/handlers/identity-retention/build.sbt
+++ b/handlers/identity-retention/build.sbt
@@ -1,0 +1,24 @@
+// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
+// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
+name := "identity-retention"
+description:= "Confirms whether an identity account can be deleted, from a reader revenue perspective"
+
+scalacOptions += "-Ypartial-unification"
+
+assemblyJarName := "identity-retention.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := "MemSub::Membership Admin::Identity Retention"
+riffRaffArtifactResources += (file("handlers/identity-retention/cfn.yaml"), "cfn/cfn.yaml")
+
+libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
+  "log4j" % "log4j" % "1.2.17",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
+  "com.typesafe.play" %% "play-json" % "2.6.9",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+)

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -97,9 +97,6 @@ Resources:
             RestApiId: !Ref IdentityRetentionAPI
             ResourceId: !Ref IdentityRetentionProxyResource
             HttpMethod: GET
-            RequestParameters:
-              method.request.querystring.apiClientId: true
-              method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
               IntegrationHttpMethod: GET

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -99,7 +99,7 @@ Resources:
             HttpMethod: GET
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: GET
+              IntegrationHttpMethod: POST
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IdentityRetentionLambda.Arn}/invocations
         DependsOn:
         - IdentityRetentionAPI

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -1,0 +1,166 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Performs a reader revenue check to determine whether an identity account should be retained
+
+Parameters:
+    Stage:
+        Description: Stage name
+        Type: String
+        AllowedValues:
+            - PROD
+            - CODE
+        Default: CODE
+
+Conditions:
+  CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]
+
+Mappings:
+    StageMap:
+        CODE:
+            ApiName: identity-retention-api-CODE
+        PROD:
+            ApiName: identity-retention-api-PROD
+
+Resources:
+    IdentityRetentionRole:
+        Type: AWS::IAM::Role
+        Properties:
+            AssumeRolePolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Principal:
+                          Service:
+                             - lambda.amazonaws.com
+                      Action:
+                          - sts:AssumeRole
+            Path: /
+            Policies:
+                - PolicyName: LambdaPolicy
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action:
+                            - logs:CreateLogGroup
+                            - logs:CreateLogStream
+                            - logs:PutLogEvents
+                            - lambda:InvokeFunction
+                            Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/identity-retention-${Stage}:log-stream:*"
+                - PolicyName: ReadPrivateCredentials
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action: s3:GetObject
+                            Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/${Stage}/*
+    IdentityRetentionLambda:
+        Type: AWS::Lambda::Function
+        Properties:
+            Description: Check whether an identity account is attached to an active billing account in Zuora
+            FunctionName:
+                !Sub identity-retention-${Stage}
+            Code:
+                S3Bucket: zuora-auto-cancel-dist
+                S3Key: !Sub membership/${Stage}/identity-retention/identity-retention.jar
+            Handler: com.gu.identityRetention.Handler::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+            Role:
+                Fn::GetAtt:
+                - "IdentityRetentionRole"
+                - Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - "IdentityRetentionRole"
+
+    IdentityRetentionAPIPermission:
+        Type: AWS::Lambda::Permission
+        Properties:
+            Action: lambda:invokeFunction
+            FunctionName: !Sub identity-retention-${Stage}
+            Principal: apigateway.amazonaws.com
+        DependsOn: IdentityRetentionLambda
+
+    IdentityRetentionProxyResource:
+        Type: AWS::ApiGateway::Resource
+        Properties:
+            RestApiId: !Ref IdentityRetentionAPI
+            ParentId: !GetAtt [IdentityRetentionAPI, RootResourceId]
+            PathPart: identity-retention
+        DependsOn: IdentityRetentionAPI
+
+    IdentityRetentionMethod:
+        Type: AWS::ApiGateway::Method
+        Properties:
+            AuthorizationType: NONE
+            ApiKeyRequired: true
+            RestApiId: !Ref IdentityRetentionAPI
+            ResourceId: !Ref IdentityRetentionProxyResource
+            HttpMethod: POST
+            RequestParameters:
+              method.request.querystring.apiClientId: true
+              method.request.querystring.apiToken: true
+            Integration:
+              Type: AWS_PROXY
+              IntegrationHttpMethod: POST
+              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IdentityRetentionLambda.Arn}/invocations
+        DependsOn:
+        - IdentityRetentionAPI
+        - IdentityRetentionLambda
+        - IdentityRetentionProxyResource
+
+    IdentityRetentionAPI:
+        Type: "AWS::ApiGateway::RestApi"
+        Properties:
+            Description: Identity call this API as part of a clean-up process for dormant identity accounts
+            Name: !FindInMap [StageMap, !Ref Stage, ApiName]
+
+    IdentityRetentionAPIStage:
+        Type: AWS::ApiGateway::Stage
+        Properties:
+            Description: Stage for identity-retention-api
+            RestApiId: !Ref IdentityRetentionAPI
+            DeploymentId: !Ref IdentityRetentionAPIDeployment
+            StageName: !Sub ${Stage}
+        DependsOn: IdentityRetentionMethod
+
+    IdentityRetentionAPIDeployment:
+        Type: AWS::ApiGateway::Deployment
+        Properties:
+            Description: Deploys identity-retention-api into an environment/stage
+            RestApiId: !Ref IdentityRetentionAPI
+        DependsOn: IdentityRetentionMethod
+
+    IdentityRetentionAPIKey:
+      Type: AWS::ApiGateway::ApiKey
+      Properties:
+        Description: Key required to call identity retention API
+        Enabled: true
+        Name: !Sub identity-retention-api-key-${Stage}
+        StageKeys:
+          - RestApiId: !Ref IdentityRetentionAPI
+            StageName: !Sub ${Stage}
+      DependsOn:
+      - IdentityRetentionAPI
+      - IdentityRetentionAPIStage
+
+    IdentityRetentionUsagePlan:
+      Type: "AWS::ApiGateway::UsagePlan"
+      Properties:
+        UsagePlanName: !Sub identity-retention-api-usage-plan-${Stage}
+        ApiStages:
+        - ApiId: !Ref IdentityRetentionAPI
+          Stage: !Ref IdentityRetentionAPIStage
+      DependsOn:
+      - IdentityRetentionAPI
+      - IdentityRetentionAPIStage
+
+    IdentityRetentionUsagePlanKey:
+      Type: "AWS::ApiGateway::UsagePlanKey"
+      Properties:
+        KeyId: !Ref IdentityRetentionAPIKey
+        KeyType: API_KEY
+        UsagePlanId: !Ref IdentityRetentionUsagePlan
+      DependsOn:
+      - IdentityRetentionAPIKey
+      - IdentityRetentionUsagePlan

--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -96,13 +96,13 @@ Resources:
             ApiKeyRequired: true
             RestApiId: !Ref IdentityRetentionAPI
             ResourceId: !Ref IdentityRetentionProxyResource
-            HttpMethod: POST
+            HttpMethod: GET
             RequestParameters:
               method.request.querystring.apiClientId: true
               method.request.querystring.apiToken: true
             Integration:
               Type: AWS_PROXY
-              IntegrationHttpMethod: POST
+              IntegrationHttpMethod: GET
               Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IdentityRetentionLambda.Arn}/invocations
         DependsOn:
         - IdentityRetentionAPI

--- a/handlers/identity-retention/riff-raff.yaml
+++ b/handlers/identity-retention/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+- membership
+regions:
+- eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: identity-retention
+    parameters:
+      templatePath: cfn.yaml
+
+  identity-retention:
+    type: aws-lambda
+    parameters:
+      fileName: identity-retention.jar
+      bucket: zuora-auto-cancel-dist
+      prefixStack: false
+      functionNames:
+      - identity-retention-
+    dependencies: [cfn]

--- a/handlers/identity-retention/src/main/resources/log4j.properties
+++ b/handlers/identity-retention/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log = .
+log4j.rootLogger = INFO, LAMBDA
+
+# Define the LAMBDA Appender
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/identity-retention/src/main/scala/com.gu.identityRetention/Handler.scala
+++ b/handlers/identity-retention/src/main/scala/com.gu.identityRetention/Handler.scala
@@ -1,0 +1,39 @@
+package com.gu.identityRetention
+
+import java.io.{InputStream, OutputStream}
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.effects.RawEffects
+import com.gu.util.apigateway.ApiGatewayHandler
+import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
+import com.gu.util.config.ConfigReads.ConfigFailure
+import com.gu.util.config.{Config, LoadConfig, Stage}
+import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraRestConfig
+import okhttp3.{Request, Response}
+import play.api.libs.json.{Json, Reads}
+import scalaz.\/
+
+object Handler {
+
+  case class StepsConfig(zuoraRestConfig: ZuoraRestConfig)
+
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
+
+  // Referenced in Cloudformation
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    runWithEffects(RawEffects.response, RawEffects.stage, RawEffects.s3Load, LambdaIO(inputStream, outputStream, context))
+  }
+
+  def runWithEffects(response: Request => Response, stage: Stage, s3Load: Stage => ConfigFailure \/ String, lambdaIO: LambdaIO) = {
+
+    def operation: Config[StepsConfig] => Operation = config => IdentityRetentionSteps.apply
+
+    ApiGatewayHandler[StepsConfig](lambdaIO)(for {
+      config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(stage))
+        .toFailableOp("load config")
+      configuredOp = operation(config)
+
+    } yield (config, configuredOp))
+  }
+
+}

--- a/handlers/identity-retention/src/main/scala/com.gu.identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com.gu.identityRetention/IdentityRetentionSteps.scala
@@ -1,0 +1,18 @@
+package com.gu.identityRetention
+
+import com.gu.util.Logging
+import com.gu.util.apigateway.ApiGatewayHandler.Operation
+import com.gu.util.apigateway.ApiGatewayRequest
+import com.gu.util.reader.Types._
+import scala.util.Success
+
+object IdentityRetentionSteps extends Logging {
+
+  def apply: Operation = Operation.noHealthcheck(steps, false)
+
+  def steps(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
+    logger.info("Running fake identity retention steps")
+    Success(()).toFailableOp("always succeeds")
+  }
+
+}


### PR DESCRIPTION
Adds resources and deployment config for a new lambda (and API gateway instance), which will be used for the new identity retention check. 

The purpose of this PR is to get the stack up and running (the lambda currently just loads config and returns Success).

