### PR TITLE
Handle GET requests

### DIFF
--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
@@ -1,20 +1,16 @@
 package com.gu.digitalSubscriptionExpiry
 
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
+import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses
 import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.{AccountId, AccountSummaryResult}
 import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription.{SubscriptionId, SubscriptionResult}
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.{ApiGatewayRequest, URLParams}
-import com.gu.util.reader.Types.{FailableOp, _}
+import com.gu.util.reader.Types._
 import main.scala.com.gu.digitalSubscriptionExpiry.DigitalSubscriptionExpiryRequest
-import play.api.libs.json.{JsValue, Json}
 import scalaz.\/-
 
-import scala.util.Try
 object DigitalSubscriptionExpirySteps extends Logging {
-
-  def parseJson(input: String): Option[JsValue] = Try(Json.parse(input)).toOption
 
   def apply(
     getEmergencyTokenExpiry: String => FailableOp[Unit],
@@ -27,14 +23,13 @@ object DigitalSubscriptionExpirySteps extends Logging {
 
     def steps(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
       for {
-        jsonRequest <- parseJson(apiGatewayRequest.body).toFailableOp(badRequest)
-        expiryRequest <- Json.fromJson[DigitalSubscriptionExpiryRequest](jsonRequest).asOpt.toFailableOp(badRequest)
+        expiryRequest <- apiGatewayRequest.parseBody[DigitalSubscriptionExpiryRequest](CommonApiResponses.badRequest)
         _ <- getEmergencyTokenExpiry(expiryRequest.subscriberId)
         subscriptionId = SubscriptionId(expiryRequest.subscriberId.trim.dropWhile(_ == '0'))
         subscriptionResult <- getSubscription(subscriptionId)
         _ <- if (skipActivationDateUpdate(apiGatewayRequest.queryStringParameters, subscriptionResult)) \/-(()) else setActivationDate(subscriptionResult.id)
         accountSummary <- getAccountSummary(subscriptionResult.accountId)
-        password <- expiryRequest.password.toFailableOp(notFoundResponse)
+        password <- expiryRequest.password.toFailableOp(CommonApiResponses.notFoundResponse)
         subscriptionEndDate <- getSubscriptionExpiry(password, subscriptionResult, accountSummary)
       } yield {}
 

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -87,7 +87,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, request, None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
 
     actual.shouldBe(successfulResponseFromZuora)
   }
@@ -100,7 +100,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, request, None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
 
     verifyResponse(
       actualResponse = actual,
@@ -118,7 +118,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, request, None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
 
     val expectedResponseBody =
       """{
@@ -148,7 +148,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, request, None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
 
     verifyResponse(
       actualResponse = actual,
@@ -161,7 +161,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
     val request = "{}"
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, request, None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
 
     verifyResponse(
       actualResponse = actual,
@@ -179,7 +179,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
 
   """.stripMargin
 
-    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, request, None))
+    val actual = digitalSubscriptionExpirySteps.steps(ApiGatewayRequest(None, Some(request), None))
 
     val expectedResponseBody =
       """{

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -34,8 +34,7 @@ object IdentityBackfillSteps extends Logging {
   )(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
 
     for {
-      request <- Json.parse(apiGatewayRequest.body).validate[IdentityBackfillRequest]
-        .toFailableOp.withLogging("identity id backfill request")
+      request <- apiGatewayRequest.parseBody[IdentityBackfillRequest]()
       preReq <- preReqCheck(fromRequest(request))
       _ <- dryRunAbort(request).withLogging("dryrun aborter")
       _ <- updateZuoraIdentityId(preReq.zuoraAccountId, preReq.requiredIdentityId).nonSuccessToError

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -44,7 +44,7 @@ class StepsTest extends FlatSpec with Matchers {
     import stepsWithMocks._
 
     val result =
-      getSteps()(ApiGatewayRequest(None, identityBackfillRequest(false), None))
+      getSteps()(ApiGatewayRequest(None, Some(identityBackfillRequest(false)), None))
 
     val expectedResult = \/-(())
     result should be(expectedResult)
@@ -59,7 +59,7 @@ class StepsTest extends FlatSpec with Matchers {
     import stepsWithMocks._
 
     val result =
-      getSteps()(ApiGatewayRequest(None, identityBackfillRequest(true), None))
+      getSteps()(ApiGatewayRequest(None, Some(identityBackfillRequest(true)), None))
 
     val expectedResult = -\/(ApiGatewayResponse.noActionRequired("DRY RUN requested! skipping to the end"))
     result should be(expectedResult)
@@ -74,7 +74,7 @@ class StepsTest extends FlatSpec with Matchers {
     import stepsWithMocks._
 
     val result =
-      getSteps(false)(ApiGatewayRequest(None, identityBackfillRequest(false), None))
+      getSteps(false)(ApiGatewayRequest(None, Some(identityBackfillRequest(false)), None))
 
     val expectedResult = -\/(ApiGatewayResponse.notFound("dummy"))
     result should be(expectedResult)

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -23,7 +23,7 @@ object ApiGatewayHandler extends Logging {
       jsonString <- inputFromApiGateway(inputStream)
         .toFailableOp("get json data from API gateway").withLogging("payload from api gateway")
       apiGatewayRequest <- Json.parse(jsonString).validate[ApiGatewayRequest]
-        .toFailableOp.withLogging("parsed api gateway object")
+        .toFailableOp().withLogging("parsed api gateway object")
 
     } yield apiGatewayRequest
   }

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -15,12 +15,12 @@ object Types extends Logging {
   // handy classes for converting things
   implicit class JsResultOps[A](jsResult: JsResult[A]) {
 
-    def toFailableOp: FailableOp[A] = {
+    def toFailableOp(response: ApiResponse = badRequest): FailableOp[A] = {
       jsResult match {
-        case JsSuccess(apiGatewayCallout, _) => \/-(apiGatewayCallout)
+        case JsSuccess(value, _) => \/-(value)
         case JsError(error) => {
-          logger.error(s"Error when parsing JSON from API Gateway: $error")
-          -\/(badRequest)
+          logger.error(s"Error when deserializing JSON from API Gateway: $error")
+          -\/(response)
         }
       }
     }

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
@@ -63,7 +63,7 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
     val expected: JsResult[ApiGatewayRequest] = JsSuccess(
       ApiGatewayRequest(
         queryStringParameters = None,
-        body = eventBodySimple,
+        body = Some(eventBodySimple),
         headers = Some(eventHeaders)
       )
     )

--- a/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelSteps.scala
@@ -9,7 +9,6 @@ import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.exacttarget.EmailRequest
 import com.gu.util.reader.Types._
-import play.api.libs.json.Json
 import scalaz.\/-
 
 object AutoCancelSteps extends Logging {
@@ -21,7 +20,7 @@ object AutoCancelSteps extends Logging {
     sendEmailRegardingAccount: (String, PaymentFailureInformation => EmailRequest) => FailableOp[Unit]
   ): Operation = Operation.noHealthcheck({ apiGatewayRequest: ApiGatewayRequest =>
     for {
-      autoCancelCallout <- Json.fromJson[AutoCancelCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("zuora callout")
+      autoCancelCallout <- apiGatewayRequest.parseBody[AutoCancelCallout]()
       _ <- AutoCancelInputFilter(autoCancelCallout, onlyCancelDirectDebit = apiGatewayRequest.onlyCancelDirectDebit)
       acRequest <- autoCancelFilter2(autoCancelCallout).withLogging(s"auto-cancellation filter for ${autoCancelCallout.accountId}")
       _ <- autoCancel(acRequest).withLogging(s"auto-cancellation for ${autoCancelCallout.accountId}")

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -28,7 +28,7 @@ object PaymentFailureSteps extends Logging {
     trustedApiConfig: TrustedApiConfig
   ): Operation = Operation.noHealthcheck({ apiGatewayRequest: ApiGatewayRequest =>
     for {
-      paymentFailureCallout <- Json.fromJson[PaymentFailureCallout](Json.parse(apiGatewayRequest.body)).toFailableOp
+      paymentFailureCallout <- apiGatewayRequest.parseBody[PaymentFailureCallout]()
       _ = logger.info(s"received ${loggableData(paymentFailureCallout)}")
       _ <- validateTenantCallout(trustedApiConfig)(paymentFailureCallout.tenantId)
       request <- makeRequest(etSendIDs, paymentFailureCallout)

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedSteps.scala
@@ -27,7 +27,7 @@ object SourceUpdatedSteps extends Logging {
   def apply(zuoraRequests: Requests, stripeDeps: StripeDeps): Operation = Operation.noHealthcheck({ apiGatewayRequest: ApiGatewayRequest =>
     for {
       _ <- if (stripeDeps.config.signatureChecking) bodyIfSignatureVerified(stripeDeps, apiGatewayRequest) else \/-(())
-      sourceUpdatedCallout <- Json.fromJson[SourceUpdatedCallout](Json.parse(apiGatewayRequest.body)).toFailableOp.withLogging("fromJson SourceUpdatedCallout")
+      sourceUpdatedCallout <- apiGatewayRequest.parseBody[SourceUpdatedCallout]()
       _ = logger.info(s"from: ${apiGatewayRequest.queryStringParameters.map(_.stripeAccount)}")
       _ <- (for {
         defaultPaymentMethod <- ListT(getPaymentMethodsToUpdate(zuoraRequests)(sourceUpdatedCallout.data.`object`.customer, sourceUpdatedCallout.data.`object`.id))
@@ -44,12 +44,12 @@ object SourceUpdatedSteps extends Logging {
     } yield ()
   }
 
-  def bodyIfSignatureVerified(stripeDeps: StripeDeps, apiGatewayRequest: ApiGatewayRequest): FailableOp[String] = {
+  def bodyIfSignatureVerified(stripeDeps: StripeDeps, apiGatewayRequest: ApiGatewayRequest): FailableOp[SourceUpdatedCallout] = {
     val maybeStripeAccount: Option[StripeAccount] = apiGatewayRequest.queryStringParameters.flatMap { params => params.stripeAccount }
-    val signatureVerified: Boolean = verifyRequest(stripeDeps, apiGatewayRequest.headers.getOrElse(Map()), apiGatewayRequest.body, maybeStripeAccount)
+    val signatureVerified: Boolean = verifyRequest(stripeDeps, apiGatewayRequest.headers.getOrElse(Map()), apiGatewayRequest.body.getOrElse(""), maybeStripeAccount)
 
     if (signatureVerified)
-      \/-(apiGatewayRequest.body)
+      apiGatewayRequest.parseBody[SourceUpdatedCallout]()
     else
       -\/(unauthorized)
   }

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -360,7 +360,7 @@ class SourceUpdatedStepsApplyTest extends FlatSpec with Matchers {
       "Stripe-Signature" -> "t=1513759648,v1=longAlphanumericString"
     )
 
-    val someBody =
+    val body =
       """
         |{
         |  "id": "evt_lettersAndNumbers",
@@ -390,7 +390,7 @@ class SourceUpdatedStepsApplyTest extends FlatSpec with Matchers {
         |}
       """.stripMargin
 
-    val testGatewayRequest = ApiGatewayRequest(None, someBody.toString, Some(badHeaders))
+    val testGatewayRequest = ApiGatewayRequest(None, Some(body.toString), Some(badHeaders))
 
     val actual = sourceUpdatedSteps.steps(testGatewayRequest)
 

--- a/src/test/scala/manualTest/CODEPRODHealthCheck.scala
+++ b/src/test/scala/manualTest/CODEPRODHealthCheck.scala
@@ -28,7 +28,7 @@ class CODEPRODHealthCheck extends FlatSpec with Matchers {
   private def healthcheckForEnv(env: HealthChecks => List[HealthCheckConfig]) = {
     val healthchecks = for {
       jsonString <- S3ConfigLoad.load(Stage("DEV"), "payment-failure-healthcheck.private.json").toFailableOp("read local config")
-      healthcheck <- Json.parse(jsonString).validate[HealthChecks](HealthChecks.reads).toFailableOp
+      healthcheck <- Json.parse(jsonString).validate[HealthChecks](HealthChecks.reads).toFailableOp()
 
     } yield env(healthcheck)
 


### PR DESCRIPTION
So far all of our API Gateway > Lambda wiring assumes that the request is a POST. This PR allows us to cope with requests which don't contain a body.