### PR TITLE
Return JSON response bodies

### DIFF
--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
@@ -1,6 +1,6 @@
 package com.gu.digitalSubscriptionExpiry
 
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses
 import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.{AccountId, AccountSummaryResult}
 import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription.{SubscriptionId, SubscriptionResult}
 import com.gu.util.Logging
@@ -23,13 +23,13 @@ object DigitalSubscriptionExpirySteps extends Logging {
 
     def steps(apiGatewayRequest: ApiGatewayRequest): FailableOp[Unit] = {
       for {
-        expiryRequest <- apiGatewayRequest.bodyAsCaseClass[DigitalSubscriptionExpiryRequest](CommonApiResponses.badRequest)
+        expiryRequest <- apiGatewayRequest.bodyAsCaseClass[DigitalSubscriptionExpiryRequest](DigitalSubscriptionApiResponses.badRequest)
         _ <- getEmergencyTokenExpiry(expiryRequest.subscriberId)
         subscriptionId = SubscriptionId(expiryRequest.subscriberId.trim.dropWhile(_ == '0'))
         subscriptionResult <- getSubscription(subscriptionId)
         _ <- if (skipActivationDateUpdate(apiGatewayRequest.queryStringParameters, subscriptionResult)) \/-(()) else setActivationDate(subscriptionResult.id)
         accountSummary <- getAccountSummary(subscriptionResult.accountId)
-        password <- expiryRequest.password.toFailableOp(CommonApiResponses.notFoundResponse)
+        password <- expiryRequest.password.toFailableOp(DigitalSubscriptionApiResponses.notFoundResponse)
         subscriptionEndDate <- getSubscriptionExpiry(password, subscriptionResult, accountSummary)
       } yield {}
 

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiry.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiry.scala
@@ -1,14 +1,13 @@
 package com.gu.digitalSubscriptionExpiry.emergencyToken
 
 import java.time.LocalDate
-
 import com.gu.cas.Valid
 import com.gu.digitalSubscriptionExpiry.DigitalSubscriptionExpirySteps.logger
 import TokenPayloadImplicits._
-import com.gu.digitalSubscriptionExpiry.{Expiry, ExpiryType, SuccessResponse}
 import com.gu.util.reader.Types.FailableOp
 import scalaz.{-\/, \/-}
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.{Expiry, ExpiryType, SuccessResponse}
 
 import scala.util.{Success, Try}
 

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/responses/DigitalSubscriptionApiResponses.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/responses/DigitalSubscriptionApiResponses.scala
@@ -1,13 +1,13 @@
 package com.gu.digitalSubscriptionExpiry.responses
 
-import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}
+import com.gu.util.apigateway.ResponseModels.ApiResponse
 import play.api.libs.json.Json
 
 object DigitalSubscriptionApiResponses {
 
   def apiResponse(body: DigitalSubscriptionExpiryResponse, status: String) = {
     val bodyTxt = Json.prettyPrint(Json.toJson(body))
-    ApiResponse(status, new Headers, bodyTxt)
+    ApiResponse(status, bodyTxt)
   }
 
   val notFoundResponse = apiResponse(ErrorResponse("Unknown subscriber", -90), "404")

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/responses/DigitalSubscriptionApiResponses.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/responses/DigitalSubscriptionApiResponses.scala
@@ -1,10 +1,10 @@
-package com.gu.digitalSubscriptionExpiry.common
+package com.gu.digitalSubscriptionExpiry.responses
 
-import com.gu.digitalSubscriptionExpiry.{DigitalSubscriptionExpiryResponse, ErrorResponse}
 import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}
 import play.api.libs.json.Json
 
-object CommonApiResponses {
+object DigitalSubscriptionApiResponses {
+
   def apiResponse(body: DigitalSubscriptionExpiryResponse, status: String) = {
     val bodyTxt = Json.prettyPrint(Json.toJson(body))
     ApiResponse(status, new Headers, bodyTxt)

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/responses/DigitalSubscriptionResponseModels.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/responses/DigitalSubscriptionResponseModels.scala
@@ -1,4 +1,4 @@
-package com.gu.digitalSubscriptionExpiry
+package com.gu.digitalSubscriptionExpiry.responses
 
 import com.gu.cas.SubscriptionCode
 import java.time.LocalDate

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscription.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscription.scala
@@ -4,11 +4,11 @@ import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.AccountId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types._
 import java.time.LocalDate
-
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import com.gu.util.zuora.RestRequestMaker.{GenericError, NotFound, Requests}
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses._
+
 object GetSubscription {
 
   case class SubscriptionId(get: String) extends AnyVal

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiry.scala
@@ -1,9 +1,8 @@
 package com.gu.digitalSubscriptionExpiry.zuora
 
 import java.time.LocalDate
-
-import com.gu.digitalSubscriptionExpiry._
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.{Expiry, ExpiryType, SuccessResponse}
 import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.AccountSummaryResult
 import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription.{RatePlanCharge, SubscriptionResult}
 import com.gu.util.reader.Types.FailableOp

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
@@ -2,7 +2,6 @@ package com.gu.digitalSubscriptionExpiry
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.time.{LocalDateTime}
-
 import com.gu.effects.RawEffects
 import com.gu.test.EffectsTest
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryResponseTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryResponseTest.scala
@@ -1,8 +1,8 @@
 package com.gu.digitalSubscriptionExpiry
 
 import java.time.LocalDate
-
 import com.gu.cas.SevenDay
+import com.gu.digitalSubscriptionExpiry.responses.{ErrorResponse, Expiry, SuccessResponse}
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import play.api.libs.json.Json

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -1,9 +1,9 @@
 package com.gu.digitalSubscriptionExpiry
 
 import java.time.LocalDate
-
 import com.gu.cas.SevenDay
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.{Expiry, ExpiryType, SuccessResponse}
 import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.{AccountId, AccountSummaryResult}
 import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription.{SubscriptionId, SubscriptionName, SubscriptionResult}
 import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -6,7 +6,7 @@ import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponse
 import com.gu.digitalSubscriptionExpiry.responses.{Expiry, ExpiryType, SuccessResponse}
 import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.{AccountId, AccountSummaryResult}
 import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription.{SubscriptionId, SubscriptionName, SubscriptionResult}
-import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}
+import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse, URLParams}
 import com.gu.util.reader.Types.FailableOp
 import org.scalatest.{FlatSpec, Matchers}
@@ -25,7 +25,7 @@ class DigitalSubscriptionExpiryStepsTest extends FlatSpec with Matchers {
     apiResponse(SuccessResponse(expiry), "200")
   }
 
-  val successfulResponseFromZuora = -\/(ApiResponse("123", new Headers, "valid zuora response"))
+  val successfulResponseFromZuora = -\/(ApiResponse("123", "valid zuora response"))
 
   def getSubId(s: SubscriptionId): FailableOp[SubscriptionResult] = {
     if (s.get == "validZuoraSubId") {

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
@@ -42,7 +42,7 @@ class GetTokenExpiryTest extends FlatSpec with Matchers {
     )
 
     val responseBody = Json.prettyPrint(Json.toJson(SuccessResponse(expiry)))
-    -\/(ApiResponse("200", new Headers, responseBody))
+    -\/(ApiResponse("200", responseBody))
   }
 }
 

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/emergencyToken/GetTokenExpiryTest.scala
@@ -1,9 +1,8 @@
 package com.gu.digitalSubscriptionExpiry.emergencyToken
 
 import java.time.LocalDate
-
 import com.gu.cas.{PrefixedTokens, SevenDay}
-import com.gu.digitalSubscriptionExpiry.{Expiry, ExpiryType, SuccessResponse}
+import com.gu.digitalSubscriptionExpiry.responses.{Expiry, ExpiryType, SuccessResponse}
 import com.gu.util.apigateway.ResponseModels.{ApiResponse, Headers}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.Json

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
@@ -10,7 +10,7 @@ import com.gu.test.EffectsTest
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.{-\/, \/, \/-}
 import scalaz.syntax.std.either._
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses._
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses._
 import com.gu.util.config.{LoadConfig, Stage}
 import com.gu.util.zuora.ZuoraRestRequestMaker
 class GetSubscriptionEffectsTest extends FlatSpec with Matchers {

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionExpiryTest.scala
@@ -1,9 +1,8 @@
 package com.gu.digitalSubscriptionExpiry.zuora
 
 import java.time.LocalDate
-
-import com.gu.digitalSubscriptionExpiry._
-import com.gu.digitalSubscriptionExpiry.common.CommonApiResponses.apiResponse
+import com.gu.digitalSubscriptionExpiry.responses.DigitalSubscriptionApiResponses.apiResponse
+import com.gu.digitalSubscriptionExpiry.responses.{ErrorResponse, Expiry, ExpiryType, SuccessResponse}
 import com.gu.digitalSubscriptionExpiry.zuora.GetAccountSummary.{AccountId, AccountSummaryResult}
 import com.gu.digitalSubscriptionExpiry.zuora.GetSubscription._
 import org.scalatest.FlatSpec

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -21,9 +21,13 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     val (responseString, requests): (String, List[TestingRawEffects.BasicRequest]) = getResultAndRequests(identityBackfillRequest(true))
 
     val expectedResponse =
-      s"""
-         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Processing is not required: DRY RUN requested! skipping to the end"}
-         |""".stripMargin
+      """{
+        |"statusCode":"200",
+        |"headers":{"Content-Type":"application/json"},
+        |"body":"{\n  \"message\" : \"Processing is not required: DRY RUN requested! skipping to the end\"\n}"
+        |}
+        |""".stripMargin
+
     responseString jsonMatches expectedResponse
     requests should be(List(
       BasicRequest("GET", "/services/data/v20.0/sobjects/Contact/00110000011AABBAAB", ""),
@@ -40,9 +44,13 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     val (responseString, requests): (String, List[TestingRawEffects.BasicRequest]) = getResultAndRequests(identityBackfillRequest(false))
 
     val expectedResponse =
-      s"""
-         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
-         |""".stripMargin
+      """{
+        |"statusCode":"200",
+        |"headers":{"Content-Type":"application/json"},
+        |"body":"{\n  \"message\" : \"Success\"\n}"
+        |}
+        |""".stripMargin
+
     responseString jsonMatches expectedResponse
     requests should be(List(
       BasicRequest("PATCH", "/services/data/v20.0/sobjects/Contact/00110000011AABBAAB", """{"IdentityID__c":"1234"}"""),

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
@@ -13,7 +13,7 @@ import play.api.libs.json.Json
 // you should also run the healthcheck in code after deploy
 class HealthCheckSystemTest extends FlatSpec with Matchers {
 
-  it should "successfull run the health check using the local code against real backend" taggedAs EffectsTest in {
+  it should "successfully run the health check using the local code against real backend" taggedAs EffectsTest in {
 
     val stream = new ByteArrayInputStream(healthcheckRequest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     val os = new ByteArrayOutputStream()
@@ -25,9 +25,13 @@ class HealthCheckSystemTest extends FlatSpec with Matchers {
     val responseString = new String(os.toByteArray, "UTF-8")
 
     val expectedResponse =
-      s"""
-         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
-         |""".stripMargin
+      """{
+        |"statusCode":"200",
+        |"headers":{"Content-Type":"application/json"},
+        |"body":"{\n  \"message\" : \"Success\"\n}"
+        |}
+        |""".stripMargin
+
     responseString jsonMatches expectedResponse
   }
 

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -11,7 +11,7 @@ object ResponseModels {
 
   case class Headers(contentType: String = "application/json")
 
-  case class ApiResponse(statusCode: String, headers: Headers, body: String)
+  case class ApiResponse(statusCode: String, body: String, headers: Headers = new Headers)
 
 }
 
@@ -51,31 +51,26 @@ object ApiGatewayResponse extends Logging {
 
   val successfulExecution = ApiResponse(
     "200",
-    new Headers,
     toJsonBody(ResponseBody("Success"))
   )
 
   def noActionRequired(reason: String) = ApiResponse(
     "200",
-    new Headers,
     toJsonBody(ResponseBody(s"Processing is not required: $reason"))
   )
 
   val badRequest = ApiResponse(
     "400",
-    new Headers,
     toJsonBody(ResponseBody("Failure to parse JSON successfully"))
   )
 
   val unauthorized = ApiResponse(
     "401",
-    new Headers,
     toJsonBody(ResponseBody("Credentials are missing or invalid"))
   )
 
   def notFound(message: String) = ApiResponse(
     "404",
-    new Headers,
     toJsonBody(ResponseBody(message))
   )
 
@@ -83,7 +78,6 @@ object ApiGatewayResponse extends Logging {
     logger.error(s"Processing failed due to $error")
     ApiResponse(
       "500",
-      new Headers,
       toJsonBody(ResponseBody(s"Internal server error"))
     )
   }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -5,14 +5,13 @@ import com.gu.util.apigateway.Auth.validTenant
 import com.gu.util.config.ETConfig.ETSendIds
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
-import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
+import com.gu.util.apigateway.ApiGatewayResponse.{unauthorized, internalServerError}
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.config.TrustedApiConfig
 import com.gu.util.exacttarget.EmailRequest
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
-import play.api.libs.json.Json
 import scalaz.syntax.std.option._
 import scalaz.{-\/, \/-}
 
@@ -57,7 +56,7 @@ object ZuoraEmailSteps {
       invoiceTransactionSummary <- getInvoiceTransactions(accountId).leftMap(ZuoraToApiGateway.fromClientFail)
       paymentInformation <- GetPaymentData(accountId)(invoiceTransactionSummary)
       message = toMessage(paymentInformation)
-      _ <- sendEmail(message).leftMap(resp => resp.copy(body = s"email not sent for account ${accountId}"))
+      _ <- sendEmail(message).leftMap(_ => internalServerError(s"email not sent for account ${accountId}"))
     } yield ()
   }
 

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -5,7 +5,7 @@ import com.gu.util.apigateway.Auth.validTenant
 import com.gu.util.config.ETConfig.ETSendIds
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
-import com.gu.util.apigateway.ApiGatewayResponse.{unauthorized, internalServerError}
+import com.gu.util.apigateway.ApiGatewayResponse.{ResponseBody, unauthorized, toJsonBody}
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.config.TrustedApiConfig
 import com.gu.util.exacttarget.EmailRequest
@@ -56,7 +56,8 @@ object ZuoraEmailSteps {
       invoiceTransactionSummary <- getInvoiceTransactions(accountId).leftMap(ZuoraToApiGateway.fromClientFail)
       paymentInformation <- GetPaymentData(accountId)(invoiceTransactionSummary)
       message = toMessage(paymentInformation)
-      _ <- sendEmail(message).leftMap(_ => internalServerError(s"email not sent for account ${accountId}"))
+      _ <- sendEmail(message).leftMap(resp =>
+        resp.copy(body = toJsonBody(ResponseBody(s"email not sent for account ${accountId}"))))
     } yield ()
   }
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -39,25 +39,37 @@ object TestData extends Matchers {
     stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")), true)
   )
 
-  val missingCredentialsResponse = """{
-                                     |"statusCode":"401",
-                                     |"headers":{"Content-Type":"application/json"},
-                                     |"body":"{\n  \"message\" : \"Credentials are missing or invalid\"\n}"
-                                     |}
-                                     |""".stripMargin
-  val successfulResponse = """{
-                             |"statusCode":"200",
-                             |"headers":{"Content-Type":"application/json"},
-                             |"body":"{\n  \"message\" : \"Success\"\n}"
-                             |}
-                             |""".stripMargin
+  val missingCredentialsResponse =
+    """{
+       |"statusCode":"401",
+       |"headers":{"Content-Type":"application/json"},
+       |"body":"{\n  \"message\" : \"Credentials are missing or invalid\"\n}"
+       |}
+       |""".stripMargin
 
-  val internalServerErrorResponse = """{
-                                      |"statusCode":"500",
-                                      |"headers":{"Content-Type":"application/json"},
-                                      |"body":"{\n  \"message\" : \"Internal server error\"\n}"
-                                      |}
-                                      |""".stripMargin
+  val successfulResponse =
+    """{
+       |"statusCode":"200",
+       |"headers":{"Content-Type":"application/json"},
+       |"body":"{\n  \"message\" : \"Success\"\n}"
+       |}
+       |""".stripMargin
+
+  val internalServerErrorResponse =
+    """{
+       |"statusCode":"500",
+       |"headers":{"Content-Type":"application/json"},
+       |"body":"{\n  \"message\" : \"Internal server error\"\n}"
+       |}
+       |""".stripMargin
+
+  val emailFailureResponse =
+    """{
+      |"statusCode":"500",
+      |"headers":{"Content-Type":"application/json"},
+      |"body":"{\n  \"message\" : \"email not sent for account accountId\"\n}"
+      |}
+      |""".stripMargin
 
   implicit class JsonMatcher(private val actual: String) {
     def jsonMatches(expected: String) = {

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -39,8 +39,25 @@ object TestData extends Matchers {
     stripeConfig = StripeConfig(customerSourceUpdatedWebhook = StripeWebhook(ukStripeSecretKey = StripeSecretKey("abc"), auStripeSecretKey = StripeSecretKey("def")), true)
   )
 
-  val missingCredentialsResponse = """{"statusCode":"401","headers":{"Content-Type":"application/json"},"body":"Credentials are missing or invalid"}"""
-  val successfulResponse = """{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}"""
+  val missingCredentialsResponse = """{
+                                     |"statusCode":"401",
+                                     |"headers":{"Content-Type":"application/json"},
+                                     |"body":"{\n  \"message\" : \"Credentials are missing or invalid\"\n}"
+                                     |}
+                                     |""".stripMargin
+  val successfulResponse = """{
+                             |"statusCode":"200",
+                             |"headers":{"Content-Type":"application/json"},
+                             |"body":"{\n  \"message\" : \"Success\"\n}"
+                             |}
+                             |""".stripMargin
+
+  val internalServerErrorResponse = """{
+                                      |"statusCode":"500",
+                                      |"headers":{"Content-Type":"application/json"},
+                                      |"body":"{\n  \"message\" : \"Internal server error\"\n}"
+                                      |}
+                                      |""".stripMargin
 
   implicit class JsonMatcher(private val actual: String) {
     def jsonMatches(expected: String) = {

--- a/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -29,10 +29,13 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
 
     val responseString = new String(os.toByteArray(), "UTF-8")
 
-    val expectedResponse =
-      s"""
-         |{"statusCode":"200","headers":{"Content-Type":"application/json"},"body":"Success"}
-         |""".stripMargin
+    val expectedResponse = """{
+                             |"statusCode":"200",
+                             |"headers":{"Content-Type":"application/json"},
+                             |"body":"{\n  \"message\" : \"Success\"\n}"
+                             |}
+                             |""".stripMargin
+
     responseString jsonMatches expectedResponse
   }
 }

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -7,12 +7,14 @@ import com.gu.TestData._
 import com.gu.stripeCustomerSourceUpdated.SourceUpdatedSteps.StepsConfig
 import com.gu.util.config.ETConfig.ETSendId
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
+import com.gu.util.apigateway.ApiGatewayResponse.ResponseBody
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
 import com.gu.util.config.Stage
 import com.gu.util.exacttarget._
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
 import org.scalatest.{FlatSpec, Matchers}
+
 import scalaz.{-\/, \/-}
 
 class PaymentFailureHandlerTest extends FlatSpec with Matchers {
@@ -163,7 +165,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
 
     val responseString = new String(os.toByteArray(), "UTF-8")
 
-    responseString jsonMatches internalServerErrorResponse
+    responseString jsonMatches emailFailureResponse
   }
 
 }

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -114,8 +114,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
     //verify
     val responseString = new String(os.toByteArray(), "UTF-8")
 
-    val expectedResponse = s"""{"statusCode":"500","headers":{"Content-Type":"application/json"},"body":"Failed to process event due to the following error: Could not retrieve additional data for account $accountId"} """
-    responseString jsonMatches expectedResponse
+    responseString jsonMatches internalServerErrorResponse
   }
 
   def apiGatewayHandler: (Operation, LambdaIO) => Unit = {
@@ -164,8 +163,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
 
     val responseString = new String(os.toByteArray(), "UTF-8")
 
-    val expectedResponse = s"""{"statusCode":"500","headers":{"Content-Type":"application/json"},"body":"email not sent for account $accountId"} """
-    responseString jsonMatches expectedResponse
+    responseString jsonMatches internalServerErrorResponse
   }
 
 }


### PR DESCRIPTION
As we'll need this for the identity team's retention lookup / API call...

Also note that more specific messages about why the operation failed are now logged, rather than returned in the response body (it seemed a bit odd that we were leaking details of the failed operation via the response).

This PR also renames the 'common' package/objects in Digital Subscription Expiry.