### PR TITLE
Exclude accounts which are outside of the retention period

### DIFF
--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -14,7 +14,7 @@ object IdentityRetentionResponseModels {
     implicit val successResponseWrites = Json.writes[SuccessResponse]
   }
 
-  case class NotFoundResponse(message: String = "identity account can be deleted") extends IdentityRetentionResponse
+  case class NotFoundResponse(message: String = "User has no active relationships") extends IdentityRetentionResponse
 
   object NotFoundResponse {
     implicit val notFoundResponseWrites = Json.writes[NotFoundResponse]

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionResponses.scala
@@ -14,7 +14,7 @@ object IdentityRetentionResponseModels {
     implicit val successResponseWrites = Json.writes[SuccessResponse]
   }
 
-  case class NotFoundResponse(previousRelationship: Boolean) extends IdentityRetentionResponse
+  case class NotFoundResponse(message: String = "identity account can be deleted") extends IdentityRetentionResponse
 
   object NotFoundResponse {
     implicit val notFoundResponseWrites = Json.writes[NotFoundResponse]
@@ -43,8 +43,7 @@ object IdentityRetentionApiResponses {
   val ongoingRelationship = apiResponse(SuccessResponse(true, None), "200")
   def cancelledRelationship(latestCancellationDate: LocalDate) = apiResponse(SuccessResponse(false, Some(latestCancellationDate)), "200")
 
-  val notFoundInZuora = apiResponse(NotFoundResponse(false), "404")
-  val outsideOfRetentionPeriod = apiResponse(NotFoundResponse(true), "404")
+  val canBeDeleted = apiResponse(NotFoundResponse(), "404")
 
 }
 

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/RelationshipForSubscriptions.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/RelationshipForSubscriptions.scala
@@ -11,7 +11,7 @@ object RelationshipForSubscriptions {
   def apply(subscriptions: List[SubscriptionsQueryResponse]): ApiResponse = {
     subscriptions match {
       case Nil =>
-        IdentityRetentionApiResponses.notFoundInZuora
+        IdentityRetentionApiResponses.canBeDeleted
       case subs if (subs.exists(_.Status == "Active")) =>
         IdentityRetentionApiResponses.ongoingRelationship
       case _ =>

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/HasActiveZuoraAccountsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/HasActiveZuoraAccountsTest.scala
@@ -12,11 +12,11 @@ class HasActiveZuoraAccountsTest extends FlatSpec with Matchers {
 
   val noZuoraAccounts = QueryResult[IdentityQueryResponse](Nil, 0, true, None)
 
-  val singleZuoraAccount = QueryResult[IdentityQueryResponse](List(IdentityQueryResponse("acc123", "Active")), 1, true, None)
+  val singleZuoraAccount = QueryResult[IdentityQueryResponse](List(IdentityQueryResponse("acc123")), 1, true, None)
 
   it should "return a left(404) if the identity id is not linked to any Zuora accounts" in {
     val zuoraCheck = HasActiveZuoraAccounts.processQueryResult(\/-(noZuoraAccounts))
-    val expected = -\/(IdentityRetentionApiResponses.notFoundInZuora)
+    val expected = -\/(IdentityRetentionApiResponses.canBeDeleted)
     zuoraCheck should be(expected)
   }
 

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerTest.scala
@@ -120,7 +120,7 @@ class IdentityRetentionHandlerTest extends FlatSpec with Matchers {
       |{
       |"statusCode":"404",
       |"headers":{"Content-Type":"application/json"},
-      |"body":"{\n  \"message\" : \"identity account can be deleted\"\n}"
+      |"body":"{\n  \"message\" : \"User has no active relationships\"\n}"
       |}""".stripMargin
 
 }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerTest.scala
@@ -11,7 +11,7 @@ class IdentityRetentionHandlerTest extends FlatSpec with Matchers {
 
   it should "return 404 if the identity id is not linked to any Zuora billing accounts" taggedAs EffectsTest in {
     val actualResponse = runWithMock(dummyRequest("12345"))
-    actualResponse jsonMatches (noPreviousRelationship)
+    actualResponse jsonMatches (safeToDelete)
   }
 
   it should "return an ongoing relationship response (200) if identity id is linked to an active sub" taggedAs EffectsTest in {
@@ -22,6 +22,11 @@ class IdentityRetentionHandlerTest extends FlatSpec with Matchers {
   it should "return 200 if the identity id has a cancelled sub" taggedAs EffectsTest in {
     val actualResponse = runWithMock(dummyRequest("78973513"))
     actualResponse jsonMatches (cancelledRelationship)
+  }
+
+  it should "return 404 if the identity id is only linked to Zuora accounts which are cancelled or tagged with DoNotProcess" taggedAs EffectsTest in {
+    val actualResponse = runWithMock(dummyRequest("78973514"))
+    actualResponse jsonMatches (safeToDelete)
   }
 
   implicit class JsonMatcher(private val actual: String) {
@@ -110,12 +115,12 @@ class IdentityRetentionHandlerTest extends FlatSpec with Matchers {
       |"body":"{\n  \"ongoingRelationship\" : false,\n  \"relationshipEndDate\" : \"2018-04-04\"\n}"
       |}""".stripMargin
 
-  val noPreviousRelationship =
+  val safeToDelete =
     """
       |{
       |"statusCode":"404",
       |"headers":{"Content-Type":"application/json"},
-      |"body":"{\n  \"previousRelationship\" : false\n}"
+      |"body":"{\n  \"message\" : \"identity account can be deleted\"\n}"
       |}""".stripMargin
 
 }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/RelationshipForSubscriptionsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/RelationshipForSubscriptionsTest.scala
@@ -12,7 +12,7 @@ class RelationshipForSubscriptionsTest extends FlatSpec with Matchers {
 
   it should "return a 404 if no subscriptions are found" in {
     val subResults = RelationshipForSubscriptions(List())
-    val expected = IdentityRetentionApiResponses.notFoundInZuora
+    val expected = IdentityRetentionApiResponses.canBeDeleted
     subResults should be(expected)
   }
 


### PR DESCRIPTION
... so that we can allow the associated identity accounts to be deleted.

Note that this PR also removes a distinction between users who don't appear in Zuora at all, and those who are in Zuora (but are outside of the relevant retention period), because nobody can think of a use case for this extra detail in the response.