### PR TITLE
Add simple monitoring for catalog service

### DIFF
--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -207,11 +207,11 @@ Resources:
 
     InvocationErrorsAlarm:
       Type: AWS::CloudWatch::Alarm
-      # Condition: CreateProdOnlyResources
+      Condition: CreateProdOnlyResources
       Properties:
         AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
-        AlarmName: High error rate for PROD Zuora Catalog Service
+        AlarmName: High error rate for Zuora PROD Catalog Service
         ComparisonOperator: GreaterThanThreshold
         Dimensions:
           - Name: FunctionName
@@ -219,7 +219,7 @@ Resources:
         EvaluationPeriods: 9
         MetricName: Errors
         Namespace: AWS/Lambda
-        Period: 3600
+        Period: 600
         Statistic: Sum
         Threshold: 1
         TreatMissingData: notBreaching

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -205,18 +205,56 @@ Resources:
         DependsOn:
         - PRODCatalogServiceLambda
 
-    InvocationErrorsAlarm:
+    StaleProdCatalogAlarm:
       Type: AWS::CloudWatch::Alarm
       Condition: CreateProdOnlyResources
       Properties:
         AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
-        AlarmName: High error rate for Zuora PROD Catalog Service
+        AlarmName: High error rate when fetching PROD Zuora Catalog
         ComparisonOperator: GreaterThanThreshold
         Dimensions:
           - Name: FunctionName
             Value: !Ref PRODCatalogServiceLambda
         EvaluationPeriods: 9
+        MetricName: Errors
+        Namespace: AWS/Lambda
+        Period: 600
+        Statistic: Sum
+        Threshold: 1
+        TreatMissingData: notBreaching
+
+    StaleUatCatalogAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdOnlyResources
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        AlarmName: High error rate when fetching UAT Zuora Catalog
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: FunctionName
+            Value: !Ref UATCatalogServiceLambda
+        EvaluationPeriods: 18
+        MetricName: Errors
+        Namespace: AWS/Lambda
+        Period: 600
+        Statistic: Sum
+        Threshold: 1
+        TreatMissingData: notBreaching
+
+    StaleDevCatalogAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdOnlyResources
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        AlarmName: High error rate when fetching DEV Zuora Catalog
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: FunctionName
+            Value: !Ref DEVCatalogServiceLambda
+        EvaluationPeriods: 36
         MetricName: Errors
         Namespace: AWS/Lambda
         Period: 600

--- a/handlers/catalog-service/cfn.yaml
+++ b/handlers/catalog-service/cfn.yaml
@@ -204,3 +204,22 @@ Resources:
               Id: !Sub PRODCatalogServiceLambda
         DependsOn:
         - PRODCatalogServiceLambda
+
+    InvocationErrorsAlarm:
+      Type: AWS::CloudWatch::Alarm
+      # Condition: CreateProdOnlyResources
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        AlarmName: High error rate for PROD Zuora Catalog Service
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: FunctionName
+            Value: !Ref PRODCatalogServiceLambda
+        EvaluationPeriods: 9
+        MetricName: Errors
+        Namespace: AWS/Lambda
+        Period: 3600
+        Statistic: Sum
+        Threshold: 1
+        TreatMissingData: notBreaching


### PR DESCRIPTION
This PR means that we will be alerted if we fail to update the Zuora catalog(s) in S3 for a sustained period of time:

PROD - an hour and a half
UAT - 3 hours
DEV - 6 hours

Based on https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation

There's no point having super-sensitive alerts because they will just spam us (even more) if the Zuora API is down; these alerts are just intended to catch obvious production bugs/misconfigurations with this handler.