### PR TITLE
Remove false alarm

### DIFF
--- a/handlers/identity-retention/cfn.yaml
+++ b/handlers/identity-retention/cfn.yaml
@@ -225,27 +225,3 @@ Resources:
         Statistic: Sum
         Threshold: 5
         TreatMissingData: notBreaching
-
-    4xxApiAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Condition: CreateProdMonitoring
-      Properties:
-        AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
-        AlarmName:
-          !Sub
-           - 4XX rate from ${ApiName}
-           - { ApiName: !FindInMap [StageMap, !Ref Stage, ApiName] }
-        ComparisonOperator: GreaterThanThreshold
-        Dimensions:
-          - Name: ApiName
-            Value: !FindInMap [StageMap, !Ref Stage, ApiName]
-          - Name: Stage
-            Value: !Sub ${Stage}
-        EvaluationPeriods: 1
-        MetricName: 4XXError
-        Namespace: AWS/ApiGateway
-        Period: 3600
-        Statistic: Sum
-        Threshold: 5
-        TreatMissingData: notBreaching


### PR DESCRIPTION
This metric includes 404s, which is not a response code that we want to get alerts about.