### PR TITLE
moved SalesforceAuthenticate into 'lib'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,9 +29,9 @@ val scalaSettings = Seq(
       .setPreference(NewlineAtEndOfFile, true)
   },libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.7" % "provided",
 
-    autoCompilerPlugins := true,
+  autoCompilerPlugins := true,
 
-addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
+  addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
   scalacOptions += "-P:acyclic:force"
 )
 
@@ -56,48 +56,46 @@ def all(theProject: Project) = theProject.settings(scalaSettings, testSettings).
 
 // ==== START libraries ====
 
-lazy val test = all(project in file("lib/test")).settings(
-  libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+lazy val test = all(project in file("lib/test"))
+  .settings(
+    libraryDependencies ++= Seq(scalatest)
   )
-)
 
 val testDep = test % "test->test"
 
-lazy val zuora = all(project in file("lib/zuora")).dependsOn(restHttp).settings(
-  libraryDependencies ++= Seq(
-    okhttp3, logging, scalaz, playJson, scalatest,
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+lazy val zuora = all(project in file("lib/zuora"))
+  .dependsOn(restHttp)
+  .settings(
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, jacksonDatabind)
   )
-)
 
-lazy val salesforce = all(project in file("lib/salesforce")).dependsOn(
-  restHttp, handler, effects % "test->test", testDep
-).settings(
-  libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
-)
+lazy val salesforce = all(project in file("lib/salesforce"))
+  .dependsOn(restHttp, handler, effects % "test->test", testDep)
+  .settings(
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
+  )
 
-lazy val restHttp = all(project in file("lib/restHttp")).settings(
-  libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
-)
+lazy val restHttp = all(project in file("lib/restHttp"))
+  .settings(
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
+  )
 
-lazy val handler = all(project in file("lib/handler")).settings(
-  libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
-)
+lazy val handler = all(project in file("lib/handler"))
+  .settings(
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
+  )
 
 // to aid testability, only the actual handlers called as a lambda can depend on this
-lazy val effects = all(project in file("lib/effects")).dependsOn(handler).settings(
-  libraryDependencies ++= Seq(
-    okhttp3, logging, scalaz, playJson, scalatest,
-    "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+lazy val effects = all(project in file("lib/effects"))
+  .dependsOn(handler)
+  .settings(
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsS3, jacksonDatabind)
   )
-)
 
 val effectsDepIncludingTestFolder: ClasspathDependency = effects % "compile->compile;test->test"
 
-
-lazy val `zuora-reports` = all(project in file("lib/zuora-reports")).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+lazy val `zuora-reports` = all(project in file("lib/zuora-reports"))
+  .dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 
 // ==== END libraries ====
@@ -122,20 +120,24 @@ lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggreg
 ).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `identity-backfill` = all(project in file("handlers/identity-backfill")) // when using the "project identity-backfill" command it uses the lazy val name
-  .enablePlugins(RiffRaffArtifact).dependsOn(zuora, salesforce, handler, effectsDepIncludingTestFolder, testDep, salesforce % "test->test")
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(zuora, salesforce, handler, effectsDepIncludingTestFolder, testDep, salesforce % "test->test")
 
 lazy val `digital-subscription-expiry` = all(project in file("handlers/digital-subscription-expiry"))
-  .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `catalog-service` = all(project in file("handlers/catalog-service"))
-  .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `identity-retention` = all(project in file("handlers/identity-retention"))
-  .enablePlugins(RiffRaffArtifact).dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `zuora-retention` = all(project in file("handlers/zuora-retention"))
-  .enablePlugins(RiffRaffArtifact).dependsOn(`zuora-reports`, handler, effectsDepIncludingTestFolder, testDep)
-
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(`zuora-reports`, handler, effectsDepIncludingTestFolder, testDep)
 
 // ==== END handlers ====
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -7,9 +7,10 @@ import com.gu.effects.RawEffects
 import com.gu.identity.{GetByEmail, IdentityConfig}
 import com.gu.identityBackfill.Types.{EmailAddress, IdentityId}
 import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SFAuthConfig
+import com.gu.salesforce.auth.SalesforceAuthenticate.SFAuthConfig
 import com.gu.identityBackfill.salesforce._
 import com.gu.identityBackfill.zuora.{AddIdentityIdToAccount, CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail, GetZuoraSubTypeForAccount}
+import com.gu.salesforce.auth.SalesforceAuthenticate
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -7,9 +7,9 @@ import com.gu.effects.TestingRawEffects.{BasicRequest, HTTPResponse, POSTRequest
 import com.gu.identity.GetByEmailTest
 import com.gu.identityBackfill.EndToEndData._
 import com.gu.identityBackfill.Runner._
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticateData
 import com.gu.identityBackfill.salesforce.getContact.GetSFContactSyncCheckFieldsTest
 import com.gu.identityBackfill.zuora.{CountZuoraAccountsForIdentityIdData, GetZuoraAccountsForEmailData}
+import com.gu.salesforce.auth.SalesforceAuthenticateData
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import play.api.libs.json.Json

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/DevSFEffects.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/DevSFEffects.scala
@@ -1,6 +1,7 @@
 package com.gu.identityBackfill.salesforce
 
 import com.gu.identityBackfill.Handler.StepsConfig
+import com.gu.salesforce.auth.SalesforceAuthenticate
 import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.{LoadConfig, Stage}
 import com.gu.util.reader.Types._

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsTest.scala
@@ -4,8 +4,9 @@ import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.HTTPResponse
 import com.gu.identityBackfill.Types.SFContactId
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields.ContactSyncCheckFields
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
-import com.gu.identityBackfill.salesforce.{GetSFContactSyncCheckFields, SalesforceRestRequestMaker}
+import com.gu.salesforce.auth.SalesforceAuthenticate.SalesforceAuth
+import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields
+import com.gu.salesforce.auth.SalesforceRestRequestMaker
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
@@ -3,8 +3,9 @@ package com.gu.identityBackfill.salesforce.updateSFIdentityId
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.identityBackfill.Types.{IdentityId, SFContactId}
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
-import com.gu.identityBackfill.salesforce.{SalesforceRestRequestMaker, UpdateSalesforceIdentityId}
+import com.gu.salesforce.auth.SalesforceAuthenticate.SalesforceAuth
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId
+import com.gu.salesforce.auth.SalesforceRestRequestMaker
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 

--- a/lib/salesforce/src/main/scala/SalesforceAuthenticate.scala
+++ b/lib/salesforce/src/main/scala/SalesforceAuthenticate.scala
@@ -1,6 +1,6 @@
-package com.gu.identityBackfill.salesforce
+package com.gu.salesforce.auth
 
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.salesforce.auth.SalesforceAuthenticate.SalesforceAuth
 import com.gu.util.Logging
 import com.gu.util.reader.Types.{ApiGatewayOp, _}
 import com.gu.util.zuora.RestRequestMaker

--- a/lib/salesforce/src/test/scala/com/gu/salesforce/auth/SalesforceAuthenticateEffectsTest.scala
+++ b/lib/salesforce/src/test/scala/com/gu/salesforce/auth/SalesforceAuthenticateEffectsTest.scala
@@ -1,15 +1,20 @@
-package com.gu.identityBackfill.salesforce
+package com.gu.salesforce.auth
 
 import com.gu.effects.{RawEffects, S3ConfigLoad}
-import com.gu.identityBackfill.Handler.StepsConfig
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.SalesforceAuth
+import com.gu.salesforce.auth.SalesforceAuthenticate.{SFAuthConfig, SalesforceAuth}
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfig, Stage}
 import com.gu.util.reader.Types._
 import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{Json, Reads}
 import scalaz.\/-
 
 class SalesforceAuthenticateEffectsTest extends FlatSpec with Matchers {
+
+  case class StepsConfig(
+    sfConfig: SFAuthConfig
+  )
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
 
   it should "get auth SF correctly" taggedAs EffectsTest in {
 

--- a/lib/salesforce/src/test/scala/com/gu/salesforce/auth/SalesforceAuthenticateTest.scala
+++ b/lib/salesforce/src/test/scala/com/gu/salesforce/auth/SalesforceAuthenticateTest.scala
@@ -1,8 +1,8 @@
-package com.gu.identityBackfill.salesforce
+package com.gu.salesforce.auth
 
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
-import com.gu.identityBackfill.salesforce.SalesforceAuthenticate.{SFAuthConfig, SalesforceAuth}
+import com.gu.salesforce.auth.SalesforceAuthenticate.{SFAuthConfig, SalesforceAuth}
 import org.scalatest.{FlatSpec, Matchers}
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.18"
   val playJson = "com.typesafe.play" %% "play-json" % "2.6.9"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
-
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+  val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311"
 
 }


### PR DESCRIPTION
Moved SalesforceAuthenticate (and accompanying tests) into 'lib' to make available for re-use (initially for a new lambda for case creation, for new cancellation flow)