### PR TITLE
build zuora queries in a fundamentally safe way

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,13 +64,23 @@ lazy val test = all(project in file("lib/test"))
 val testDep = test % "test->test"
 
 lazy val zuora = all(project in file("lib/zuora"))
-  .dependsOn(restHttp)
+  .dependsOn(
+    restHttp,
+    testDep,
+    handler % "test->test",//only for the config, which should ideally be split out
+    effects % "test->test"
+  )
   .settings(
     libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, jacksonDatabind)
   )
 
 lazy val salesforce = all(project in file("lib/salesforce"))
-  .dependsOn(restHttp, handler, effects % "test->test", testDep)
+  .dependsOn(
+    restHttp,
+    handler,// % "test->test" TODO make this dep only in test - SF client shouldn't depends on ApiGateway
+    effects % "test->test",
+    testDep
+  )
   .settings(
     libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
   )

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -2,7 +2,7 @@ package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types.{AccountId, IdentityId}
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery
+import com.gu.util.zuora.ZuoraQuery.Query
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
 import scalaz.ListT
@@ -13,7 +13,7 @@ object CountZuoraAccountsForIdentityId {
   implicit val reads = Json.reads[WireResponse]
 
   def apply(zuoraQuerier: ZuoraQuerier)(identityId: IdentityId): ClientFailableOp[Int] = {
-    val accountByIdentityQuery = ZuoraQuery.Query(s"SELECT Id FROM Account where IdentityId__c='${identityId.value}'")
+    val accountByIdentityQuery = zoql"SELECT Id FROM Account where IdentityId__c=${identityId.value}"
     val accounts = for {
       accountsWithEmail <- ListT[ClientFailableOp, WireResponse](
         zuoraQuerier[WireResponse](accountByIdentityQuery).map(_.records)

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -2,7 +2,8 @@ package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types.IdentityId
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
+import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
 
 object CountZuoraAccountsForIdentityId {

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -1,26 +1,19 @@
 package com.gu.identityBackfill.zuora
 
-import com.gu.identityBackfill.Types.{AccountId, IdentityId}
+import com.gu.identityBackfill.Types.IdentityId
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery.Query
-import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
+import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
 import play.api.libs.json.Json
-import scalaz.ListT
 
 object CountZuoraAccountsForIdentityId {
 
   case class WireResponse(Id: String)
   implicit val reads = Json.reads[WireResponse]
 
-  def apply(zuoraQuerier: ZuoraQuerier)(identityId: IdentityId): ClientFailableOp[Int] = {
-    val accountByIdentityQuery = zoql"SELECT Id FROM Account where IdentityId__c=${identityId.value}"
-    val accounts = for {
-      accountsWithEmail <- ListT[ClientFailableOp, WireResponse](
-        zuoraQuerier[WireResponse](accountByIdentityQuery).map(_.records)
-      )
-    } yield AccountId(accountsWithEmail.Id)
-
-    accounts.run.map(_.size)
-  }
+  def apply(zuoraQuerier: ZuoraQuerier)(identityId: IdentityId): ClientFailableOp[Int] =
+    for {
+      accountByIdentityQuery <- zoql"SELECT Id FROM Account where IdentityId__c=${identityId.value}"
+      noOfAccountsWithID <- zuoraQuerier[WireResponse](accountByIdentityQuery).map(_.size)
+    } yield noOfAccountsWithID
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityId.scala
@@ -14,7 +14,7 @@ object CountZuoraAccountsForIdentityId {
   def apply(zuoraQuerier: ZuoraQuerier)(identityId: IdentityId): ClientFailableOp[Int] =
     for {
       accountByIdentityQuery <- zoql"SELECT Id FROM Account where IdentityId__c=${identityId.value}"
-      noOfAccountsWithID <- zuoraQuerier[WireResponse](accountByIdentityQuery).map(_.size)
-    } yield noOfAccountsWithID
+      noOfAccountsWithID <- zuoraQuerier[WireResponse](accountByIdentityQuery)
+    } yield noOfAccountsWithID.size
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -19,14 +19,14 @@ object GetZuoraAccountsForEmail {
 
   def apply(zuoraQuerier: ZuoraQuerier)(emailAddress: EmailAddress): ClientFailableOp[List[ZuoraAccountIdentitySFContact]] = {
     val accounts = for {
-      contactWithEmail <- {
-        val contactQuery = zoql"SELECT Id FROM Contact where WorkEmail=${emailAddress.value}"
-        ListT(zuoraQuerier[WireResponseContact](contactQuery).map(_.records))
-      }
-      accountsWithEmail <- {
-        val accountQuery = zoql"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId=${contactWithEmail.Id}"
-        ListT[ClientFailableOp, WireResponseAccount](zuoraQuerier[WireResponseAccount](accountQuery).map(_.records))
-      }
+      contactWithEmail <- ListT(for {
+        contactQuery <- zoql"SELECT Id FROM Contact where WorkEmail=${emailAddress.value}"
+        queryResult <- zuoraQuerier[WireResponseContact](contactQuery).map(_.records)
+      } yield queryResult)
+      accountsWithEmail <- ListT(for {
+        accountQuery <- zoql"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId=${contactWithEmail.Id}"
+        queryResult <- zuoraQuerier[WireResponseAccount](accountQuery).map(_.records)
+      } yield queryResult)
     } yield ZuoraAccountIdentitySFContact(
       AccountId(accountsWithEmail.Id),
       accountsWithEmail.IdentityId__c.map(IdentityId.apply),

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -2,7 +2,8 @@ package com.gu.identityBackfill.zuora
 
 import com.gu.identityBackfill.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
+import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
 import scalaz.ListT
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -20,11 +20,11 @@ object GetZuoraAccountsForEmail {
   def apply(zuoraQuerier: ZuoraQuerier)(emailAddress: EmailAddress): ClientFailableOp[List[ZuoraAccountIdentitySFContact]] = {
     val accounts = for {
       contactWithEmail <- {
-        val contactQuery = Query(s"SELECT Id FROM Contact where WorkEmail='${emailAddress.value}'")
+        val contactQuery = zoql"SELECT Id FROM Contact where WorkEmail=${emailAddress.value}"
         ListT(zuoraQuerier[WireResponseContact](contactQuery).map(_.records))
       }
       accountsWithEmail <- {
-        val accountQuery = Query(s"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='${contactWithEmail.Id}'")
+        val accountQuery = zoql"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId=${contactWithEmail.Id}"
         ListT[ClientFailableOp, WireResponseAccount](zuoraQuerier[WireResponseAccount](accountQuery).map(_.records))
       }
     } yield ZuoraAccountIdentitySFContact(

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
@@ -22,7 +22,7 @@ object GetZuoraSubTypeForAccount {
 
   def apply(zuoraQuerier: ZuoraQuerier)(accountId: AccountId): ClientFailableOp[List[ReaderType]] = {
 
-    val contactQuery = Query(s"SELECT ReaderType__c FROM Subscription where AccountId='${accountId.value}'")
+    val contactQuery = zoql"SELECT ReaderType__c FROM Subscription where AccountId=${accountId.value}"
     zuoraQuerier[WireResponse](contactQuery).map(_.records.map(_.ReaderType__c.map(ReaderTypeValue.apply).getOrElse(NoReaderType)))
 
   }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
@@ -22,8 +22,10 @@ object GetZuoraSubTypeForAccount {
 
   def apply(zuoraQuerier: ZuoraQuerier)(accountId: AccountId): ClientFailableOp[List[ReaderType]] = {
 
-    val contactQuery = zoql"SELECT ReaderType__c FROM Subscription where AccountId=${accountId.value}"
-    zuoraQuerier[WireResponse](contactQuery).map(_.records.map(_.ReaderType__c.map(ReaderTypeValue.apply).getOrElse(NoReaderType)))
+    for {
+      contactQuery <- zoql"SELECT ReaderType__c FROM Subscription where AccountId=${accountId.value}"
+      queryResults <- zuoraQuerier[WireResponse](contactQuery).map(_.records.map(_.ReaderType__c.map(ReaderTypeValue.apply).getOrElse(NoReaderType)))
+    } yield queryResults
 
   }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraSubTypeForAccount.scala
@@ -3,7 +3,8 @@ package com.gu.identityBackfill.zuora
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.zuora.GetZuoraSubTypeForAccount.ReaderType.{NoReaderType, ReaderTypeValue}
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
+import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import play.api.libs.json.Json
 
 object GetZuoraSubTypeForAccount {
@@ -24,8 +25,8 @@ object GetZuoraSubTypeForAccount {
 
     for {
       contactQuery <- zoql"SELECT ReaderType__c FROM Subscription where AccountId=${accountId.value}"
-      queryResults <- zuoraQuerier[WireResponse](contactQuery).map(_.records.map(_.ReaderType__c.map(ReaderTypeValue.apply).getOrElse(NoReaderType)))
-    } yield queryResults
+      queryResults <- zuoraQuerier[WireResponse](contactQuery)
+    } yield queryResults.records.map(_.ReaderType__c.map(ReaderTypeValue.apply).getOrElse(NoReaderType))
 
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/CountZuoraAccountsForIdentityIdTest.scala
@@ -36,7 +36,7 @@ object CountZuoraAccountsForIdentityIdData {
          |    "records": [
          |      ${if (hasResult) result else ""}
          |    ],
-         |    "size": 1,
+         |    "size": ${if (hasResult) "1" else "0"},
          |    "done": true
          |}
     """.stripMargin

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/HasActiveZuoraAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/HasActiveZuoraAccounts.scala
@@ -4,7 +4,7 @@ import com.gu.identityRetention.Types.{AccountId, IdentityId}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery
+import com.gu.util.zuora.ZuoraQuery._
 import com.gu.util.zuora.ZuoraQuery.{QueryResult, ZuoraQuerier}
 import play.api.libs.json.Json
 import scalaz.{-\/, \/-}
@@ -18,17 +18,19 @@ object HasActiveZuoraAccounts {
 
     def searchForAccounts = {
 
-      val commonConditions = s"IdentityId__c = '${identityId.value}' and status != 'Canceled'"
+      val commonConditions = zoql"IdentityId__c = ${identityId.value} and status != 'Canceled'"
 
       /*
       Todo simplify this once we can rely on Account.Status
       Unfortunately Zuora do not support parentheses, and != doesn't pick up nulls
       https://knowledgecenter.zuora.com/DC_Developers/K_Zuora_Object_Query_Language#Syntax
       */
-      val identityQuery = ZuoraQuery.Query(
-        s"select id from account where $commonConditions and ProcessingAdvice__c != 'DoNotProcess' or " +
-          s"$commonConditions and ProcessingAdvice__c = null"
-      )
+      val identityQuery =
+        zoql"""select id
+           | from account
+           | where $commonConditions and ProcessingAdvice__c != 'DoNotProcess'
+           |    or $commonConditions and ProcessingAdvice__c = null
+           |""".stripMarginAndNewline
 
       zuoraQuerier[IdentityQueryResponse](identityQuery)
     }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/HasActiveZuoraAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/HasActiveZuoraAccounts.scala
@@ -4,7 +4,7 @@ import com.gu.identityRetention.Types.{AccountId, IdentityId}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery._
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.gu.util.zuora.ZuoraQuery.{QueryResult, ZuoraQuerier}
 import play.api.libs.json.Json
 import scalaz.{-\/, \/-}

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
@@ -16,7 +16,7 @@ object IdentityRetentionSteps extends Logging {
       (for {
         identityId <- extractIdentityId(apiGatewayRequest.queryStringParameters)
         accounts <- HasActiveZuoraAccounts(identityId, zuoraQuerier)
-        subs <- SubscriptionsForAccounts(accounts, zuoraQuerier)
+        subs <- SubscriptionsForAccounts(zuoraQuerier)(accounts)
       } yield RelationshipForSubscriptions(subs)).apiResponse
   }, false)
 

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
@@ -34,7 +34,7 @@ object IdentityRetentionSteps extends Logging {
 
   def validate(input: String): Option[IdentityId] = {
     Try(input.toLong) match {
-      case Success(validUserId) => Some(IdentityId(validUserId))
+      case Success(validUserId) => Some(IdentityId(validUserId.toString))
       case Failure(ex) =>
         logger.error(s"Invalid identity id provided", ex)
         None

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
@@ -5,7 +5,9 @@ import java.time.LocalDate
 import com.gu.identityRetention.Types.AccountId
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.ZuoraQuery.{OrTraverse, Query, SanitisedQuery, ZuoraQuerier}
+import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SanitisedQuery}
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
+import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
 
 object SubscriptionsForAccounts {

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.identityRetention.Types.AccountId
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.RestRequestMaker.ClientFailableOp
-import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SanitisedQuery}
+import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SafeQuery}
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
@@ -20,7 +20,7 @@ object SubscriptionsForAccounts {
 
   implicit val reads = Json.reads[SubscriptionsQueryResponse]
 
-  def buildQuery(accountsToQuery: List[AccountId]): ClientFailableOp[SanitisedQuery] = {
+  def buildQuery(accountsToQuery: List[AccountId]): ClientFailableOp[SafeQuery] = {
     zoql"""select
         id,
         name,

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
@@ -4,8 +4,9 @@ import java.time.LocalDate
 
 import com.gu.identityRetention.Types.AccountId
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.ZuoraQuery.{Query, SanitisedQuery, ZuoraQuerier}
+import com.gu.util.zuora.ZuoraQuery.{Or, Query, SanitisedQuery, ZuoraQuerier}
 import play.api.libs.json.Json
+
 object SubscriptionsForAccounts {
 
   case class SubscriptionsQueryResponse(
@@ -23,7 +24,7 @@ object SubscriptionsForAccounts {
        | status,
        | termEndDate
        | from subscription
-       | where ${accountsToQuery.map(acc => zoql"status != 'Expired' and accountId = ${acc.value}").or}
+       | where ${Or(accountsToQuery.map(acc => zoql"status != 'Expired' and accountId = ${acc.value}"))}
        |"""
       .stripMarginAndNewline
   }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Types.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Types.scala
@@ -2,7 +2,7 @@ package com.gu.identityRetention
 
 object Types {
 
-  case class IdentityId(value: Long)
+  case class IdentityId(value: String)
   case class AccountId(value: String)
 
 }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerEffectsTest.scala
@@ -7,7 +7,7 @@ import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import play.api.libs.json.Json
 
-class IdentityRetentionHandlerTest extends FlatSpec with Matchers {
+class IdentityRetentionHandlerEffectsTest extends FlatSpec with Matchers {
 
   it should "return 404 if the identity id is not linked to any Zuora billing accounts" taggedAs EffectsTest in {
     val actualResponse = runWithMock(dummyRequest("12345"))

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionStepsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionStepsTest.scala
@@ -15,7 +15,7 @@ class IdentityRetentionStepsTest extends FlatSpec with Matchers {
 
   it should "return the identity id if it was included in a query string param" in {
     val result = IdentityRetentionSteps.extractIdentityId(Some(URLParams(None, false, None, false, false, Some("123"))))
-    val expected = \/-(IdentityId(123))
+    val expected = \/-(IdentityId("123"))
     result.toDisjunction should be(expected)
   }
 

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
@@ -12,7 +12,6 @@ import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 import scalaz.syntax.std.either._
 
-// run this manually
 class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
 
   it should "successfull query multiple accounts" taggedAs EffectsTest in {
@@ -21,11 +20,20 @@ class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
       configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
       config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
-      subs <- SubscriptionsForAccounts(zuoraQuerier)(List(AccountId("2c92c0f86371efdc0163871a9ad72274"), AccountId("2c92c0f86371f0360163871d94eb0e68"))).toDisjunction
+      subsForAccounts = SubscriptionsForAccounts(zuoraQuerier)
+      subs <- subsForAccounts(List(
+        AccountId("2c92c0f86371efdc0163871a9ad72274"),
+        AccountId("2c92c0f86371f0360163871d94eb0e68")
+      )).toDisjunction
     } yield {
       subs
     }
-    actual.map(_.map(_.TermEndDate)) should be(\/-(List(LocalDate.of(2019, 5, 21), LocalDate.of(2018, 4, 4))))
+
+    val expectedEndDates = List(
+      LocalDate.of(2019, 5, 21),
+      LocalDate.of(2018, 4, 4)
+    )
+    actual.map(_.map(_.TermEndDate)) should be(\/-(expectedEndDates))
 
   }
 

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
@@ -1,0 +1,32 @@
+package com.gu.identityRetention
+
+import java.time.LocalDate
+
+import com.gu.effects.{RawEffects, S3ConfigLoad}
+import com.gu.identityRetention.Handler.StepsConfig
+import com.gu.identityRetention.Types.AccountId
+import com.gu.test.EffectsTest
+import com.gu.util.config.{LoadConfig, Stage}
+import com.gu.util.zuora.{ZuoraQuery, ZuoraRestRequestMaker}
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+import scalaz.syntax.std.either._
+
+// run this manually
+class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
+
+  it should "successfull query multiple accounts" taggedAs EffectsTest in {
+
+    val actual = for {
+      configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
+      config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
+      zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
+      subs <- SubscriptionsForAccounts(zuoraQuerier)(List(AccountId("2c92c0f86371efdc0163871a9ad72274"), AccountId("2c92c0f86371f0360163871d94eb0e68"))).toDisjunction
+    } yield {
+      subs
+    }
+    actual.map(_.map(_.TermEndDate)) should be(\/-(List(LocalDate.of(2019, 5, 21), LocalDate.of(2018, 4, 4))))
+
+  }
+
+}

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
@@ -30,7 +30,7 @@ class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
       configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
       config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
-      subsForAccounts = SubscriptionsForAccounts(zuoraQuerier)
+      subsForAccounts = SubscriptionsForAccounts(zuoraQuerier) _
       subs <- subsForAccounts(testAccountIds).toDisjunction
     } yield {
       subs

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
@@ -16,23 +16,25 @@ class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
 
   it should "successfull query multiple accounts" taggedAs EffectsTest in {
 
-    val actual = for {
-      configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
-      config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
-      zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
-      subsForAccounts = SubscriptionsForAccounts(zuoraQuerier)
-      subs <- subsForAccounts(List(
-        AccountId("2c92c0f86371efdc0163871a9ad72274"),
-        AccountId("2c92c0f86371f0360163871d94eb0e68")
-      )).toDisjunction
-    } yield {
-      subs
-    }
+    val testAccountIds = List(
+      AccountId("2c92c0f86371efdc0163871a9ad72274"),
+      AccountId("2c92c0f86371f0360163871d94eb0e68")
+    )
 
     val expectedEndDates = List(
       LocalDate.of(2019, 5, 21),
       LocalDate.of(2018, 4, 4)
     )
+
+    val actual = for {
+      configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
+      config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
+      zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
+      subsForAccounts = SubscriptionsForAccounts(zuoraQuerier)
+      subs <- subsForAccounts(testAccountIds).toDisjunction
+    } yield {
+      subs
+    }
     actual.map(_.map(_.TermEndDate)) should be(\/-(expectedEndDates))
 
   }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
@@ -2,6 +2,7 @@ package com.gu.identityRetention
 
 import com.gu.identityRetention.Types.AccountId
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
 
 class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
 
@@ -10,7 +11,7 @@ class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
       AccountId("acc123")
     ))
     val expectedQuery = s"select id, name, status, termEndDate from subscription where status != 'Expired' and accountId = 'acc123'"
-    query.queryString should be(expectedQuery)
+    query.map(_.queryString) should be(\/-(expectedQuery))
   }
 
   it should "build a valid query for multiple accounts" in {
@@ -23,7 +24,7 @@ class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
          | where status != 'Expired' and accountId = 'acc123'
             | or status != 'Expired' and accountId = 'acc321'
          |""".stripMargin.replaceAll("\n", "")
-    query.queryString should be(expectedQuery)
+    query.map(_.queryString) should be(\/-(expectedQuery))
   }
 
 }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
@@ -6,15 +6,24 @@ import org.scalatest.{FlatSpec, Matchers}
 class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
 
   it should "build a valid query for a single account" in {
-    val query = SubscriptionsForAccounts.buildQuery(List(AccountId("acc123")))
+    val query = SubscriptionsForAccounts.buildQuery(List(
+      AccountId("acc123")
+    ))
     val expectedQuery = s"select id, name, status, termEndDate from subscription where status != 'Expired' and accountId = 'acc123'"
-    query should be(expectedQuery)
+    query.queryString should be(expectedQuery)
   }
 
   it should "build a valid query for multiple accounts" in {
-    val query = SubscriptionsForAccounts.buildQuery(List(AccountId("acc123"), AccountId("acc321"), AccountId("acc456")))
-    val expectedQuery = s"select id, name, status, termEndDate from subscription where status != 'Expired' and accountId = 'acc123' or accountId = 'acc321' or accountId = 'acc456'"
-    query should be(expectedQuery)
+    val query = SubscriptionsForAccounts.buildQuery(List(
+      AccountId("acc123"),
+      AccountId("acc321")
+    ))
+    val expectedQuery =
+      s"""select id, name, status, termEndDate from subscription
+         | where status != 'Expired' and accountId = 'acc123'
+            | or status != 'Expired' and accountId = 'acc321'
+         |""".stripMargin.replaceAll("\n", "")
+    query.queryString should be(expectedQuery)
   }
 
 }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -41,6 +41,13 @@ object SafeQueryBuilder {
         \/-(safeQuery.queryString)
     }
 
+    // this code is designed for the zoql query interface, where backslash is used to escape any special characters
+    // https://knowledgecenter.zuora.com/DC_Developers/K_Zuora_Object_Query_Language/Filter_Statements#Reserved_and_Escaped_Characters
+    // However, in the "zoql export" api, which takes pretty much the same types of queries, in typical zuora style they
+    // have gone for escaping single quotes by doubling them up. So we will need a separate serialiser for that at some point
+    // https://knowledgecenter.zuora.com/DC_Developers/M_Export_ZOQL/A_Select_Statement#Reserved_and_Escaped_Characters
+    //
+    // this has been tested and confirmed in june 2018
     implicit val makeSafeStringIntoQueryLiteral: MakeSafe[String] = new MakeSafe[String] {
       override def apply(untrusted: String): ClientFailableOp[String] = {
         if (untrusted.replaceFirst("""\p{Cntrl}""", "") != untrusted) {

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -15,75 +15,73 @@ object SafeQueryBuilder {
 
       // only went up to 4 at the moment, might need more
 
-      def zoql[A: MakeSafe, B: MakeSafe, C: MakeSafe, D: MakeSafe](a: A, b: B, c: C, d: D): ClientFailableOp[SanitisedQuery] =
-        SanitisedQuery(hardCode = sc, inserts = List(asSafe(a), asSafe(b), asSafe(c), asSafe(d)))
+      def zoql[A: MakeSafe, B: MakeSafe, C: MakeSafe, D: MakeSafe](a: A, b: B, c: C, d: D): ClientFailableOp[SafeQuery] =
+        SafeQuery(hardCode = sc, inserts = List(asSafe(a), asSafe(b), asSafe(c), asSafe(d)))
 
-      def zoql[A: MakeSafe, B: MakeSafe, C: MakeSafe](a: A, b: B, c: C): ClientFailableOp[SanitisedQuery] =
-        SanitisedQuery(hardCode = sc, inserts = List(asSafe(a), asSafe(b), asSafe(c)))
+      def zoql[A: MakeSafe, B: MakeSafe, C: MakeSafe](a: A, b: B, c: C): ClientFailableOp[SafeQuery] =
+        SafeQuery(hardCode = sc, inserts = List(asSafe(a), asSafe(b), asSafe(c)))
 
-      def zoql[A: MakeSafe, B: MakeSafe](a: A, b: B): ClientFailableOp[SanitisedQuery] =
-        SanitisedQuery(hardCode = sc, inserts = List(asSafe(a), asSafe(b)))
+      def zoql[A: MakeSafe, B: MakeSafe](a: A, b: B): ClientFailableOp[SafeQuery] =
+        SafeQuery(hardCode = sc, inserts = List(asSafe(a), asSafe(b)))
 
-      def zoql[A: MakeSafe](a: A): ClientFailableOp[SanitisedQuery] =
-        SanitisedQuery(hardCode = sc, inserts = List(asSafe(a)))
+      def zoql[A: MakeSafe](a: A): ClientFailableOp[SafeQuery] =
+        SafeQuery(hardCode = sc, inserts = List(asSafe(a)))
 
     }
 
     def asSafe[A](a: A)(implicit makeSafe: MakeSafe[A]) = makeSafe(a)
 
-    @implicitNotFound("implicitNotFound: ZuoraQuery: can only insert a string literal or a sanitised query into a parent query")
+    @implicitNotFound("implicitNotFound: ZuoraQuery: can only insert a string literal or an already safe query into a parent query")
     trait MakeSafe[A] {
       def apply(a: A): ClientFailableOp[String]
     }
 
-    implicit val makeSafeSanitised = new MakeSafe[SanitisedQuery] {
-      override def apply(sanitised: SanitisedQuery): ClientFailableOp[String] =
-        \/-(sanitised.queryString) // already sanitised
+    implicit val makeSafeAlreadySafe = new MakeSafe[SafeQuery] {
+      override def apply(safeQuery: SafeQuery): ClientFailableOp[String] =
+        \/-(safeQuery.queryString)
     }
 
-    implicit val makeSafeFailableSanitised = new MakeSafe[ClientFail \/ SanitisedQuery] {
-      override def apply(failableSanitised: ClientFail \/ SanitisedQuery): ClientFailableOp[String] =
-        failableSanitised.map(_.queryString)
+    implicit val makeSafeFailableAlreadySafe = new MakeSafe[ClientFail \/ SafeQuery] {
+      override def apply(failableSafeQuery: ClientFail \/ SafeQuery): ClientFailableOp[String] =
+        failableSafeQuery.map(_.queryString)
     }
 
-    implicit val makeSafeStringIntoLiteral = new MakeSafe[String] {
+    implicit val makeSafeStringIntoQueryLiteral = new MakeSafe[String] {
       override def apply(untrusted: String): ClientFailableOp[String] = {
-        val sanitised = \/-(untrusted)
-          .flatMap { orig =>
-            if (orig.replaceAll("""\p{Cntrl}""", "") == orig)
-              \/-(orig)
-            else
-              -\/(GenericError(s"control characters can't be inserted into a query: $orig"))
-          }
-          .map(_.replaceAll("""\\""", """\\\\""")
+        if (untrusted.replaceAll("""\p{Cntrl}""", "") != untrusted) {
+          -\/(GenericError(s"control characters can't be inserted into a query: $untrusted"))
+        } else {
+          val trusted = untrusted.replaceAll("""\\""", """\\\\""")
             .replaceAll("'", """\\'""")
-            .replaceAll(""""""", """\\""""))
-        sanitised.map(sanitised => s"'$sanitised'")
+            .replaceAll(""""""", """\\"""")
+          \/-(s"'$trusted'")
+        }
+
       }
     }
 
   }
 
   object OrTraverse {
-    def apply[A](queries: List[A])(f: A => ClientFailableOp[SanitisedQuery]): ClientFailableOp[SanitisedQuery] = {
-      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SanitisedQuery(_))
+    def apply[A](queries: List[A])(f: A => ClientFailableOp[SafeQuery]): ClientFailableOp[SafeQuery] = {
+      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SafeQuery(_))
     }
   }
 
-  object SanitisedQuery {
+  object SafeQuery {
 
-    def apply(hardCode: StringContext, inserts: List[ClientFailableOp[String]]): ClientFailableOp[SanitisedQuery] = {
+    def apply(hardCode: StringContext, inserts: List[ClientFailableOp[String]]): ClientFailableOp[SafeQuery] = {
       val maybeEscapedInserts = inserts.sequence
       maybeEscapedInserts.map { escapedInserts =>
         val rawQueryString = hardCode.s(escapedInserts.toArray: _*)
         val queryString = rawQueryString.lines.map(_.trim).filter(_ != "").mkString(" ")
-        new SanitisedQuery(queryString)
+        new SafeQuery(queryString)
       }
     }
 
-    def unapply(arg: SanitisedQuery): Option[String] = Some(arg.queryString)
+    def unapply(arg: SafeQuery): Option[String] = Some(arg.queryString)
   }
 
-  class SanitisedQuery(val queryString: String)
+  class SafeQuery(val queryString: String)
 
 }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -43,7 +43,7 @@ object SafeQueryBuilder {
 
     implicit val makeSafeStringIntoQueryLiteral: MakeSafe[String] = new MakeSafe[String] {
       override def apply(untrusted: String): ClientFailableOp[String] = {
-        if (untrusted.replaceAll("""\p{Cntrl}""", "") != untrusted) {
+        if (untrusted.replaceFirst("""\p{Cntrl}""", "") != untrusted) {
           -\/(GenericError(s"control characters can't be inserted into a query: $untrusted"))
         } else {
           val trusted = untrusted.replaceAll("""\\""", """\\\\""")

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -1,0 +1,90 @@
+package com.gu.util.zuora
+
+import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp, GenericError}
+import scalaz.std.list.listInstance
+import scalaz.syntax.traverse.ToTraverseOps
+import scalaz.{-\/, \/, \/-}
+
+import scala.annotation.implicitNotFound
+
+object SafeQueryBuilder {
+
+  object Implicits {
+
+    implicit class Query(val sc: StringContext) extends AnyVal {
+
+      def zoql[A: Conv, B: Conv, C: Conv, D: Conv](a: A, b: B, c: C, d: D): ClientFailableOp[SanitisedQuery] =
+        SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b), conv(c), conv(d)))
+
+      def zoql[A: Conv, B: Conv, C: Conv](a: A, b: B, c: C): ClientFailableOp[SanitisedQuery] =
+        SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b), conv(c)))
+
+      def zoql[A: Conv, B: Conv](a: A, b: B): ClientFailableOp[SanitisedQuery] =
+        SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b)))
+
+      def zoql[A: Conv](a: A): ClientFailableOp[SanitisedQuery] =
+        SanitisedQuery(hardCode = sc, inserts = List(conv(a)))
+
+    }
+
+    def conv[A](a: A)(implicit convertToString: Conv[A]) = convertToString(a)
+
+    @implicitNotFound("implicitNotFound: ZuoraQuery: can only insert a string literal or a sanitised query into a parent query")
+    trait Conv[A] {
+      def apply(a: A): ClientFailableOp[String]
+    }
+
+    implicit val sanitisedConv = new Conv[SanitisedQuery] {
+      override def apply(sanitised: SanitisedQuery): ClientFailableOp[String] =
+        \/-(sanitised.queryString) // already sanitised
+    }
+
+    implicit val failableSanitisedConv = new Conv[ClientFail \/ SanitisedQuery] {
+      override def apply(failableSanitised: ClientFail \/ SanitisedQuery): ClientFailableOp[String] =
+        failableSanitised match {
+          case \/-(SanitisedQuery(sanitisedString)) => \/-(sanitisedString) // already sanitised
+          case -\/(fail: ClientFail) => -\/(fail) // failed to sanitise the sub query
+        }
+    }
+
+    implicit val stringInsertToQueryLiteral = new Conv[String] {
+      override def apply(untrusted: String): ClientFailableOp[String] = {
+        val sanitised = \/-(untrusted)
+          .flatMap { orig =>
+            if (orig.replaceAll("""\p{Cntrl}""", "") == orig)
+              \/-(orig)
+            else
+              -\/(GenericError(s"control characters can't be inserted into a query: $orig"))
+          }
+          .map(_.replaceAll("""\\""", """\\\\""")
+            .replaceAll("'", """\\'""")
+            .replaceAll(""""""", """\\""""))
+        sanitised.map(sanitised => s"'$sanitised'")
+      }
+    }
+
+  }
+
+  object OrTraverse {
+    def apply[A](queries: List[A])(f: A => ClientFailableOp[SanitisedQuery]): ClientFailableOp[SanitisedQuery] = {
+      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SanitisedQuery(_))
+    }
+  }
+
+  object SanitisedQuery {
+
+    def apply(hardCode: StringContext, inserts: List[ClientFailableOp[String]]): ClientFailableOp[SanitisedQuery] = {
+      val maybeEscapedInserts = inserts.sequence
+      maybeEscapedInserts.map { escapedInserts =>
+        val rawQueryString = hardCode.s(escapedInserts.toArray: _*)
+        val queryString = rawQueryString.lines.map(_.trim).filter(_ != "").mkString(" ")
+        new SanitisedQuery(queryString)
+      }
+    }
+
+    def unapply(arg: SanitisedQuery): Option[String] = Some(arg.queryString)
+  }
+
+  class SanitisedQuery(val queryString: String)
+
+}

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -36,17 +36,17 @@ object SafeQueryBuilder {
       def apply(a: A): ClientFailableOp[String]
     }
 
-    implicit val sanitisedConv = new MakeSafe[SanitisedQuery] {
+    implicit val makeSafeSanitised = new MakeSafe[SanitisedQuery] {
       override def apply(sanitised: SanitisedQuery): ClientFailableOp[String] =
         \/-(sanitised.queryString) // already sanitised
     }
 
-    implicit val failableSanitisedConv = new MakeSafe[ClientFail \/ SanitisedQuery] {
+    implicit val makeSafeFailableSanitised = new MakeSafe[ClientFail \/ SanitisedQuery] {
       override def apply(failableSanitised: ClientFail \/ SanitisedQuery): ClientFailableOp[String] =
         failableSanitised.map(_.queryString)
     }
 
-    implicit val stringInsertToQueryLiteral = new MakeSafe[String] {
+    implicit val makeSafeStringIntoLiteral = new MakeSafe[String] {
       override def apply(untrusted: String): ClientFailableOp[String] = {
         val sanitised = \/-(untrusted)
           .flatMap { orig =>

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -12,8 +12,8 @@ object ZuoraQuery {
     }
   }
 
-  implicit class QueryAnd(val queries: List[SanitisedQuery]) extends AnyVal {
-    def or: SanitisedQuery = {
+  object Or {
+    def apply(queries: List[SanitisedQuery]): SanitisedQuery = {
       new SanitisedQuery(queries.map(_.queryString).mkString(" or "))
     }
   }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -12,7 +12,10 @@ object ZuoraQuery {
   case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
 
   // can't generate from macro as it needs an apply method for some reason which we'd rather not expose
-  implicit val queryW: Writes[SafeQuery] = (JsPath \ "queryString").write[String].contramap(_.queryString)
+  implicit val queryW: Writes[SafeQuery] =
+    (response: SafeQuery) => Json.obj(
+      "queryString" -> response.queryString
+    )
 
   implicit val queryLocator: Format[QueryLocator] =
     Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), Writes { (o: QueryLocator) => JsString(o.value) })

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,87 +1,11 @@
 package com.gu.util.zuora
 
 import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp, GenericError, Requests}
+import com.gu.util.zuora.SafeQueryBuilder.SanitisedQuery
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import scalaz.std.list.listInstance
-import scalaz.syntax.traverse.ToTraverseOps
-import scalaz.{-\/, \/, \/-}
-
-import scala.annotation.implicitNotFound
 
 object ZuoraQuery {
-
-  implicit class Query(val sc: StringContext) extends AnyVal {
-
-    def zoql[A: Conv, B: Conv, C: Conv, D: Conv](a: A, b: B, c: C, d: D): ClientFailableOp[SanitisedQuery] =
-      SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b), conv(c), conv(d)))
-
-    def zoql[A: Conv, B: Conv, C: Conv](a: A, b: B, c: C): ClientFailableOp[SanitisedQuery] =
-      SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b), conv(c)))
-
-    def zoql[A: Conv, B: Conv](a: A, b: B): ClientFailableOp[SanitisedQuery] =
-      SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b)))
-
-    def zoql[A: Conv](a: A): ClientFailableOp[SanitisedQuery] =
-      SanitisedQuery(hardCode = sc, inserts = List(conv(a)))
-
-  }
-
-  def conv[A](a: A)(implicit aString: Conv[A]) = aString(a)
-
-  @implicitNotFound("implicitNotFound: ZuoraQuery: can only insert a string literal or a sanitised query into a parent query")
-  trait Conv[A] {
-    def apply(a: A): ClientFailableOp[String]
-  }
-
-  implicit val aaa = new Conv[SanitisedQuery] {
-    override def apply(a: SanitisedQuery): ClientFailableOp[String] = \/-(a.queryString) // already sanitised
-  }
-
-  implicit val aaac = new Conv[ClientFail \/ SanitisedQuery] {
-    override def apply(a: ClientFail \/ SanitisedQuery): ClientFailableOp[String] = a match {
-      case \/-(SanitisedQuery(string)) => \/-(string) // already sanitised
-      case -\/(fail: ClientFail) => -\/(fail) // failed to sanitise the sub query
-    }
-  }
-
-  implicit val stringInsertToQueryLiteral = new Conv[String] {
-    override def apply(untrusted: String): ClientFailableOp[String] = {
-      val sanitised = \/-(untrusted)
-        .flatMap { orig =>
-          if (orig.replaceAll("""\p{Cntrl}""", "") == orig)
-            \/-(orig)
-          else
-            -\/(GenericError(s"control characters can't be inserted into a query: $orig"))
-        }
-        .map(_.replaceAll("""\\""", """\\\\""")
-          .replaceAll("'", """\\'""")
-          .replaceAll(""""""", """\\""""))
-      sanitised.map(sanitised => s"'$sanitised'")
-    }
-  }
-
-  object OrTraverse {
-    def apply[A](queries: List[A])(f: A => ClientFailableOp[SanitisedQuery]): ClientFailableOp[SanitisedQuery] = {
-      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SanitisedQuery(_))
-    }
-  }
-
-  object SanitisedQuery {
-
-    def apply(hardCode: StringContext, inserts: List[ClientFailableOp[String]]): ClientFailableOp[SanitisedQuery] = {
-      val maybeEscapedInserts = inserts.sequence
-      maybeEscapedInserts.map { escapedInserts =>
-        val rawQueryString = hardCode.s(escapedInserts.toArray: _*)
-        val queryString = rawQueryString.lines.map(_.trim).filter(_ != "").mkString(" ")
-        new SanitisedQuery(queryString)
-      }
-    }
-
-    def unapply(arg: SanitisedQuery): Option[String] = Some(arg.queryString)
-  }
-
-  class SanitisedQuery(val queryString: String)
 
   case class QueryLocator(value: String) extends AnyVal
 
@@ -113,6 +37,6 @@ object ZuoraQuery {
   trait ZuoraQuerier {
     // this is a single function that can be partially applied, but it has to be a trait because type parameters are needed
     // don't add any extra methods to this trait
-    def apply[QUERYRECORD: Reads](query: ZuoraQuery.SanitisedQuery): ClientFailableOp[QueryResult[QUERYRECORD]]
+    def apply[QUERYRECORD: Reads](query: SanitisedQuery): ClientFailableOp[QueryResult[QUERYRECORD]]
   }
 }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -50,7 +50,8 @@ object ZuoraQuery {
 
   case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
 
-  implicit val queryW: Writes[SanitisedQuery] = Json.writes[SanitisedQuery]
+  // can't generate from macro as it needs an apply method for some reason which we'd rather not expose
+  implicit val queryW: Writes[SanitisedQuery] = (JsPath \ "queryString").write[String].contramap(_.queryString)
 
   implicit val queryLocator: Format[QueryLocator] =
     Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), Writes { (o: QueryLocator) => JsString(o.value) })

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,6 +1,6 @@
 package com.gu.util.zuora
 
-import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp, GenericError, Requests}
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
 import com.gu.util.zuora.SafeQueryBuilder.SafeQuery
 import play.api.libs.functional.syntax._
 import play.api.libs.json._

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,50 +1,87 @@
 package com.gu.util.zuora
 
-import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
+import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp, GenericError, Requests}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import scalaz.std.list.listInstance
+import scalaz.syntax.traverse.ToTraverseOps
+import scalaz.{-\/, \/, \/-}
+
+import scala.annotation.implicitNotFound
 
 object ZuoraQuery {
 
   implicit class Query(val sc: StringContext) extends AnyVal {
-    def zoql(args: Any*): SanitisedQuery = {
-      SanitisedQuery(hardCode = sc, inserts = args)
+
+    def zoql[A: Conv, B: Conv, C: Conv, D: Conv](a: A, b: B, c: C, d: D): ClientFailableOp[SanitisedQuery] =
+      SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b), conv(c), conv(d)))
+
+    def zoql[A: Conv, B: Conv, C: Conv](a: A, b: B, c: C): ClientFailableOp[SanitisedQuery] =
+      SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b), conv(c)))
+
+    def zoql[A: Conv, B: Conv](a: A, b: B): ClientFailableOp[SanitisedQuery] =
+      SanitisedQuery(hardCode = sc, inserts = List(conv(a), conv(b)))
+
+    def zoql[A: Conv](a: A): ClientFailableOp[SanitisedQuery] =
+      SanitisedQuery(hardCode = sc, inserts = List(conv(a)))
+
+  }
+
+  def conv[A](a: A)(implicit aString: Conv[A]) = aString(a)
+
+  @implicitNotFound("implicitNotFound: ZuoraQuery: can only insert a string literal or a sanitised query into a parent query")
+  trait Conv[A] {
+    def apply(a: A): ClientFailableOp[String]
+  }
+
+  implicit val aaa = new Conv[SanitisedQuery] {
+    override def apply(a: SanitisedQuery): ClientFailableOp[String] = \/-(a.queryString) // already sanitised
+  }
+
+  implicit val aaac = new Conv[ClientFail \/ SanitisedQuery] {
+    override def apply(a: ClientFail \/ SanitisedQuery): ClientFailableOp[String] = a match {
+      case \/-(SanitisedQuery(string)) => \/-(string) // already sanitised
+      case -\/(fail: ClientFail) => -\/(fail) // failed to sanitise the sub query
     }
   }
 
-  object Or {
-    def apply(queries: List[SanitisedQuery]): SanitisedQuery = {
-      new SanitisedQuery(queries.map(_.queryString).mkString(" or "))
+  implicit val stringInsertToQueryLiteral = new Conv[String] {
+    override def apply(untrusted: String): ClientFailableOp[String] = {
+      val sanitised = \/-(untrusted)
+        .flatMap { orig =>
+          if (orig.replaceAll("""\p{Cntrl}""", "") == orig)
+            \/-(orig)
+          else
+            -\/(GenericError(s"control characters can't be inserted into a query: $orig"))
+        }
+        .map(_.replaceAll("""\\""", """\\\\""")
+          .replaceAll("'", """\\'""")
+          .replaceAll(""""""", """\\""""))
+      sanitised.map(sanitised => s"'$sanitised'")
+    }
+  }
+
+  object OrTraverse {
+    def apply[A](queries: List[A])(f: A => ClientFailableOp[SanitisedQuery]): ClientFailableOp[SanitisedQuery] = {
+      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SanitisedQuery(_))
     }
   }
 
   object SanitisedQuery {
 
-    def sanitise(input: String): String = {
-      val sanitised = input
-        .replaceAll("""\p{Cntrl}""", "")
-        .replaceAll("""\\""", """\\\\""")
-        .replaceAll("'", """\\'""")
-        .replaceAll(""""""", """\\"""")
-      s"'$sanitised'"
-    }
-
-    def doInsert(input: Any): String = input match {
-      case SanitisedQuery(string) => string // already sanitised
-      case untrusted => sanitise(untrusted.toString)
-    }
-
-    def apply(hardCode: StringContext, inserts: Seq[Any]): SanitisedQuery = {
-      val queryString = hardCode.s(inserts.map(doInsert).toArray: _*)
-      new SanitisedQuery(queryString)
+    def apply(hardCode: StringContext, inserts: List[ClientFailableOp[String]]): ClientFailableOp[SanitisedQuery] = {
+      val maybeEscapedInserts = inserts.sequence
+      maybeEscapedInserts.map { escapedInserts =>
+        val rawQueryString = hardCode.s(escapedInserts.toArray: _*)
+        val queryString = rawQueryString.lines.map(_.trim).filter(_ != "").mkString(" ")
+        new SanitisedQuery(queryString)
+      }
     }
 
     def unapply(arg: SanitisedQuery): Option[String] = Some(arg.queryString)
   }
 
-  class SanitisedQuery(val queryString: String) {
-    def stripMarginAndNewline: SanitisedQuery = new SanitisedQuery(queryString.stripMargin.replaceAll("\n", ""))
-  }
+  class SanitisedQuery(val queryString: String)
 
   case class QueryLocator(value: String) extends AnyVal
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,7 +1,7 @@
 package com.gu.util.zuora
 
 import com.gu.util.zuora.RestRequestMaker.{ClientFail, ClientFailableOp, GenericError, Requests}
-import com.gu.util.zuora.SafeQueryBuilder.SanitisedQuery
+import com.gu.util.zuora.SafeQueryBuilder.SafeQuery
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -12,7 +12,7 @@ object ZuoraQuery {
   case class QueryResult[QUERYRECORD](records: List[QUERYRECORD], size: Int, done: Boolean, queryLocator: Option[QueryLocator])
 
   // can't generate from macro as it needs an apply method for some reason which we'd rather not expose
-  implicit val queryW: Writes[SanitisedQuery] = (JsPath \ "queryString").write[String].contramap(_.queryString)
+  implicit val queryW: Writes[SafeQuery] = (JsPath \ "queryString").write[String].contramap(_.queryString)
 
   implicit val queryLocator: Format[QueryLocator] =
     Format[QueryLocator](JsPath.read[String].map(QueryLocator.apply), Writes { (o: QueryLocator) => JsString(o.value) })
@@ -30,13 +30,13 @@ object ZuoraQuery {
 
   // in order to allow partial application with unapplied type parameter, we need to use a trait
   def apply(requests: Requests): ZuoraQuerier = new ZuoraQuerier {
-    def apply[QUERYRECORD: Reads](query: SanitisedQuery): ClientFailableOp[QueryResult[QUERYRECORD]] =
+    def apply[QUERYRECORD: Reads](query: SafeQuery): ClientFailableOp[QueryResult[QUERYRECORD]] =
       requests.post(query, s"action/query", true): ClientFailableOp[QueryResult[QUERYRECORD]]
   }
 
   trait ZuoraQuerier {
     // this is a single function that can be partially applied, but it has to be a trait because type parameters are needed
     // don't add any extra methods to this trait
-    def apply[QUERYRECORD: Reads](query: SanitisedQuery): ClientFailableOp[QueryResult[QUERYRECORD]]
+    def apply[QUERYRECORD: Reads](query: SafeQuery): ClientFailableOp[QueryResult[QUERYRECORD]]
   }
 }

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -20,16 +20,13 @@ object ZuoraQuery {
 
   object SanitisedQuery {
 
-    @deprecated("use zoql\"query=$here\" string interpolation", "")
-    def apply(queryString: String): SanitisedQuery = new SanitisedQuery("")
-
     def sanitise(input: String): String = {
       val sanitised = input
         .replaceAll("""\p{Cntrl}""", "")
         .replaceAll("""\\""", """\\\\""")
         .replaceAll("'", """\\'""")
         .replaceAll(""""""", """\\"""")
-      s"'${sanitised}'"
+      s"'$sanitised'"
     }
 
     def doInsert(input: Any): String = input match {
@@ -41,9 +38,11 @@ object ZuoraQuery {
       val queryString = hardCode.s(inserts.map(doInsert).toArray: _*)
       new SanitisedQuery(queryString)
     }
+
+    def unapply(arg: SanitisedQuery): Option[String] = Some(arg.queryString)
   }
 
-  case class SanitisedQuery(queryString: String) {
+  class SanitisedQuery(val queryString: String) {
     def stripMarginAndNewline: SanitisedQuery = new SanitisedQuery(queryString.stripMargin.replaceAll("\n", ""))
   }
 

--- a/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
@@ -82,7 +82,4 @@ class SafeQueryBuilderApplyTest extends FlatSpec with Matchers {
     actual.map(_.queryString) should be(\/-("""select hi from table where id = 'anna' or id = 'bill'"""))
   }
 
-  //POST query - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'
-  // NOTE for "zoql export" we don't escape anything, just double up on single quotes only. tested all june 2018
-
 }

--- a/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
@@ -38,12 +38,15 @@ class SafeQueryBuilderEscapeTest extends FlatSpec with Matchers {
     actual.map(_.length) should be(\/-(4))
   }
 
-  it should "remove control chars - this is not 100% safe - we should reject completely" in {
-    val actual = makeSafeStringIntoQueryLiteral("\t\n\rhello\u007f\u0000")
-    actual.leftMap {
-      case GenericError(mess) => mess.split(':')(0)
-      case a => a
-    } should be(-\/("control characters can't be inserted into a query"))
+  it should "reject control chars completely" in {
+    val badChars = "\t\n\r\u007f\u0000".toCharArray.toList
+    badChars.foreach { char =>
+      val actual = makeSafeStringIntoQueryLiteral(s"hello${char}bye")
+      actual.leftMap {
+        case GenericError(mess) => mess.split(':')(0)
+        case a => a
+      } should be(-\/("control characters can't be inserted into a query"))
+    }
   }
 
 }

--- a/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
@@ -72,8 +72,10 @@ class SafeQueryBuilderApplyTest extends FlatSpec with Matchers {
 
   it should "use a List in insert clause" in {
     val ids = List("anna", "bill")
-    val insert = OrTraverse(ids)({ id => zoql"""id = $id""" })
-    val actual: ClientFailableOp[SafeQuery] = zoql"""select hi from table where $insert"""
+    val actual = for {
+      insert <- OrTraverse(ids)({ id => zoql"""id = $id""" })
+      wholeQuery <- zoql"""select hi from table where $insert"""
+    } yield wholeQuery
     actual.map(_.queryString) should be(\/-("""select hi from table where id = 'anna' or id = 'bill'"""))
   }
 

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
@@ -7,8 +7,8 @@ import com.gu.util.zuora.ZuoraQuery._
 import com.gu.util.zuora.{RestRequestMaker, ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{Json, Reads}
-import scalaz.{\/, \/-}
 import scalaz.syntax.std.either._
+import scalaz.{\/, \/-}
 
 // run this manually
 class ZuoraQueryEffectsTest extends FlatSpec with Matchers {
@@ -46,18 +46,16 @@ object SubscriptionsForPromoCode {
 
   def apply(zuoraQuerier: ZuoraQuerier)(testString: String): RestRequestMaker.ClientFail \/ List[TestQueryResponse] = {
 
-    def searchForSubscriptions = {
-      val subscriptionsQuery = zoql"""select
-                                     | id,
-                                     | promotionCode__c
-                                     | from subscription
-                                     | where PromotionCode__c = $testString
-                                     |"""
-        .stripMarginAndNewline
-      zuoraQuerier[TestQueryResponse](subscriptionsQuery)
-    }
-
-    searchForSubscriptions.map(_.records)
+    for {
+      subscriptionsQuery <- zoql"""
+                select
+                id,
+                promotionCode__c
+                from subscription
+                where PromotionCode__c = $testString
+                """
+      queryResult <- zuoraQuerier[TestQueryResponse](subscriptionsQuery)
+    } yield queryResult.records
 
   }
 

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
@@ -23,7 +23,7 @@ class ZuoraQueryEffectsTest extends FlatSpec with Matchers {
       configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
       config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
-      subs <- SubscriptionsForAccounts(zuoraQuerier)("""qwerty"asdf'zxcv\1234""")
+      subs <- SubscriptionsForPromoCode(zuoraQuerier)("""qwerty"asdf'zxcv\1234""")
     } yield {
       subs
     }
@@ -32,7 +32,7 @@ class ZuoraQueryEffectsTest extends FlatSpec with Matchers {
   }
 
 }
-object SubscriptionsForAccounts {
+object SubscriptionsForPromoCode {
 
   //POST query - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'
   // NOTE for "zoql export" we don't escape anything, just double up on single quotes only. tested all june 2018

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
@@ -25,6 +25,9 @@ class ZuoraQueryEffectsTest extends FlatSpec with Matchers {
       config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
       subs <- SubscriptionsForPromoCode(zuoraQuerier)("""qwerty"asdf'zxcv\1234""")
+
+      //POST query should be - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'
+
     } yield {
       subs
     }

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
@@ -3,6 +3,7 @@ package com.gu.util
 import com.gu.effects.{RawEffects, S3ConfigLoad}
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfig, Stage}
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.gu.util.zuora.ZuoraQuery._
 import com.gu.util.zuora.{RestRequestMaker, ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryEffectsTest.scala
@@ -1,0 +1,64 @@
+package com.gu.util
+
+import com.gu.effects.{RawEffects, S3ConfigLoad}
+import com.gu.test.EffectsTest
+import com.gu.util.config.{LoadConfig, Stage}
+import com.gu.util.zuora.ZuoraQuery._
+import com.gu.util.zuora.{RestRequestMaker, ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{Json, Reads}
+import scalaz.{\/, \/-}
+import scalaz.syntax.std.either._
+
+// run this manually
+class ZuoraQueryEffectsTest extends FlatSpec with Matchers {
+
+  case class StepsConfig(zuoraRestConfig: ZuoraRestConfig)
+
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
+
+  it should "successfull query multiple accounts" taggedAs EffectsTest in {
+
+    val actual = for {
+      configAttempt <- S3ConfigLoad.load(Stage("DEV")).toEither.disjunction
+      config <- LoadConfig.parseConfig[StepsConfig](configAttempt)
+      zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
+      subs <- SubscriptionsForAccounts(zuoraQuerier)("""qwerty"asdf'zxcv\1234""")
+    } yield {
+      subs
+    }
+    actual.map(_.map(_.PromotionCode__c)) should be(\/-(List("""qwerty"asdf'zxcv\1234""")))
+
+  }
+
+}
+object SubscriptionsForAccounts {
+
+  //POST query - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'
+  // NOTE for "zoql export" we don't escape anything, just double up on single quotes only. tested all june 2018
+
+  case class TestQueryResponse(
+    Id: String,
+    PromotionCode__c: String
+  )
+
+  implicit val reads = Json.reads[TestQueryResponse]
+
+  def apply(zuoraQuerier: ZuoraQuerier)(testString: String): RestRequestMaker.ClientFail \/ List[TestQueryResponse] = {
+
+    def searchForSubscriptions = {
+      val subscriptionsQuery = zoql"""select
+                                     | id,
+                                     | promotionCode__c
+                                     | from subscription
+                                     | where PromotionCode__c = $testString
+                                     |"""
+        .stripMarginAndNewline
+      zuoraQuerier[TestQueryResponse](subscriptionsQuery)
+    }
+
+    searchForSubscriptions.map(_.records)
+
+  }
+
+}

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
@@ -9,37 +9,37 @@ import scalaz.{-\/, \/-}
 class WireQueryEscapeTest extends FlatSpec with Matchers {
 
   it should "escape single quotes" in {
-    val actual = stringInsertToQueryLiteral("""bobby tables'drop database students""")
+    val actual = makeSafeStringIntoLiteral("""bobby tables'drop database students""")
     actual should be(\/-("""'bobby tables\'drop database students'"""))
   }
 
   it should "escape double quotes" in {
-    val actual = stringInsertToQueryLiteral("""a very "nice" query""")
+    val actual = makeSafeStringIntoLiteral("""a very "nice" query""")
     actual should be(\/-("""'a very \"nice\" query'"""))
   }
 
   it should "escape backslashes" in {
-    val actual = stringInsertToQueryLiteral("""a very \ query""")
+    val actual = makeSafeStringIntoLiteral("""a very \ query""")
     actual should be(\/-("""'a very \\ query'"""))
   }
 
   it should "escape single quotes double check the length" in {
-    val actual = stringInsertToQueryLiteral("""'""")
+    val actual = makeSafeStringIntoLiteral("""'""")
     actual.map(_.length) should be(\/-(4))
   }
 
   it should "escape double quotes double check the length" in {
-    val actual = stringInsertToQueryLiteral(""""""")
+    val actual = makeSafeStringIntoLiteral(""""""")
     actual.map(_.length) should be(\/-(4))
   }
 
   it should "escape backslash double check the length" in {
-    val actual = stringInsertToQueryLiteral("""\""")
+    val actual = makeSafeStringIntoLiteral("""\""")
     actual.map(_.length) should be(\/-(4))
   }
 
   it should "remove control chars - this is not 100% safe - we should reject completely" in {
-    val actual = stringInsertToQueryLiteral("\t\n\rhello\u007f\u0000")
+    val actual = makeSafeStringIntoLiteral("\t\n\rhello\u007f\u0000")
     actual.leftMap {
       case GenericError(mess) => mess.split(':')(0)
       case a => a

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
@@ -1,0 +1,77 @@
+package com.gu.util
+
+import com.gu.util.zuora.ZuoraQuery.{SanitisedQuery, Query}
+import org.scalatest._
+
+class WireQueryEscapeTest extends FlatSpec with Matchers {
+
+  it should "escape signel quotes" in {
+    val actual = SanitisedQuery.sanitise("""bobby tables'drop database students""")
+    actual should be("""'bobby tables\'drop database students'""")
+  }
+
+  it should "escape double quotes" in {
+    val actual = SanitisedQuery.sanitise("""a very "nice" query""")
+    actual should be("""'a very \"nice\" query'""")
+  }
+
+  it should "escape backslashes" in {
+    val actual = SanitisedQuery.sanitise("""a very \ query""")
+    actual should be("""'a very \\ query'""")
+  }
+
+  it should "escape signel quotes double check the length" in {
+    val actual = SanitisedQuery.sanitise("""'""")
+    actual.length should be(4)
+  }
+
+  it should "escape double quotes double check the length" in {
+    val actual = SanitisedQuery.sanitise(""""""")
+    actual.length should be(4)
+  }
+
+  it should "escape backslasgh double check the length" in {
+    val actual = SanitisedQuery.sanitise("""\""")
+    actual.length should be(4)
+  }
+
+  it should "remove control chars - this is not 100% safe - we should reject completely" in {
+    val actual = SanitisedQuery.sanitise("\t\n\rhello\u007f\u0000")
+    actual should be("'hello'")
+  }
+
+}
+
+class WireQueryApplyTest extends FlatSpec with Matchers {
+
+  it should "assemble a whole query with no fanfare" in {
+    val actual: SanitisedQuery = zoql"""field=${"hahaha"}"""
+    actual.queryString should be("""field='hahaha'""")
+  }
+
+  it should "assemble a whole query apostrophe" in {
+    val actual: SanitisedQuery = zoql"""field=${"o'leary"}"""
+    actual.queryString should be("""field='o\'leary'""")
+  }
+
+  it should "assemble a whole query double quote" in {
+    val actual: SanitisedQuery = zoql"""field=${"""o"leary"""}"""
+    actual.queryString should be("""field='o\"leary'""")
+  }
+
+  it should "assemble a whole query backslash" in {
+    val actual: SanitisedQuery = zoql"""field=${"""o\leary"""}"""
+    actual.queryString should be("""field='o\\leary'""")
+  }
+
+  it should "use a List in insert clause" in {
+    val ids = List("anna", "bill")
+    val insert = ids.map { id => zoql"""id = $id""" }.or
+    val actual: SanitisedQuery = zoql"""select * from table where $insert"""
+    actual.queryString should be("""select * from table where id = 'anna' or id = 'bill'""")
+  }
+
+  //POST query - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'
+  // NOTE for "zoql export" we don't escape anything, just double up on single quotes only. tested all june 2018
+
+}

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
@@ -8,7 +8,7 @@ import scalaz.{-\/, \/-}
 
 class WireQueryEscapeTest extends FlatSpec with Matchers {
 
-  it should "escape signel quotes" in {
+  it should "escape single quotes" in {
     val actual = stringInsertToQueryLiteral("""bobby tables'drop database students""")
     actual should be(\/-("""'bobby tables\'drop database students'"""))
   }
@@ -23,7 +23,7 @@ class WireQueryEscapeTest extends FlatSpec with Matchers {
     actual should be(\/-("""'a very \\ query'"""))
   }
 
-  it should "escape signel quotes double check the length" in {
+  it should "escape single quotes double check the length" in {
     val actual = stringInsertToQueryLiteral("""'""")
     actual.map(_.length) should be(\/-(4))
   }
@@ -33,7 +33,7 @@ class WireQueryEscapeTest extends FlatSpec with Matchers {
     actual.map(_.length) should be(\/-(4))
   }
 
-  it should "escape backslasgh double check the length" in {
+  it should "escape backslash double check the length" in {
     val actual = stringInsertToQueryLiteral("""\""")
     actual.map(_.length) should be(\/-(4))
   }

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
@@ -1,45 +1,45 @@
 package com.gu.util
 
 import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
-import com.gu.util.zuora.ZuoraQuery
-import com.gu.util.zuora.ZuoraQuery.{OrTraverse, Query, SanitisedQuery}
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
+import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SanitisedQuery}
 import org.scalatest._
 import scalaz.{-\/, \/-}
 
 class WireQueryEscapeTest extends FlatSpec with Matchers {
 
   it should "escape signel quotes" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral("""bobby tables'drop database students""")
+    val actual = stringInsertToQueryLiteral("""bobby tables'drop database students""")
     actual should be(\/-("""'bobby tables\'drop database students'"""))
   }
 
   it should "escape double quotes" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral("""a very "nice" query""")
+    val actual = stringInsertToQueryLiteral("""a very "nice" query""")
     actual should be(\/-("""'a very \"nice\" query'"""))
   }
 
   it should "escape backslashes" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral("""a very \ query""")
+    val actual = stringInsertToQueryLiteral("""a very \ query""")
     actual should be(\/-("""'a very \\ query'"""))
   }
 
   it should "escape signel quotes double check the length" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral("""'""")
+    val actual = stringInsertToQueryLiteral("""'""")
     actual.map(_.length) should be(\/-(4))
   }
 
   it should "escape double quotes double check the length" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral(""""""")
+    val actual = stringInsertToQueryLiteral(""""""")
     actual.map(_.length) should be(\/-(4))
   }
 
   it should "escape backslasgh double check the length" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral("""\""")
+    val actual = stringInsertToQueryLiteral("""\""")
     actual.map(_.length) should be(\/-(4))
   }
 
   it should "remove control chars - this is not 100% safe - we should reject completely" in {
-    val actual = ZuoraQuery.stringInsertToQueryLiteral("\t\n\rhello\u007f\u0000")
+    val actual = stringInsertToQueryLiteral("\t\n\rhello\u007f\u0000")
     actual.leftMap {
       case GenericError(mess) => mess.split(':')(0)
       case a => a
@@ -73,8 +73,8 @@ class WireQueryApplyTest extends FlatSpec with Matchers {
   it should "use a List in insert clause" in {
     val ids = List("anna", "bill")
     val insert = OrTraverse(ids)({ id => zoql"""id = $id""" })
-    val actual: ClientFailableOp[SanitisedQuery] = zoql"""select * from table where $insert"""
-    actual.map(_.queryString) should be(\/-("""select * from table where id = 'anna' or id = 'bill'"""))
+    val actual: ClientFailableOp[SanitisedQuery] = zoql"""select hi from table where $insert"""
+    actual.map(_.queryString) should be(\/-("""select hi from table where id = 'anna' or id = 'bill'"""))
   }
 
   //POST query - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
@@ -1,43 +1,49 @@
 package com.gu.util
 
-import com.gu.util.zuora.ZuoraQuery.{Or, Query, SanitisedQuery}
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
+import com.gu.util.zuora.ZuoraQuery
+import com.gu.util.zuora.ZuoraQuery.{OrTraverse, Query, SanitisedQuery}
 import org.scalatest._
+import scalaz.{-\/, \/-}
 
 class WireQueryEscapeTest extends FlatSpec with Matchers {
 
   it should "escape signel quotes" in {
-    val actual = SanitisedQuery.sanitise("""bobby tables'drop database students""")
-    actual should be("""'bobby tables\'drop database students'""")
+    val actual = ZuoraQuery.stringInsertToQueryLiteral("""bobby tables'drop database students""")
+    actual should be(\/-("""'bobby tables\'drop database students'"""))
   }
 
   it should "escape double quotes" in {
-    val actual = SanitisedQuery.sanitise("""a very "nice" query""")
-    actual should be("""'a very \"nice\" query'""")
+    val actual = ZuoraQuery.stringInsertToQueryLiteral("""a very "nice" query""")
+    actual should be(\/-("""'a very \"nice\" query'"""))
   }
 
   it should "escape backslashes" in {
-    val actual = SanitisedQuery.sanitise("""a very \ query""")
-    actual should be("""'a very \\ query'""")
+    val actual = ZuoraQuery.stringInsertToQueryLiteral("""a very \ query""")
+    actual should be(\/-("""'a very \\ query'"""))
   }
 
   it should "escape signel quotes double check the length" in {
-    val actual = SanitisedQuery.sanitise("""'""")
-    actual.length should be(4)
+    val actual = ZuoraQuery.stringInsertToQueryLiteral("""'""")
+    actual.map(_.length) should be(\/-(4))
   }
 
   it should "escape double quotes double check the length" in {
-    val actual = SanitisedQuery.sanitise(""""""")
-    actual.length should be(4)
+    val actual = ZuoraQuery.stringInsertToQueryLiteral(""""""")
+    actual.map(_.length) should be(\/-(4))
   }
 
   it should "escape backslasgh double check the length" in {
-    val actual = SanitisedQuery.sanitise("""\""")
-    actual.length should be(4)
+    val actual = ZuoraQuery.stringInsertToQueryLiteral("""\""")
+    actual.map(_.length) should be(\/-(4))
   }
 
   it should "remove control chars - this is not 100% safe - we should reject completely" in {
-    val actual = SanitisedQuery.sanitise("\t\n\rhello\u007f\u0000")
-    actual should be("'hello'")
+    val actual = ZuoraQuery.stringInsertToQueryLiteral("\t\n\rhello\u007f\u0000")
+    actual.leftMap {
+      case GenericError(mess) => mess.split(':')(0)
+      case a => a
+    } should be(-\/("control characters can't be inserted into a query"))
   }
 
 }
@@ -45,30 +51,30 @@ class WireQueryEscapeTest extends FlatSpec with Matchers {
 class WireQueryApplyTest extends FlatSpec with Matchers {
 
   it should "assemble a whole query with no fanfare" in {
-    val actual: SanitisedQuery = zoql"""field=${"hahaha"}"""
-    actual.queryString should be("""field='hahaha'""")
+    val actual: ClientFailableOp[SanitisedQuery] = zoql"""field=${"hahaha"}"""
+    actual.map(_.queryString) should be(\/-("""field='hahaha'"""))
   }
 
   it should "assemble a whole query apostrophe" in {
-    val actual: SanitisedQuery = zoql"""field=${"o'leary"}"""
-    actual.queryString should be("""field='o\'leary'""")
+    val actual: ClientFailableOp[SanitisedQuery] = zoql"""field=${"o'leary"}"""
+    actual.map(_.queryString) should be(\/-("""field='o\'leary'"""))
   }
 
   it should "assemble a whole query double quote" in {
-    val actual: SanitisedQuery = zoql"""field=${"""o"leary"""}"""
-    actual.queryString should be("""field='o\"leary'""")
+    val actual: ClientFailableOp[SanitisedQuery] = zoql"""field=${"""o"leary"""}"""
+    actual.map(_.queryString) should be(\/-("""field='o\"leary'"""))
   }
 
   it should "assemble a whole query backslash" in {
-    val actual: SanitisedQuery = zoql"""field=${"""o\leary"""}"""
-    actual.queryString should be("""field='o\\leary'""")
+    val actual: ClientFailableOp[SanitisedQuery] = zoql"""field=${"""o\leary"""}"""
+    actual.map(_.queryString) should be(\/-("""field='o\\leary'"""))
   }
 
   it should "use a List in insert clause" in {
     val ids = List("anna", "bill")
-    val insert = Or(ids.map { id => zoql"""id = $id""" })
-    val actual: SanitisedQuery = zoql"""select * from table where $insert"""
-    actual.queryString should be("""select * from table where id = 'anna' or id = 'bill'""")
+    val insert = OrTraverse(ids)({ id => zoql"""id = $id""" })
+    val actual: ClientFailableOp[SanitisedQuery] = zoql"""select * from table where $insert"""
+    actual.map(_.queryString) should be(\/-("""select * from table where id = 'anna' or id = 'bill'"""))
   }
 
   //POST query - SELECT Id, promotioncode__c FROM Subscription where PromotionCode__c = 'qwerty\"asdf\'zxcv\\1234'

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraQueryTest.scala
@@ -1,6 +1,6 @@
 package com.gu.util
 
-import com.gu.util.zuora.ZuoraQuery.{SanitisedQuery, Query}
+import com.gu.util.zuora.ZuoraQuery.{Or, Query, SanitisedQuery}
 import org.scalatest._
 
 class WireQueryEscapeTest extends FlatSpec with Matchers {
@@ -66,7 +66,7 @@ class WireQueryApplyTest extends FlatSpec with Matchers {
 
   it should "use a List in insert clause" in {
     val ids = List("anna", "bill")
-    val insert = ids.map { id => zoql"""id = $id""" }.or
+    val insert = Or(ids.map { id => zoql"""id = $id""" })
     val actual: SanitisedQuery = zoql"""select * from table where $insert"""
     actual.queryString should be("""select * from table where id = 'anna' or id = 'bill'""")
   }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
@@ -29,18 +29,18 @@ object ZuoraQueryPaymentMethod extends Logging {
     sourceId: StripeSourceId
   ): ApiGatewayOp[List[AccountPaymentMethodIds]] = {
     val query =
-      s"""SELECT
+      zoql"""SELECT
          | Id,
          | AccountId,
          | NumConsecutiveFailures
          | FROM PaymentMethod
          |  where Type='CreditCardReferenceTransaction'
          | AND PaymentMethodStatus = 'Active'
-         | AND TokenId = '${sourceId.value}'
-         | AND SecondTokenId = '${customerId.value}'
-         |""".stripMargin.replaceAll("\n", "")
+         | AND TokenId = ${sourceId.value}
+         | AND SecondTokenId = ${customerId.value}
+         |""".stripMarginAndNewline
 
-    zuoraQuerier[PaymentMethodFields](Query(query)).toApiGatewayOp("query failed").flatMap { result =>
+    zuoraQuerier[PaymentMethodFields](query).toApiGatewayOp("query failed").flatMap { result =>
 
       def groupedList(records: List[PaymentMethodFields]): List[(AccountId, NonEmptyList[PaymentMethodFields])] = {
         records.groupBy(_.AccountId).toList.collect {

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/zuora/ZuoraQueryPaymentMethod.scala
@@ -6,7 +6,8 @@ import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp.{ReturnWithResponse, ContinueProcessing}
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.ZuoraGetAccountSummary.ZuoraAccount._
-import com.gu.util.zuora.ZuoraQuery.{Query, ZuoraQuerier}
+import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
+import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import play.api.libs.json._
 import scalaz.NonEmptyList
 

--- a/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
+++ b/src/test/scala/com/gu/stripeCustomerSourceUpdated/SourceUpdatedStepsTest.scala
@@ -36,7 +36,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET = BasicRequest(
       "GET",
@@ -72,7 +72,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET = BasicRequest(
       "GET",
@@ -113,7 +113,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET = BasicRequest(
       "GET",
@@ -161,7 +161,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET1 = BasicRequest(
       "GET",
@@ -216,7 +216,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     val expectedGET1 = BasicRequest(
       "GET",
@@ -273,7 +273,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     effects.requestsAttempted should be(List(expectedPOST))
     actual.toDisjunction should be(-\/(ApiGatewayResponse.internalServerError("could not find correct account for stripe details")))
@@ -298,7 +298,7 @@ class SourceUpdatedStepsGetPaymentMethodsToUpdateTest extends FlatSpec with Matc
     val expectedPOST = BasicRequest(
       "POST",
       "/action/query",
-      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod  where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
+      "{\"queryString\":\"SELECT Id, AccountId, NumConsecutiveFailures FROM PaymentMethod where Type='CreditCardReferenceTransaction' AND PaymentMethodStatus = 'Active' AND TokenId = 'fakecardid' AND SecondTokenId = 'fakecustid'\"}"
     )
     effects.requestsAttempted should be(List(expectedPOST))
     actual.toDisjunction should be(\/-(List()))


### PR DESCRIPTION
At the moment we leave it up to callers to construct a zuora query by concatenating together strings.  This is a fundamentally broken and dangerous way to work - no application code should build "strings" which have higher level meaning, it should only happen in specifically written serialisation code, and well tested as such.

This PR introduces a query serialiser as a custom string interpolator.  It builds a Safe query object which can then be further serialised into Json by the normal js writes.  All of the inserts are classed as string literals, and as such it will insert the appropriate single quotes, plus escaping of such.

As an interesting aside which would be particularly relevant to @pvighi , this code is designed for the zoql query interface, where backslash is used to escape any special characters: https://knowledgecenter.zuora.com/DC_Developers/K_Zuora_Object_Query_Language/Filter_Statements#Reserved_and_Escaped_Characters
However, in the "zoql export" api, which takes pretty much the same types of queries, in typical zuora style they have gone for escaping single quotes by doubling them up.  So we will need a separate serialiser for that at some point https://knowledgecenter.zuora.com/DC_Developers/M_Export_ZOQL/A_Select_Statement#Reserved_and_Escaped_Characters 

This is about ready to go, please take a (another) look @pvighi @paulbrown1982 @twrichards @jacobwinch   Expecially interested in ease of use/clarity and safety.  There are a fair few concepts in there I'd rather avoid, apart from the readabilirty.  Custom string interpolation, varargs extracted separately with type classes on each arg, there's a lot of weirdness going on.