### PR TITLE
Zuora retention fixes

### DIFF
--- a/handlers/zuora-retention/cfn.yaml
+++ b/handlers/zuora-retention/cfn.yaml
@@ -348,21 +348,31 @@ Resources:
                   },
                   "WaitSomeTime":{
                      "Type":"Wait",
-                     "Seconds":10,
+                     "Seconds":60,
                      "Next":"FetchResults"
                   },
                   "FetchResults":{
                      "Type":"Task",
                      "Resource":"${fetcherArn}",
-                     "Next":"FetchFiles",
+                     "Next":"checkResultsAvailable",
                      "Retry":[
                         {
                            "ErrorEquals":["States.ALL"],
-                           "IntervalSeconds":60,
-                           "MaxAttempts":10,
-                           "BackoffRate":1.0
+                            "IntervalSeconds":30,
+                            "MaxAttempts":3
                         }
                      ]
+                  },
+                  "checkResultsAvailable":{
+                     "Type":"Choice",
+                     "Choices":[
+                        {
+                           "Variable":"$.status",
+                           "StringEquals":"pending",
+                           "Next":"WaitSomeTime"
+                        }
+                     ],
+                     "Default":"FetchFiles"
                   },
                   "FetchFiles":{
                      "Type":"Task",

--- a/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/GetJobResult.scala
+++ b/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/GetJobResult.scala
@@ -1,7 +1,7 @@
 package com.gu.zuora.reports
 
 import com.gu.util.zuora.RestRequestMaker
-import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError, Requests}
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
 import com.gu.zuora.reports.aqua.AquaJobResponse
 import com.gu.zuora.reports.dataModel.Batch
 import play.api.libs.json._
@@ -9,8 +9,8 @@ import scalaz.{-\/, \/-}
 
 object GetJobResult {
   val MAX_RETRIES = 10
-  def apply(zuoraRequester: Requests)(jobResultRequest: JobResultRequest): ClientFailableOp[JobResult] = {
-    val zuoraAquaResponse = zuoraRequester.get[AquaJobResponse](s"batch-query/jobs/${jobResultRequest.jobId}")
+  def apply(aquaGet: String => ClientFailableOp[AquaJobResponse])(jobResultRequest: JobResultRequest): ClientFailableOp[JobResult] = {
+    val zuoraAquaResponse = aquaGet(s"batch-query/jobs/${jobResultRequest.jobId}")
     val retries = jobResultRequest.retries.getOrElse(MAX_RETRIES)
     if (retries < 0)
       -\/(GenericError("too many retries!"))

--- a/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/GetJobResult.scala
+++ b/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/GetJobResult.scala
@@ -8,26 +8,31 @@ import play.api.libs.json._
 import scalaz.{-\/, \/-}
 
 object GetJobResult {
+  val MAX_RETRIES = 10
   def apply(zuoraRequester: Requests)(jobResultRequest: JobResultRequest): ClientFailableOp[JobResult] = {
     val zuoraAquaResponse = zuoraRequester.get[AquaJobResponse](s"batch-query/jobs/${jobResultRequest.jobId}")
-    toJobResultResponse(zuoraAquaResponse, jobResultRequest.dryRun, jobResultRequest.jobId)
+    val retries = jobResultRequest.retries.getOrElse(MAX_RETRIES)
+    if (retries < 0)
+      -\/(GenericError("too many retries!"))
+    else
+      toJobResultResponse(zuoraAquaResponse, jobResultRequest.dryRun, jobResultRequest.jobId, retries - 1)
   }
 
   def toBatch(aquaBatch: aqua.Batch): Option[Batch] = aquaBatch.fileId.map {
     fileId => Batch(name = aquaBatch.name, fileId = fileId)
   }
 
-  def toJobResultResponse(aquaResponse: ClientFailableOp[AquaJobResponse], dryRun: Boolean, jobId: String): ClientFailableOp[JobResult] = {
+  def toJobResultResponse(aquaResponse: ClientFailableOp[AquaJobResponse], dryRun: Boolean, jobId: String, retries: Int): ClientFailableOp[JobResult] = {
     aquaResponse match {
       case \/-(AquaJobResponse(status, name, aquaBatches, _)) if status == "completed" =>
         val batches = aquaBatches.map(toBatch)
         if (batches.contains(None)) {
           -\/(RestRequestMaker.GenericError(s"file Id missing from response : $aquaResponse"))
         } else {
-          \/-(Completed(name, jobId, batches.flatten, dryRun))
+          \/-(Completed(name, jobId, batches.flatten, dryRun, retries))
         }
 
-      case \/-(AquaJobResponse(status, name, _, _)) if pendingValues.contains(status) => \/-(Pending(name, jobId, dryRun))
+      case \/-(AquaJobResponse(status, name, _, _)) if pendingValues.contains(status) => \/-(Pending(name, jobId, dryRun, retries))
       case \/-(zuoraResponse) => -\/(GenericError(s"unexpected status in zuora response: $zuoraResponse"))
       case -\/(error) => -\/(error)
     }
@@ -36,7 +41,7 @@ object GetJobResult {
   val pendingValues = List("pending", "executing")
 }
 
-case class JobResultRequest(jobId: String, dryRun: Boolean)
+case class JobResultRequest(jobId: String, dryRun: Boolean, retries: Option[Int])
 
 object JobResultRequest {
   implicit val reads = Json.reads[JobResultRequest]
@@ -46,26 +51,28 @@ sealed trait JobResult {
   def name: String
   def jobId: String
   def dryRun: Boolean
+  def retries: Int
 }
 
-case class Completed(name: String, jobId: String, batches: Seq[Batch], dryRun: Boolean) extends JobResult
+case class Completed(name: String, jobId: String, batches: Seq[Batch], dryRun: Boolean, retries: Int) extends JobResult
 
-case class Pending(name: String, jobId: String, dryRun: Boolean) extends JobResult
+case class Pending(name: String, jobId: String, dryRun: Boolean, retries: Int) extends JobResult
 
 case class JobResultWire(
   name: String,
   jobId: String,
   status: String,
   batches: Option[Seq[Batch]],
-  dryRun: Boolean
+  dryRun: Boolean,
+  retries: Int
 )
 
 object JobResultWire {
   implicit val writes = Json.writes[JobResultWire]
 
   def fromJobResult(jobResult: JobResult) = jobResult match {
-    case Completed(name, jobId, batches, dryRun) => JobResultWire(name, jobId, "completed", Some(batches), dryRun)
-    case Pending(name, jobId, dryRun) => JobResultWire(name, jobId, "pending", None, dryRun)
+    case Completed(name, jobId, batches, dryRun, retries) => JobResultWire(name, jobId, "completed", Some(batches), dryRun, retries)
+    case Pending(name, jobId, dryRun, retries) => JobResultWire(name, jobId, "pending", None, dryRun, retries)
   }
 }
 

--- a/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/handlers/FetchResultsHandler.scala
+++ b/lib/zuora-reports/src/main/scala/com/gu/zuora/reports/handlers/FetchResultsHandler.scala
@@ -6,19 +6,20 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.RawEffects
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.config.Config
-import com.gu.util.zuora.RestRequestMaker.Requests
 import com.gu.zuora.reports.ReportsLambda.{AquaCall, StepsConfig}
 import com.gu.zuora.reports.aqua.ZuoraAquaRequestMaker
 import com.gu.zuora.reports.{GetJobResult, JobResult, JobResultRequest, ReportsLambda}
 
 object FetchResultsHandler {
 
-  private def wireCall(call: Requests => AquaCall[JobResultRequest, JobResult])(config: Config[StepsConfig]): AquaCall[JobResultRequest, JobResult] = {
-    call(ZuoraAquaRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig))
+  private def wireCall(config: Config[StepsConfig]): AquaCall[JobResultRequest, JobResult] = {
+    val zuoraRequests = ZuoraAquaRequestMaker(RawEffects.response, config.stepsConfig.zuoraRestConfig)
+    GetJobResult(zuoraRequests.get)
   }
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
-  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    ReportsLambda[JobResultRequest, JobResult](RawEffects.stage, RawEffects.s3Load, LambdaIO(inputStream, outputStream, context), wireCall(GetJobResult.apply))
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    ReportsLambda[JobResultRequest, JobResult](RawEffects.stage, RawEffects.s3Load, LambdaIO(inputStream, outputStream, context), wireCall)
+  }
 }

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultResponseTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultResponseTest.scala
@@ -14,7 +14,8 @@ class GetJobResultResponseTest extends AsyncFlatSpec {
         Batch("fileId1", "batch1"),
         Batch("fileId2", "batch2")
       ),
-      true
+      true,
+      13
     )
 
     val expected =
@@ -33,7 +34,8 @@ class GetJobResultResponseTest extends AsyncFlatSpec {
         |      "name": "batch2"
         |    }
         |  ],
-        |  "dryRun": true
+        |  "dryRun": true,
+        |  "retries" : 13
         |}
       """.stripMargin
 
@@ -48,11 +50,12 @@ class GetJobResultResponseTest extends AsyncFlatSpec {
         |  "name": "testResponse",
         |  "jobId" : "someJobId",
         |  "status" : "pending",
-        |  "dryRun" : false
+        |  "dryRun" : false,
+        |  "retries" : 13
         |}
       """.stripMargin
 
-    val pendingResponse = Pending("testResponse", "someJobId", false)
+    val pendingResponse = Pending("testResponse", "someJobId", false, 13)
 
     Json.toJson(pendingResponse) shouldBe Json.parse(expected)
   }

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultResponseTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultResponseTest.scala
@@ -35,7 +35,7 @@ class GetJobResultResponseTest extends AsyncFlatSpec {
         |    }
         |  ],
         |  "dryRun": true,
-        |  "retries" : 13
+        |  "tries" : 13
         |}
       """.stripMargin
 
@@ -51,7 +51,7 @@ class GetJobResultResponseTest extends AsyncFlatSpec {
         |  "jobId" : "someJobId",
         |  "status" : "pending",
         |  "dryRun" : false,
-        |  "retries" : 13
+        |  "tries" : 13
         |}
       """.stripMargin
 

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
@@ -27,37 +27,32 @@ class GetJobResultTest extends AsyncFlatSpec {
     )
   ))
   it should "decrease the amount of retries left on each execution" in {
-    def get(path :String) = ZuoraResponseWithStatus("pending")
-    val jobResultRequest = JobResultRequest(jobId= "someJobId", dryRun = false, retries = Some(7))
+    def get(path: String) = ZuoraResponseWithStatus("pending")
+    val jobResultRequest = JobResultRequest(jobId = "someJobId", dryRun = false, tries = Some(7))
     GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, 6))
   }
 
-  it should "return -1 retires when called with retries = 0" in {
-    def get(path :String) = ZuoraResponseWithStatus("pending")
-    val jobResultRequest = JobResultRequest(jobId= "someJobId", dryRun = false, retries = Some(0))
-    GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, -1))
-  }
-
-  it should "return error if called with a negative number of retries" in {
-    def get(path :String) = ZuoraResponseWithStatus("pending")
-    val jobResultRequest = JobResultRequest(jobId= "someJobId", dryRun = false, retries = Some(-1))
-    GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("too many retries!"))
+  it should "return error if called with 0 tries left" in {
+    def get(path: String) = ZuoraResponseWithStatus("pending")
+    val jobResultRequest = JobResultRequest(jobId = "someJobId", dryRun = false, tries = Some(0))
+    GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("tries must be > 0"))
   }
 
   it should "return pending if zuora response status is pending " in {
-    def get(path :String) = ZuoraResponseWithStatus("pending")
+    def get(path: String) = ZuoraResponseWithStatus("pending")
     val jobResultRequest = JobResultRequest("someJobId", false, None)
     GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, 9))
   }
   it should "return pending if zuora response status is executing " in {
-    def get(path :String) = ZuoraResponseWithStatus("executing")
+    def get(path: String) = ZuoraResponseWithStatus("executing")
     val jobResultRequest = JobResultRequest("someJobId", true, None)
     GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", true, 9))
   }
   it should "return error if zuora response status is an unexpected value " in {
-    def get(path :String) = ZuoraResponseWithStatus("aborted")
+    def get(path: String) = ZuoraResponseWithStatus("aborted")
     val jobResultRequest = JobResultRequest("someJobId", false, None)
-    GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("unexpected status in zuora response: AquaJobResponse(aborted,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,Some(fileId2))),None)"))
+    val actualResponse = GetJobResult(get)(jobResultRequest)
+    actualResponse.leftMap(_.message.split(":")(0)) shouldBe -\/("unexpected status in zuora response")
   }
 
   it should "return completed if zuora response status is completed " in {
@@ -72,7 +67,7 @@ class GetJobResultTest extends AsyncFlatSpec {
       9
     )
 
-    def get(path :String) = ZuoraResponseWithStatus("completed")
+    def get(path: String) = ZuoraResponseWithStatus("completed")
     val jobResultRequest = JobResultRequest("someJobId", false, None)
 
     GetJobResult(get)(jobResultRequest) shouldBe \/-(expected)
@@ -97,7 +92,7 @@ class GetJobResultTest extends AsyncFlatSpec {
       )
     ))
 
-    def get(path :String) = responseWithMissingFileId
+    def get(path: String) = responseWithMissingFileId
     val jobResultRequest = JobResultRequest("someJobId", false, None)
 
     GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("file Id missing from response : \\/-(AquaJobResponse(completed,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,None)),None))"))

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
@@ -28,13 +28,13 @@ class GetJobResultTest extends AsyncFlatSpec {
   ))
 
   it should "return pending if zuora response status is pending " in {
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("pending"), false, "someJobId") shouldBe \/-(Pending("testResponse", "someJobId", false))
+    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("pending"), false, "someJobId", 0) shouldBe \/-(Pending("testResponse", "someJobId", false, 0))
   }
   it should "return pending if zuora response status is executing " in {
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("executing"), true, "someJobId") shouldBe \/-(Pending("testResponse", "someJobId", true))
+    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("executing"), true, "someJobId", 0) shouldBe \/-(Pending("testResponse", "someJobId", true, 0))
   }
   it should "return error if zuora response status is an unexpected value " in {
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("aborted"), false, "someJobId") shouldBe -\/(GenericError("unexpected status in zuora response: AquaJobResponse(aborted,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,Some(fileId2))),None)"))
+    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("aborted"), false, "someJobId", 0) shouldBe -\/(GenericError("unexpected status in zuora response: AquaJobResponse(aborted,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,Some(fileId2))),None)"))
   }
 
   it should "return completed if zuora response status is completed " in {
@@ -45,9 +45,10 @@ class GetJobResultTest extends AsyncFlatSpec {
         Batch("fileId1", "batch1"),
         Batch("fileId2", "batch2")
       ),
-      false
+      false,
+      1
     )
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("completed"), false, "someJobId") shouldBe \/-(expected)
+    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("completed"), false, "someJobId",1) shouldBe \/-(expected)
   }
   it should "return error if zuora response status is completed but the response is missing fileIds" in {
 
@@ -69,6 +70,6 @@ class GetJobResultTest extends AsyncFlatSpec {
       )
     ))
 
-    GetJobResult.toJobResultResponse(responseWithMissingFileId, true, "someJobId") shouldBe -\/(GenericError("file Id missing from response : \\/-(AquaJobResponse(completed,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,None)),None))"))
+    GetJobResult.toJobResultResponse(responseWithMissingFileId, true, "someJobId",1) shouldBe -\/(GenericError("file Id missing from response : \\/-(AquaJobResponse(completed,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,None)),None))"))
   }
 }

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
@@ -26,15 +26,38 @@ class GetJobResultTest extends AsyncFlatSpec {
       )
     )
   ))
+  it should "decrease the amount of retries left on each execution" in {
+    def get(path :String) = ZuoraResponseWithStatus("pending")
+    val jobResultRequest = JobResultRequest(jobId= "someJobId", dryRun = false, retries = Some(7))
+    GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, 6))
+  }
+
+  it should "return -1 retires when called with retries = 0" in {
+    def get(path :String) = ZuoraResponseWithStatus("pending")
+    val jobResultRequest = JobResultRequest(jobId= "someJobId", dryRun = false, retries = Some(0))
+    GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, -1))
+  }
+
+  it should "return error if called with a negative number of retries" in {
+    def get(path :String) = ZuoraResponseWithStatus("pending")
+    val jobResultRequest = JobResultRequest(jobId= "someJobId", dryRun = false, retries = Some(-1))
+    GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("too many retries!"))
+  }
 
   it should "return pending if zuora response status is pending " in {
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("pending"), false, "someJobId", 0) shouldBe \/-(Pending("testResponse", "someJobId", false, 0))
+    def get(path :String) = ZuoraResponseWithStatus("pending")
+    val jobResultRequest = JobResultRequest("someJobId", false, None)
+    GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, 9))
   }
   it should "return pending if zuora response status is executing " in {
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("executing"), true, "someJobId", 0) shouldBe \/-(Pending("testResponse", "someJobId", true, 0))
+    def get(path :String) = ZuoraResponseWithStatus("executing")
+    val jobResultRequest = JobResultRequest("someJobId", true, None)
+    GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", true, 9))
   }
   it should "return error if zuora response status is an unexpected value " in {
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("aborted"), false, "someJobId", 0) shouldBe -\/(GenericError("unexpected status in zuora response: AquaJobResponse(aborted,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,Some(fileId2))),None)"))
+    def get(path :String) = ZuoraResponseWithStatus("aborted")
+    val jobResultRequest = JobResultRequest("someJobId", false, None)
+    GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("unexpected status in zuora response: AquaJobResponse(aborted,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,Some(fileId2))),None)"))
   }
 
   it should "return completed if zuora response status is completed " in {
@@ -46,9 +69,13 @@ class GetJobResultTest extends AsyncFlatSpec {
         Batch("fileId2", "batch2")
       ),
       false,
-      1
+      9
     )
-    GetJobResult.toJobResultResponse(ZuoraResponseWithStatus("completed"), false, "someJobId",1) shouldBe \/-(expected)
+
+    def get(path :String) = ZuoraResponseWithStatus("completed")
+    val jobResultRequest = JobResultRequest("someJobId", false, None)
+
+    GetJobResult(get)(jobResultRequest) shouldBe \/-(expected)
   }
   it should "return error if zuora response status is completed but the response is missing fileIds" in {
 
@@ -70,6 +97,9 @@ class GetJobResultTest extends AsyncFlatSpec {
       )
     ))
 
-    GetJobResult.toJobResultResponse(responseWithMissingFileId, true, "someJobId",1) shouldBe -\/(GenericError("file Id missing from response : \\/-(AquaJobResponse(completed,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,None)),None))"))
+    def get(path :String) = responseWithMissingFileId
+    val jobResultRequest = JobResultRequest("someJobId", false, None)
+
+    GetJobResult(get)(jobResultRequest) shouldBe -\/(GenericError("file Id missing from response : \\/-(AquaJobResponse(completed,testResponse,List(Batch(completed,batch1,Some(fileId1)), Batch(completed,batch2,None)),None))"))
   }
 }

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/GetJobResultTest.scala
@@ -26,7 +26,7 @@ class GetJobResultTest extends AsyncFlatSpec {
       )
     )
   ))
-  it should "decrease the amount of retries left on each execution" in {
+  it should "decrease the amount of tries left on each execution" in {
     def get(path: String) = ZuoraResponseWithStatus("pending")
     val jobResultRequest = JobResultRequest(jobId = "someJobId", dryRun = false, tries = Some(7))
     GetJobResult(get)(jobResultRequest) shouldBe \/-(Pending("testResponse", "someJobId", false, 6))

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsLambdaEndToEndTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsLambdaEndToEndTest.scala
@@ -88,7 +88,7 @@ class ReportsLambdaEndToEndTest extends FlatSpec with Matchers {
           |   "fileId": "someFileId"
           |   }],
           |   "dryRun" : false,
-          |   "retries" : 9
+          |   "tries" : 9
           |}
         """.stripMargin
 

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsLambdaEndToEndTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsLambdaEndToEndTest.scala
@@ -60,26 +60,26 @@ class ReportsLambdaEndToEndTest extends FlatSpec with Matchers {
     response jsonMatches expectedResponse
   }
 
-    it should "handle job status request" in {
-      val jobInput =
-        """
+  it should "handle job status request" in {
+    val jobInput =
+      """
           |{
           | "jobId" : "aquaJobId",
           | "dryRun" : false
           |}
         """.stripMargin
 
-      val responses = Map("/batch-query/jobs/aquaJobId" -> HTTPResponse(200, aquaJobResponse))
+    val responses = Map("/batch-query/jobs/aquaJobId" -> HTTPResponse(200, aquaJobResponse))
 
-      def getJobResultAdapter(requests: Requests) = GetJobResult(requests.get[AquaJobResponse]) _
-      val (response, bla) = getResultAndRequests[JobResultRequest, JobResult](
-        input = jobInput,
-        responses = responses,
-        handlerToTest = getJobResultAdapter
-      )
+    def getJobResultAdapter(requests: Requests) = GetJobResult(requests.get[AquaJobResponse]) _
+    val (response, bla) = getResultAndRequests[JobResultRequest, JobResult](
+      input = jobInput,
+      responses = responses,
+      handlerToTest = getJobResultAdapter
+    )
 
-      val expected =
-        """{
+    val expected =
+      """{
           |   "name" : "testJob",
           |   "jobId" : "aquaJobId",
           |   "status" : "completed",
@@ -92,9 +92,9 @@ class ReportsLambdaEndToEndTest extends FlatSpec with Matchers {
           |}
         """.stripMargin
 
-      response jsonMatches expected
+    response jsonMatches expected
 
-    }
+  }
 }
 
 object Runner {

--- a/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsManualEffectsTest.scala
+++ b/lib/zuora-reports/src/test/scala/com/gu/zuora/reports/ReportsManualEffectsTest.scala
@@ -3,7 +3,7 @@ package com.gu.zuora.reports
 import com.gu.effects.{RawEffects, S3ConfigLoad}
 import com.gu.util.config.{LoadConfig, Stage}
 import com.gu.zuora.reports.ReportsLambda.StepsConfig
-import com.gu.zuora.reports.aqua.{AquaQuery, AquaQueryRequest, ZuoraAquaRequestMaker}
+import com.gu.zuora.reports.aqua.{AquaJobResponse, AquaQuery, AquaQueryRequest, ZuoraAquaRequestMaker}
 import com.gu.zuora.reports.dataModel.Batch
 import okhttp3.{Request, Response}
 import play.api.libs.json.Json
@@ -50,8 +50,8 @@ object ReportsManualEffectsTest extends App {
   def getResultsTest(): Unit = {
     val response = for {
       zuoraRequests <- getZuoraRequest(RawEffects.response)
-      request = JobResultRequest("2c92c0f963f800ac0164174918d905f2", true)
-      res <- GetJobResult(zuoraRequests)(request)
+      request = JobResultRequest("2c92c0f963f800ac0164174918d905f2", true, None)
+      res <- GetJobResult(zuoraRequests.get[AquaJobResponse])(request)
     } yield {
       res
     }


### PR DESCRIPTION
I after testing in PROD I realised that I forgot to add a retry to wait until the queries in are done in Zuora.
I also added a retries parameter to getJobResults to keep track of how many times it has been run and make the whole execution fail if it retries too many times.
I can't really test this in CODE as the query always returns instantly so I will have to run it in PROD and see if it works.
updated state machine:
![statemachine](https://user-images.githubusercontent.com/15324270/41788585-f3276a90-7643-11e8-8585-6286a8f4f4e9.png)
