### PR TITLE
exclude accounts with no crmId

### DIFF
--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/query/RetentionQueryRequest.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/query/RetentionQueryRequest.scala
@@ -30,6 +30,7 @@ object ToAquaRequest {
            | Subscription
            |WHERE
            | Account.CrmId != '' AND
+           | Accoutn.CrmId IS NOT NULL AND
            | Status != 'Expired' AND
            | Status != 'Draft'
            |GROUP BY
@@ -51,6 +52,8 @@ object ToAquaRequest {
            |  Subscription
            |WHERE
            |  Account.Status != 'Canceled' AND
+           |  Account.CrmId != '' AND
+           |  Account.CrmId IS NOT NULL AND
            |  (Account.ProcessingAdvice__c != 'DoNotProcess' OR Account.ProcessingAdvice__c IS NULL) AND
            |  Subscription.Status = 'Cancelled' AND
            |  SubscriptionEndDate <= '$dateStr'


### PR DESCRIPTION
There is one account in the candidates results in prod that has no crmId. This crashes the filter when trying to find accounts in the exclusion list with a matching crmId.

This means that accounts with no crmId will never be marked doNotProcess by this. @paulbrown1982 do we need to support this case or is it expected that all accounts should have a crmId?

