### PR TITLE
include candidates with no crmId in results

### DIFF
--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/Diff.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/Diff.scala
@@ -5,10 +5,10 @@ object Diff {
   val crmIdColName = "Account.CrmId"
 
   /**
-   * Returns an iterator for the lines in candidateLines with crmIds that are not in the exclusionLines
-   * The candidates and exclusion iterators are expected to iterate ascending CrmId order.
-   * The point of this is to avoid loading the whole exclusionLines in memory.
-   */
+    * Returns an iterator for the lines in candidateLines with crmIds that are not in the exclusionLines
+    * The candidates and exclusion iterators are expected to iterate ascending CrmId order.
+    * The point of this is to avoid loading the whole exclusionLines in memory.
+    */
   def apply(candidateLines: Iterator[String], exclusionLines: Iterator[String]): Iterator[String] = {
     exclusionLines.next //skip header
     val exclusionCrmIds = SortedCrmIdIterator(exclusionLines)
@@ -16,14 +16,18 @@ object Diff {
     val crmidLocation = candidatesHeader.split(",").indexOf(crmIdColName)
     val valueRows = candidateLines.filterNot { line =>
       line.trim.isEmpty || {
-        val crmId = line.split(",")(crmidLocation).trim
-        val comp = exclusionCrmIds.nextGreaterOrEqual(crmId)
-        comp.exists(_.toLowerCase == crmId.toLowerCase)
+        val crmId = line.split(",", -1)(crmidLocation).trim
+        if (crmId.trim.isEmpty) false
+        else {
+          val comp = exclusionCrmIds.nextGreaterOrEqual(crmId)
+          comp.exists(_.toLowerCase == crmId.toLowerCase)
+        }
       }
     }
     List(candidatesHeader).iterator ++ valueRows
   }
 }
+
 /*
 this class was needed because iterators won't allow peeking without advancing
  */

--- a/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/DiffTest.scala
+++ b/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/DiffTest.scala
@@ -122,5 +122,26 @@ class DiffTest extends FlatSpec with Matchers {
 
     Diff(candidates.lines, excluded.lines).mkString("\n") shouldBe expected
   }
+
+  it should "not exclude candidates with no crmId" in {
+    val candidates =
+      """Account.Id,Account.CrmId
+        |NoCrmId_Account,
+        |excludedAccount,B
+        |includedAccount,C""".stripMargin
+
+    val excluded =
+      """Account.CrmId
+        |B
+        |0
+        """.stripMargin
+
+    val expected =
+      """Account.Id,Account.CrmId
+        |NoCrmId_Account,
+        |includedAccount,C""".stripMargin
+
+    Diff(candidates.lines, excluded.lines).mkString("\n") shouldBe expected
+  }
 }
 


### PR DESCRIPTION
normally the way this works is by finding accounts with old subs and then excluding from the results the accounts with a crmId that is also present in active or "not old enough" accounts.
If a candidate account has no crmId then it is included in the results as there is nothing to look for in the exclusion list.