### PR TITLE
exclude subscriptions with weird end dates from retention query results

### DIFF
--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/query/RetentionQueryRequest.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/query/RetentionQueryRequest.scala
@@ -53,7 +53,8 @@ object ToAquaRequest {
            |  Account.Status != 'Canceled' AND
            |  (Account.ProcessingAdvice__c != 'DoNotProcess' OR Account.ProcessingAdvice__c IS NULL) AND
            |  Subscription.Status = 'Cancelled' AND
-           |  SubscriptionEndDate <= '$dateStr'
+           |  SubscriptionEndDate <= '$dateStr' AND
+           |  SubscriptionEndDate > '1000-01-01'
            |ORDER BY
            |  Account.CrmId
     """.stripMargin

--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/updateAccounts/AccountIdIterator.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/updateAccounts/AccountIdIterator.scala
@@ -22,7 +22,7 @@ object AccountIdIterator {
   def apply(lines: Iterator[String], startingPosition: Int): Try[AccountIdIterator] = {
     Try {
       val headers = lines.next()
-      val accountIdLocation = headers.split(",").indexOf(accountIdHeader)
+      val accountIdLocation = headers.split(",", -1).indexOf(accountIdHeader)
       if (accountIdLocation < 0) throw new LambdaException(s"No $accountIdHeader column found in csv file header")
       new AccountIdIterator(lines.drop(startingPosition), accountIdLocation, startingPosition)
     }

--- a/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/query/RetentionQueryRequestTest.scala
+++ b/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/query/RetentionQueryRequestTest.scala
@@ -71,7 +71,8 @@ class RetentionQueryRequestTest extends AsyncFlatSpec {
            |  Account.Status != 'Canceled' AND
            |  (Account.ProcessingAdvice__c != 'DoNotProcess' OR Account.ProcessingAdvice__c IS NULL) AND
            |  Subscription.Status = 'Cancelled' AND
-           |  SubscriptionEndDate <= '$dateStr'
+           |  SubscriptionEndDate <= '$dateStr' AND
+           |  SubscriptionEndDate > '1000-01-01'
            |ORDER BY
            |  Account.CrmId
     """.stripMargin


### PR DESCRIPTION
there's some subscriptions in PROD with end dates like "0018-02-05" this PR excludes those from the results