### PR TITLE
exclude accounts with no crmId from zuora retention results

### DIFF
--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/Diff.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/Diff.scala
@@ -5,10 +5,10 @@ object Diff {
   val crmIdColName = "Account.CrmId"
 
   /**
-    * Returns an iterator for the lines in candidateLines with crmIds that are not in the exclusionLines
-    * The candidates and exclusion iterators are expected to iterate ascending CrmId order.
-    * The point of this is to avoid loading the whole exclusionLines in memory.
-    */
+   * Returns an iterator for the lines in candidateLines with crmIds that are not in the exclusionLines
+   * The candidates and exclusion iterators are expected to iterate ascending CrmId order.
+   * The point of this is to avoid loading the whole exclusionLines in memory.
+   */
   def apply(candidateLines: Iterator[String], exclusionLines: Iterator[String]): Iterator[String] = {
     exclusionLines.next //skip header
     val exclusionCrmIds = SortedCrmIdIterator(exclusionLines)
@@ -17,7 +17,7 @@ object Diff {
     val valueRows = candidateLines.filterNot { line =>
       line.trim.isEmpty || {
         val crmId = line.split(",", -1)(crmidLocation).trim
-        if (crmId.trim.isEmpty) false
+        if (crmId.trim.isEmpty) true
         else {
           val comp = exclusionCrmIds.nextGreaterOrEqual(crmId)
           comp.exists(_.toLowerCase == crmId.toLowerCase)

--- a/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/query/RetentionQueryRequest.scala
+++ b/handlers/zuora-retention/src/main/scala/com/gu/zuora/retention/query/RetentionQueryRequest.scala
@@ -30,6 +30,7 @@ object ToAquaRequest {
            | Subscription
            |WHERE
            | Account.CrmId != '' AND
+           | Account.CrmId IS NOT NULL AND
            | Status != 'Expired' AND
            | Status != 'Draft'
            |GROUP BY
@@ -51,6 +52,8 @@ object ToAquaRequest {
            |  Subscription
            |WHERE
            |  Account.Status != 'Canceled' AND
+           |  Account.CrmId != '' AND
+           |  Account.CrmId IS NOT NULL AND
            |  (Account.ProcessingAdvice__c != 'DoNotProcess' OR Account.ProcessingAdvice__c IS NULL) AND
            |  Subscription.Status = 'Cancelled' AND
            |  SubscriptionEndDate <= '$dateStr' AND

--- a/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/DiffTest.scala
+++ b/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/DiffTest.scala
@@ -123,7 +123,7 @@ class DiffTest extends FlatSpec with Matchers {
     Diff(candidates.lines, excluded.lines).mkString("\n") shouldBe expected
   }
 
-  it should "not exclude candidates with no crmId" in {
+  it should "exclude candidates with no crmId" in {
     val candidates =
       """Account.Id,Account.CrmId
         |NoCrmId_Account,
@@ -138,7 +138,6 @@ class DiffTest extends FlatSpec with Matchers {
 
     val expected =
       """Account.Id,Account.CrmId
-        |NoCrmId_Account,
         |includedAccount,C""".stripMargin
 
     Diff(candidates.lines, excluded.lines).mkString("\n") shouldBe expected

--- a/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/query/RetentionQueryRequestTest.scala
+++ b/handlers/zuora-retention/src/test/scala/com/gu/zuora/retention/query/RetentionQueryRequestTest.scala
@@ -47,6 +47,7 @@ class RetentionQueryRequestTest extends AsyncFlatSpec {
                  | Subscription
                  |WHERE
                  | Account.CrmId != '' AND
+                 | Account.CrmId IS NOT NULL AND
                  | Status != 'Expired' AND
                  | Status != 'Draft'
                  |GROUP BY
@@ -69,6 +70,8 @@ class RetentionQueryRequestTest extends AsyncFlatSpec {
            |  Subscription
            |WHERE
            |  Account.Status != 'Canceled' AND
+           |  Account.CrmId != '' AND
+           |  Account.CrmId IS NOT NULL AND
            |  (Account.ProcessingAdvice__c != 'DoNotProcess' OR Account.ProcessingAdvice__c IS NULL) AND
            |  Subscription.Status = 'Cancelled' AND
            |  SubscriptionEndDate <= '$dateStr' AND


### PR DESCRIPTION
we cannot skip the filtering step for subscriptions from Accounts with no crmId.
There might be accounts with multiple subscriptions only one of which is 'old', in this case we would not want to mark the account 'do_not_process'
Since there's only 14 accounts with no crmId we will just leave them alone as it is not worth it to add accountId based filtering to this code