### PR TITLE
trigger zuora retention state machine every day at 3:00 GMT

### DIFF
--- a/handlers/zuora-retention/cfn.yaml
+++ b/handlers/zuora-retention/cfn.yaml
@@ -482,8 +482,8 @@ Resources:
     ScheduleRule:
         Type: "AWS::Events::Rule"
         Properties:
-          Description: "triggerZuoraRetention"
-          ScheduleExpression: "cron(00 3 ? * * *)"
+          Description: "Trigger the Zuora Retention state machine every day at 03:00 GMT"
+          ScheduleExpression: "cron(0 3 ? * * *)"
           State: "ENABLED"
           Targets:
             -

--- a/handlers/zuora-retention/cfn.yaml
+++ b/handlers/zuora-retention/cfn.yaml
@@ -202,6 +202,26 @@ Resources:
                             Action:
                             - s3:GetObject
                             Resource: !Sub arn:aws:s3:::${RetentionBucket}/*
+    StateMachineTriggerRole:
+      Type: AWS::IAM::Role
+      Properties:
+          AssumeRolePolicyDocument:
+              Statement:
+                  - Effect: Allow
+                    Principal:
+                        Service:
+                           - events.amazonaws.com
+                    Action:
+                        - sts:AssumeRole
+          Policies:
+              - PolicyName: TriggerStateMchine
+                PolicyDocument:
+                    Version : "2012-10-17"
+                    Statement:
+                       - Effect: Allow
+                         Action:
+                         - states:StartExecution
+                         Resource: !Ref stateMachine
     ZuoraRetentionQuerier:
         Type: AWS::Lambda::Function
         Properties:
@@ -459,3 +479,18 @@ Resources:
             filterArn: !GetAtt [ ZuoraRetentionFilter, Arn ],
             accountUpdaterArn: !GetAtt [ ZuoraRetentionAccountUpdater, Arn ]
           }
+    ScheduleRule:
+        Type: "AWS::Events::Rule"
+        Properties:
+          Description: "triggerZuoraRetention"
+          ScheduleExpression: "cron(00 3 ? * * *)"
+          State: "ENABLED"
+          Targets:
+            -
+              Arn: !Ref stateMachine
+              Id: !Sub 'trigger_zuoraRetention-${Stage}'
+              Input: |
+                {
+                  "dryRun": false
+                }
+              RoleArn: !GetAtt [ StateMachineTriggerRole, Arn ]


### PR DESCRIPTION
The time was pretty much selected at random (trying to not overlap with the fulfilment queries) @paulbrown1982  do you think we should trigger this at a different time of the day / with a different frequency?
Another thing we could change is keep the Zuora Query results around for longer. Right now they are deleted automatically after one day, but we could use them in case we want to see which accounts were updated or undo the changes in postman.