### PR TITLE
Add contact merge lambda plus bonus json matcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val handler = all(project in file("lib/handler"))
 lazy val effects = all(project in file("lib/effects"))
   .dependsOn(handler)
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsS3, jacksonDatabind)
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsS3, jacksonDatabind, awsLambda)
   )
 
 val effectsDepIncludingTestFolder: ClasspathDependency = effects % "compile->compile;test->test"

--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,7 @@ lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggreg
   `catalog-service`,
   `identity-retention`,
   `zuora-retention`,
+  `sf-contact-merge`,
   `cancellation-sf-cases`,
   effects,
   handler,
@@ -149,6 +150,10 @@ lazy val `identity-retention` = all(project in file("handlers/identity-retention
 lazy val `zuora-retention` = all(project in file("handlers/zuora-retention"))
   .enablePlugins(RiffRaffArtifact)
   .dependsOn(`zuora-reports`, handler, effectsDepIncludingTestFolder, testDep)
+
+lazy val `sf-contact-merge` = all(project in file("handlers/sf-contact-merge"))
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `cancellation-sf-cases` = all(project in file("handlers/cancellation-sf-cases"))
   .enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -92,14 +92,14 @@ lazy val restHttp = all(project in file("lib/restHttp"))
 
 lazy val handler = all(project in file("lib/handler"))
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest)
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsLambda)
   )
 
 // to aid testability, only the actual handlers called as a lambda can depend on this
 lazy val effects = all(project in file("lib/effects"))
   .dependsOn(handler)
   .settings(
-    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsS3, jacksonDatabind, awsLambda)
+    libraryDependencies ++= Seq(okhttp3, logging, scalaz, playJson, scalatest, awsS3, jacksonDatabind)
   )
 
 val effectsDepIncludingTestFolder: ClasspathDependency = effects % "compile->compile;test->test"

--- a/handlers/sf-contact-merge/README.md
+++ b/handlers/sf-contact-merge/README.md
@@ -1,6 +1,6 @@
 # sf-contact-merge
 
-This lambda is used to merge together several contacts in SF.  It as initiated by running a report in SF to find out the
+This lambda is used to merge together several contacts in SF.  It is initiated by running a report in SF to find out the
 duplicate sets and which should be the "winner".  Then this is called with the zuora account ids and corrected salesforce
 crmids and contact ids.  Then this will overwrite in zuora.
 

--- a/handlers/sf-contact-merge/README.md
+++ b/handlers/sf-contact-merge/README.md
@@ -1,0 +1,7 @@
+# sf-contact-merge
+
+This lambda is used to merge together several contacts in SF.  It as initiated by running a report in SF to find out the
+duplicate sets and which should be the "winner".  Then this is called with the zuora account ids and corrected salesforce
+crmids and contact ids.  Then this will overwrite in zuora.
+
+It is called manually as part of the ongoing process to get the data quality up.

--- a/handlers/sf-contact-merge/build.sbt
+++ b/handlers/sf-contact-merge/build.sbt
@@ -1,0 +1,24 @@
+// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
+// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
+name := "sf-contact-merge"
+description:= "Merges together the salesforce account referenced by a set of zuora accounts"
+
+scalacOptions += "-Ypartial-unification"
+
+assemblyJarName := "sf-contact-merge.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := "MemSub::Membership Admin::SF Contact Merge"
+riffRaffArtifactResources += (file("handlers/sf-contact-merge/cfn.yaml"), "cfn/cfn.yaml")
+
+libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
+  "log4j" % "log4j" % "1.2.17",
+  //"com.squareup.okhttp3" % "okhttp" % "3.9.1",
+  "com.typesafe.play" %% "play-json" % "2.6.9",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+)

--- a/handlers/sf-contact-merge/build.sbt
+++ b/handlers/sf-contact-merge/build.sbt
@@ -12,13 +12,4 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::SF Contact Merge"
 riffRaffArtifactResources += (file("handlers/sf-contact-merge/cfn.yaml"), "cfn/cfn.yaml")
 
-libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
-  "log4j" % "log4j" % "1.2.17",
-  //"com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "com.typesafe.play" %% "play-json" % "2.6.9",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
-)
+libraryDependencies ++= Seq()

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -18,12 +18,11 @@ Mappings:
         CODE:
             ApiName: sf-contact-merge-api-CODE
             DomainName: sf-contact-merge-code.membership.guardianapis.com
-            CertificateId: e4e6431e-08b9-4315-b997-75f2f9569d6c
+            # need to cloudform, then find out the RegionalDomainName of the api gateway stage manually and replace it here
             ApiGatewayTargetDomainName: tbc.execute-api.eu-west-1.amazonaws.com
         PROD:
             ApiName: sf-contact-merge-api-PROD
             DomainName: sf-contact-merge-prod.membership.guardianapis.com
-            CertificateId: c1e85179-09e3-4222-adee-e4ee77e73304
             ApiGatewayTargetDomainName: tbc.execute-api.eu-west-1.amazonaws.com
 
 Resources:
@@ -173,9 +172,8 @@ Resources:
     SfContactMergeDomainName:
       Type: "AWS::ApiGateway::DomainName"
       Properties:
-        RegionalCertificateArn: !Sub
-        - arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/${CertificateId}
-        - { CertificateId: !FindInMap [ StageMap, !Ref Stage, CertificateId ] }
+        RegionalCertificateArn: # only for *.membership.guardianapis.com
+          !Sub arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/c1efc564-9ff8-4a03-be48-d1990a3d79d2
         DomainName: !FindInMap [ StageMap, !Ref Stage, DomainName ]
         EndpointConfiguration:
           Types:
@@ -189,6 +187,7 @@ Resources:
         Stage: !Sub ${Stage}
       DependsOn:
       - SfContactMergeAPI
+      - SfContactMergeAPIStage
       - SfContactMergeDomainName
 
     SfContactMergeDNSRecord:

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -19,7 +19,7 @@ Mappings:
             ApiName: sf-contact-merge-api-CODE
             DomainName: sf-contact-merge-code.membership.guardianapis.com
             # need to cloudform, then find out the RegionalDomainName of the api gateway stage manually and replace it here
-            ApiGatewayTargetDomainName: wda6lq4gre.execute-api.eu-west-1.amazonaws.com
+            ApiGatewayTargetDomainName: d-33cbf5a76l.execute-api.eu-west-1.amazonaws.com
         PROD:
             ApiName: sf-contact-merge-api-PROD
             DomainName: sf-contact-merge-prod.membership.guardianapis.com

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -1,0 +1,227 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Merges together the salesforce account referenced by a set of zuora accounts
+
+Parameters:
+    Stage:
+        Description: Stage name
+        Type: String
+        AllowedValues:
+            - PROD
+            - CODE
+        Default: CODE
+
+Conditions:
+  CreateProdMonitoring: !Equals [ !Ref Stage, PROD ]
+
+Mappings:
+    StageMap:
+        CODE:
+            ApiName: sf-contact-merge-api-CODE
+            DomainName: sf-contact-merge-code.membership.guardianapis.com
+            CertificateId: e4e6431e-08b9-4315-b997-75f2f9569d6c
+            ApiGatewayTargetDomainName: tbc.execute-api.eu-west-1.amazonaws.com
+        PROD:
+            ApiName: sf-contact-merge-api-PROD
+            DomainName: sf-contact-merge-prod.membership.guardianapis.com
+            CertificateId: c1e85179-09e3-4222-adee-e4ee77e73304
+            ApiGatewayTargetDomainName: tbc.execute-api.eu-west-1.amazonaws.com
+
+Resources:
+    SfContactMergeRole:
+        Type: AWS::IAM::Role
+        Properties:
+            AssumeRolePolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Principal:
+                          Service:
+                             - lambda.amazonaws.com
+                      Action:
+                          - sts:AssumeRole
+            Path: /
+            Policies:
+                - PolicyName: LambdaPolicy
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action:
+                            - logs:CreateLogGroup
+                            - logs:CreateLogStream
+                            - logs:PutLogEvents
+                            - lambda:InvokeFunction
+                            Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sf-contact-merge-${Stage}:log-stream:*"
+                - PolicyName: ReadPrivateCredentials
+                  PolicyDocument:
+                      Statement:
+                          - Effect: Allow
+                            Action: s3:GetObject
+                            Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/payment-failure-lambdas/${Stage}/*
+    SfContactMergeLambda:
+        Type: AWS::Lambda::Function
+        Properties:
+            Description: Merges together the salesforce account referenced by a set of zuora accounts
+            FunctionName:
+                !Sub sf-contact-merge-${Stage}
+            Code:
+                S3Bucket: zuora-auto-cancel-dist
+                S3Key: !Sub membership/${Stage}/sf-contact-merge/sf-contact-merge.jar
+            Handler: com.gu.sfContactMerge.Handler::apply
+            Environment:
+                Variables:
+                  Stage: !Ref Stage
+            Role:
+                Fn::GetAtt:
+                - "SfContactMergeRole"
+                - Arn
+            MemorySize: 1536
+            Runtime: java8
+            Timeout: 300
+        DependsOn:
+        - "SfContactMergeRole"
+
+    SfContactMergeAPIPermission:
+        Type: AWS::Lambda::Permission
+        Properties:
+            Action: lambda:invokeFunction
+            FunctionName: !Sub sf-contact-merge-${Stage}
+            Principal: apigateway.amazonaws.com
+        DependsOn: SfContactMergeLambda
+
+    SfContactMergeProxyResource:
+        Type: AWS::ApiGateway::Resource
+        Properties:
+            RestApiId: !Ref SfContactMergeAPI
+            ParentId: !GetAtt [SfContactMergeAPI, RootResourceId]
+            PathPart: retention-status
+        DependsOn: SfContactMergeAPI
+
+    SfContactMergeMethod:
+        Type: AWS::ApiGateway::Method
+        Properties:
+            AuthorizationType: NONE
+            ApiKeyRequired: true
+            RestApiId: !Ref SfContactMergeAPI
+            ResourceId: !Ref SfContactMergeProxyResource
+            HttpMethod: POST
+            RequestParameters:
+              method.request.querystring.identityId: true
+            Integration:
+              Type: AWS_PROXY
+              IntegrationHttpMethod: POST
+              Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SfContactMergeLambda.Arn}/invocations
+        DependsOn:
+        - SfContactMergeAPI
+        - SfContactMergeLambda
+        - SfContactMergeProxyResource
+
+    SfContactMergeAPI:
+        Type: "AWS::ApiGateway::RestApi"
+        Properties:
+            Description: This called when we have a set of SF accounts that all belong to one person (email) to merge them
+            Name: !FindInMap [StageMap, !Ref Stage, ApiName]
+
+    SfContactMergeAPIStage:
+        Type: AWS::ApiGateway::Stage
+        Properties:
+            Description: Stage for sf-contact-merge-api
+            RestApiId: !Ref SfContactMergeAPI
+            DeploymentId: !Ref SfContactMergeAPIDeployment
+            StageName: !Sub ${Stage}
+        DependsOn: SfContactMergeMethod
+
+    SfContactMergeAPIDeployment:
+        Type: AWS::ApiGateway::Deployment
+        Properties:
+            Description: Deploys sf-contact-merge-api into an environment/stage
+            RestApiId: !Ref SfContactMergeAPI
+        DependsOn: SfContactMergeMethod
+
+    SfContactMergeAPIKey:
+      Type: AWS::ApiGateway::ApiKey
+      Properties:
+        Description: Key required to call contact merge API
+        Enabled: true
+        Name: !Sub sf-contact-merge-api-key-${Stage}
+        StageKeys:
+          - RestApiId: !Ref SfContactMergeAPI
+            StageName: !Sub ${Stage}
+      DependsOn:
+      - SfContactMergeAPI
+      - SfContactMergeAPIStage
+
+    SfContactMergeUsagePlan:
+      Type: "AWS::ApiGateway::UsagePlan"
+      Properties:
+        UsagePlanName: !Sub sf-contact-merge-api-usage-plan-${Stage}
+        ApiStages:
+        - ApiId: !Ref SfContactMergeAPI
+          Stage: !Ref SfContactMergeAPIStage
+      DependsOn:
+      - SfContactMergeAPI
+      - SfContactMergeAPIStage
+
+    SfContactMergeUsagePlanKey:
+      Type: "AWS::ApiGateway::UsagePlanKey"
+      Properties:
+        KeyId: !Ref SfContactMergeAPIKey
+        KeyType: API_KEY
+        UsagePlanId: !Ref SfContactMergeUsagePlan
+      DependsOn:
+      - SfContactMergeAPIKey
+      - SfContactMergeUsagePlan
+
+    SfContactMergeDomainName:
+      Type: "AWS::ApiGateway::DomainName"
+      Properties:
+        RegionalCertificateArn: !Sub
+        - arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/${CertificateId}
+        - { CertificateId: !FindInMap [ StageMap, !Ref Stage, CertificateId ] }
+        DomainName: !FindInMap [ StageMap, !Ref Stage, DomainName ]
+        EndpointConfiguration:
+          Types:
+            - REGIONAL
+
+    SfContactMergeBasePathMapping:
+      Type: "AWS::ApiGateway::BasePathMapping"
+      Properties:
+        RestApiId: !Ref SfContactMergeAPI
+        DomainName: !Ref SfContactMergeDomainName
+        Stage: !Sub ${Stage}
+      DependsOn:
+      - SfContactMergeAPI
+      - SfContactMergeDomainName
+
+    SfContactMergeDNSRecord:
+      Type: AWS::Route53::RecordSet
+      Properties:
+        HostedZoneName: membership.guardianapis.com.
+        Name: !FindInMap [ StageMap, !Ref Stage, DomainName ]
+        Comment: !Sub CNAME for sf-contact-merge API ${Stage}
+        Type: CNAME
+        TTL: '120'
+        ResourceRecords:
+        - !FindInMap [ StageMap, !Ref Stage, ApiGatewayTargetDomainName ]
+
+    5xxApiAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdMonitoring
+      Properties:
+        AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
+        AlarmName:
+          !Sub
+            - 5XX rate from ${ApiName}
+            - { ApiName: !FindInMap [StageMap, !Ref Stage, ApiName] }
+        ComparisonOperator: GreaterThanThreshold
+        Dimensions:
+          - Name: ApiName
+            Value: !FindInMap [StageMap, !Ref Stage, ApiName]
+          - Name: Stage
+            Value: !Sub ${Stage}
+        EvaluationPeriods: 1
+        MetricName: 5XXError
+        Namespace: AWS/ApiGateway
+        Period: 3600
+        Statistic: Sum
+        Threshold: 5
+        TreatMissingData: notBreaching

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -19,7 +19,7 @@ Mappings:
             ApiName: sf-contact-merge-api-CODE
             DomainName: sf-contact-merge-code.membership.guardianapis.com
             # need to cloudform, then find out the RegionalDomainName of the api gateway stage manually and replace it here
-            ApiGatewayTargetDomainName: tbc.execute-api.eu-west-1.amazonaws.com
+            ApiGatewayTargetDomainName: wda6lq4gre.execute-api.eu-west-1.amazonaws.com
         PROD:
             ApiName: sf-contact-merge-api-PROD
             DomainName: sf-contact-merge-prod.membership.guardianapis.com
@@ -69,9 +69,7 @@ Resources:
                 Variables:
                   Stage: !Ref Stage
             Role:
-                Fn::GetAtt:
-                - "SfContactMergeRole"
-                - Arn
+                !GetAtt SfContactMergeRole.Arn
             MemorySize: 1536
             Runtime: java8
             Timeout: 300
@@ -91,7 +89,7 @@ Resources:
         Properties:
             RestApiId: !Ref SfContactMergeAPI
             ParentId: !GetAtt [SfContactMergeAPI, RootResourceId]
-            PathPart: retention-status
+            PathPart: sf-contact-merge
         DependsOn: SfContactMergeAPI
 
     SfContactMergeMethod:

--- a/handlers/sf-contact-merge/riff-raff.yaml
+++ b/handlers/sf-contact-merge/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+- membership
+regions:
+- eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: sf-contact-merge
+    parameters:
+      templatePath: cfn.yaml
+
+  sf-contact-merge:
+    type: aws-lambda
+    parameters:
+      fileName: sf-contact-merge.jar
+      bucket: zuora-auto-cancel-dist
+      prefixStack: false
+      functionNames:
+      - sf-contact-merge-
+    dependencies: [cfn]

--- a/handlers/sf-contact-merge/src/main/resources/log4j.properties
+++ b/handlers/sf-contact-merge/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log = .
+log4j.rootLogger = INFO, LAMBDA
+
+# Define the LAMBDA Appender
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sfContactMerge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sfContactMerge/Handler.scala
@@ -1,0 +1,39 @@
+package com.gu.sfContactMerge
+
+import java.io.{InputStream, OutputStream}
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.effects.RawEffects
+import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
+import com.gu.util.config.ConfigReads.ConfigFailure
+import com.gu.util.config.{LoadConfig, Stage}
+import com.gu.util.reader.Types._
+import com.gu.util.zuora.ZuoraRestConfig
+import play.api.libs.json.{Json, Reads}
+import scalaz.\/
+
+object Handler {
+
+  case class StepsConfig(zuoraRestConfig: ZuoraRestConfig)
+
+  implicit val stepsConfigReads: Reads[StepsConfig] = Json.reads[StepsConfig]
+
+  // Referenced in Cloudformation
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
+    runWithEffects(RawEffects.stage, RawEffects.s3Load, LambdaIO(inputStream, outputStream, context))
+  }
+
+  def runWithEffects(stage: Stage, s3Load: Stage => ConfigFailure \/ String, lambdaIO: LambdaIO) = {
+
+    ApiGatewayHandler[StepsConfig](lambdaIO) {
+      for {
+        config <- LoadConfig.default[StepsConfig](implicitly)(stage, s3Load(stage))
+          .toApiGatewayOp("load config")
+        configuredOp = Operation.noHealthcheck(req => ApiGatewayResponse.notFound("implementation Not Found (yet)"), false)
+      } yield (config, configuredOp)
+    }
+
+  }
+
+}

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
@@ -11,28 +11,28 @@ class HandlerEffectsTest extends FlatSpec with Matchers {
 
   import TestData._
 
-  case class TestJsonFormat(
+  case class ExpectedJsonFormat(
     statusCode: String,
-    body: JsEmbedded[TestBodyFormat],
+    body: JsStringContainingJson[ExpectedBodyFormat],
     headers: Map[String, String] = Map("Content-Type" -> "application/json")
   )
 
-  case class TestBodyFormat(message: String)
+  case class ExpectedBodyFormat(message: String)
 
-  implicit val mF: OFormat[TestBodyFormat] = Json.format[TestBodyFormat]
-  implicit val apiF: OFormat[TestJsonFormat] = Json.format[TestJsonFormat]
+  implicit val mF: OFormat[ExpectedBodyFormat] = Json.format[ExpectedBodyFormat]
+  implicit val apiF: OFormat[ExpectedJsonFormat] = Json.format[ExpectedJsonFormat]
 
   it should "return 404 if the lambda hasn't been implemented" taggedAs EffectsTest in {
 
     val actualResponse = runWithEffects(dummyRequest())
 
-    val expected = TestJsonFormat(
+    val expected = ExpectedJsonFormat(
       "404",
-      JsEmbedded(TestBodyFormat("implementation Not Found (yet)")),
+      JsStringContainingJson(ExpectedBodyFormat("implementation Not Found (yet)")),
       Map("Content-Type" -> "application/json")
     )
 
-    actualResponse jsonMatches expected
+    actualResponse jsonMatchesFormat expected
   }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
@@ -11,7 +11,11 @@ class HandlerEffectsTest extends FlatSpec with Matchers {
 
   import TestData._
 
-  case class ApiResponse(statusCode: String, body: JsEmbedded[Message], headers: Map[String, String] = Map("Content-Type" -> "application/json"))
+  case class ApiResponse(
+    statusCode: String,
+    body: JsEmbedded[Message],
+    headers: Map[String, String] = Map("Content-Type" -> "application/json")
+  )
 
   case class Message(message: String)
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
@@ -11,24 +11,24 @@ class HandlerEffectsTest extends FlatSpec with Matchers {
 
   import TestData._
 
-  case class ApiResponse(
+  case class TestJsonFormat(
     statusCode: String,
-    body: JsEmbedded[Message],
+    body: JsEmbedded[TestBodyFormat],
     headers: Map[String, String] = Map("Content-Type" -> "application/json")
   )
 
-  case class Message(message: String)
+  case class TestBodyFormat(message: String)
 
-  implicit val mF: OFormat[Message] = Json.format[Message]
-  implicit val apiF: OFormat[ApiResponse] = Json.format[ApiResponse]
+  implicit val mF: OFormat[TestBodyFormat] = Json.format[TestBodyFormat]
+  implicit val apiF: OFormat[TestJsonFormat] = Json.format[TestJsonFormat]
 
   it should "return 404 if the lambda hasn't been implemented" taggedAs EffectsTest in {
 
     val actualResponse = runWithEffects(dummyRequest())
 
-    val expected = ApiResponse(
+    val expected = TestJsonFormat(
       "404",
-      JsEmbedded(Message("implementation Not Found (yet)")),
+      JsEmbedded(TestBodyFormat("implementation Not Found (yet)")),
       Map("Content-Type" -> "application/json")
     )
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
@@ -11,7 +11,7 @@ class HandlerEffectsTest extends FlatSpec with Matchers {
 
   import TestData._
 
-  case class ApiResponse(statusCode: String, body: JsEmbeddded[Message], headers: Map[String, String] = Map("Content-Type" -> "application/json"))
+  case class ApiResponse(statusCode: String, body: JsEmbedded[Message], headers: Map[String, String] = Map("Content-Type" -> "application/json"))
 
   case class Message(message: String)
 
@@ -24,7 +24,7 @@ class HandlerEffectsTest extends FlatSpec with Matchers {
 
     val expected = ApiResponse(
       "404",
-      JsEmbeddded(Message("implementation Not Found (yet)")),
+      JsEmbedded(Message("implementation Not Found (yet)")),
       Map("Content-Type" -> "application/json")
     )
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/HandlerEffectsTest.scala
@@ -1,0 +1,100 @@
+package com.gu.sfContactMerge
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+import com.gu.sfContactMerge.JsonMatchers._
+import com.gu.test.EffectsTest
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json._
+
+class HandlerEffectsTest extends FlatSpec with Matchers {
+
+  import TestData._
+
+  case class ApiResponse(statusCode: String, body: JsEmbeddded[Message], headers: Map[String, String] = Map("Content-Type" -> "application/json"))
+
+  case class Message(message: String)
+
+  implicit val mF: OFormat[Message] = Json.format[Message]
+  implicit val apiF: OFormat[ApiResponse] = Json.format[ApiResponse]
+
+  it should "return 404 if the lambda hasn't been implemented" taggedAs EffectsTest in {
+
+    val actualResponse = runWithEffects(dummyRequest())
+
+    val expected = ApiResponse(
+      "404",
+      JsEmbeddded(Message("implementation Not Found (yet)")),
+      Map("Content-Type" -> "application/json")
+    )
+
+    actualResponse jsonMatches expected
+  }
+
+}
+
+object TestData {
+
+  def runWithEffects(mockRequest: String): String = {
+    val stream = new ByteArrayInputStream(mockRequest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    val output = new ByteArrayOutputStream()
+    Handler(stream, output, null)
+    new String(output.toByteArray, "UTF-8")
+  }
+
+  def dummyRequest() =
+    s"""
+       |{
+       |    "resource": "/retention-status",
+       |    "path": "/retention-status",
+       |    "httpMethod": "POST",
+       |    "headers": {
+       |        "CloudFront-Forwarded-Proto": "https",
+       |        "CloudFront-Is-Desktop-Viewer": "true",
+       |        "CloudFront-Is-Mobile-Viewer": "false",
+       |        "CloudFront-Is-SmartTV-Viewer": "false",
+       |        "CloudFront-Is-Tablet-Viewer": "false",
+       |        "CloudFront-Viewer-Country": "US",
+       |        "Content-Type": "application/json; charset=utf-8",
+       |        "Host": "hosthosthost",
+       |        "User-Agent": "Amazon CloudFront",
+       |        "Via": "1.1 123.cloudfront.net (CloudFront), 1.1 123.cloudfront.net (CloudFront)",
+       |        "X-Amz-Cf-Id": "hihi",
+       |        "X-Amzn-Trace-Id": "trace123",
+       |        "X-Forwarded-For": "1.1.1.1, 1.1.1.1",
+       |        "X-Forwarded-Port": "443",
+       |        "X-Forwarded-Proto": "https"
+       |    },
+       |    "body": "",
+       |    "queryStringParameters": null,
+       |    "pathParameters": null,
+       |    "stageVariables": null,
+       |    "requestContext": {
+       |        "path": "/CODE/retention-status",
+       |        "accountId": "12345",
+       |        "resourceId": "321",
+       |        "stage": "CODE",
+       |        "requestId": "45678",
+       |        "identity": {
+       |            "cognitoIdentityPoolId": null,
+       |            "accountId": null,
+       |            "cognitoIdentityId": null,
+       |            "caller": null,
+       |            "apiKey": "",
+       |            "sourceIp": "1.1.1.1",
+       |            "accessKey": null,
+       |            "cognitoAuthenticationType": null,
+       |            "cognitoAuthenticationProvider": null,
+       |            "userArn": null,
+       |            "userAgent": "Amazon CloudFront",
+       |            "user": null
+       |        },
+       |        "resourcePath": "/sf-contact-merge",
+       |        "httpMethod": "POST",
+       |        "apiId": "11111"
+       |    },
+       |    "isBase64Encoded": false
+       |}
+    """.stripMargin
+
+}

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
@@ -38,7 +38,7 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
 
   case class Simple(key: String)
   implicit val sR = Json.format[Simple]
-  case class WithEmbed(embed: JsEmbedded[Simple])
+  case class WithEmbed(embed: JsStringContainingJson[Simple])
   implicit val wR = Json.format[WithEmbed]
 
   it should "handle missed fields as normal" in {
@@ -58,7 +58,7 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
   it should "work with the correct fields" in {
     val testData = """{"embed":"{\"key\":\"test\"  }"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    actual should be(JsSuccess(WithoutExtras(WithEmbed(JsEmbedded(Simple("test"))))))
+    actual should be(JsSuccess(WithoutExtras(WithEmbed(JsStringContainingJson(Simple("test"))))))
   }
 
   it should "fail for extra fields in the nested class" in {

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
@@ -1,0 +1,67 @@
+package com.gu.sfContactMerge
+
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsSuccess, Json}
+
+class JSComparisonTest extends FlatSpec with Matchers {
+
+  import JsonMatchers._
+
+  case class Simple(key: String)
+  implicit val sR = Json.format[Simple]
+
+  it should "handle missed fields as normal" in {
+    val testData = """{}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
+    actual.asEither.left.map(_.toString) should be(Left("List((/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"))
+  }
+
+  it should "work with the correct fields" in {
+    val testData = """{"key":"test"}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
+    actual should be(JsSuccess(WithoutExtras(Simple("test"))))
+  }
+
+  it should "fail for extra fields" in {
+    val testData = """{"key":"test", "extra": "bad"}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
+    actual.asEither.left.map(_.toString) should be(Left("List((,List(JsonValidationError(List(extra fields),WrappedArray()))))"))
+  }
+
+}
+
+class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
+
+  import JsonMatchers._
+
+  case class Simple(key: String)
+  implicit val sR = Json.format[Simple]
+  case class WithEmbed(embed: JsEmbeddded[Simple])
+  implicit val wR = Json.format[WithEmbed]
+
+  it should "handle missed fields as normal" in {
+    val testData = """{}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
+    actual.asEither.left.map(_.toString) should be(Left("List((/embed,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"))
+  }
+
+  it should "handle missed fields in the nested class" in {
+    val testData = """{"embed":"{}"}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
+    actual.asEither.left.map(_.toString) should be(Left("List((/embed/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"))
+  }
+
+  it should "work with the correct fields" in {
+    val testData = """{"embed":"{\"key\":\"test\"  }"}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
+    actual should be(JsSuccess(WithoutExtras(WithEmbed(JsEmbeddded(Simple("test"))))))
+  }
+
+  it should "fail for extra fields in the nested class" in {
+    val testData = """{"embed":"{\"key\":\"test\",  \"extra\":\"bad\"}"}"""
+    val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
+    actual.asEither.left.map(_.toString) should be(Left("List((/embed,List(JsonValidationError(List(extra fields),WrappedArray()))))"))
+  }
+
+}
+

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
@@ -13,7 +13,8 @@ class JSComparisonTest extends FlatSpec with Matchers {
   it should "handle missed fields as normal" in {
     val testData = """{}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    actual.asEither.left.map(_.toString) should be(Left("List((/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"))
+    val expectedError = "List((/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"
+    actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
   it should "work with the correct fields" in {
@@ -25,7 +26,8 @@ class JSComparisonTest extends FlatSpec with Matchers {
   it should "fail for extra fields" in {
     val testData = """{"key":"test", "extra": "bad"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    actual.asEither.left.map(_.toString) should be(Left("""List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),WrappedArray()))))"""))
+    val expectedError = """List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),WrappedArray()))))"""
+    actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
 }
@@ -42,13 +44,15 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
   it should "handle missed fields as normal" in {
     val testData = """{}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    actual.asEither.left.map(_.toString) should be(Left("List((/embed,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"))
+    val expectedError = "List((/embed,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"
+    actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
   it should "handle missed fields in the nested class" in {
     val testData = """{"embed":"{}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    actual.asEither.left.map(_.toString) should be(Left("List((/embed/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"))
+    val expectedError = "List((/embed/key,List(JsonValidationError(List(error.path.missing),WrappedArray()))))"
+    actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
   it should "work with the correct fields" in {
@@ -60,7 +64,8 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
   it should "fail for extra fields in the nested class" in {
     val testData = """{"embed":"{\"key\":\"test\",  \"extra\":\"bad\"}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    actual.asEither.left.map(_.toString) should be(Left("List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),WrappedArray()))))"))
+    val expectedError = "List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),WrappedArray()))))"
+    actual.asEither.left.map(_.toString) should be(Left(expectedError))
   }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsComparisonTest.scala
@@ -25,7 +25,7 @@ class JSComparisonTest extends FlatSpec with Matchers {
   it should "fail for extra fields" in {
     val testData = """{"key":"test", "extra": "bad"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[Simple]]
-    actual.asEither.left.map(_.toString) should be(Left("List((,List(JsonValidationError(List(extra fields),WrappedArray()))))"))
+    actual.asEither.left.map(_.toString) should be(Left("""List((,List(JsonValidationError(List(extra fields, {"key":"test"} == {"key":"test","extra":"bad"}),WrappedArray()))))"""))
   }
 
 }
@@ -36,7 +36,7 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
 
   case class Simple(key: String)
   implicit val sR = Json.format[Simple]
-  case class WithEmbed(embed: JsEmbeddded[Simple])
+  case class WithEmbed(embed: JsEmbedded[Simple])
   implicit val wR = Json.format[WithEmbed]
 
   it should "handle missed fields as normal" in {
@@ -54,13 +54,13 @@ class JSComparisonEmdeddedTest extends FlatSpec with Matchers {
   it should "work with the correct fields" in {
     val testData = """{"embed":"{\"key\":\"test\"  }"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    actual should be(JsSuccess(WithoutExtras(WithEmbed(JsEmbeddded(Simple("test"))))))
+    actual should be(JsSuccess(WithoutExtras(WithEmbed(JsEmbedded(Simple("test"))))))
   }
 
   it should "fail for extra fields in the nested class" in {
     val testData = """{"embed":"{\"key\":\"test\",  \"extra\":\"bad\"}"}"""
     val actual = Json.parse(testData).validate[WithoutExtras[WithEmbed]]
-    actual.asEither.left.map(_.toString) should be(Left("List((/embed,List(JsonValidationError(List(extra fields),WrappedArray()))))"))
+    actual.asEither.left.map(_.toString) should be(Left("List((/embed,List(JsonValidationError(List(extra fields, {\"key\":\"test\"} == {\"key\":\"test\",\"extra\":\"bad\"}),WrappedArray()))))"))
   }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsonMatchers.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsonMatchers.scala
@@ -17,6 +17,13 @@ object JsonMatchers {
 
   // *** //
 
+  /*
+  this marks a field as being a JsString which contains serialised json.  This is common where the body
+  is json within a json api gateway json descriptor.
+  When we deserialise, we store the serialised form to use when we serialise again, so that the higher level
+  JsValue comparison will still match exactly.
+  The structure of the embedded value will be checked when it in turn is deseralised.
+   */
   case class JsEmbeddded[C](c: C, origIgnoredInComparison: Option[String] = None) {
     override def equals(obj: scala.Any): Boolean = obj match {
       case JsEmbeddded(objc, _) => c.equals(objc)
@@ -44,6 +51,9 @@ object JsonMatchers {
       withExtrasCheck.map(c => JsEmbeddded(c, Some(stringContainingEmbeddedJson)))
     }
 
+  /*
+  This class wraps a class so that when we deserialise json into the object contained, it will ensure no extra fields whatsoever
+   */
   case class WithoutExtras[C](c: C)
 
   implicit def weW[C: OFormat]: Writes[WithoutExtras[C]] = (o: WithoutExtras[C]) =>

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsonMatchers.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsonMatchers.scala
@@ -3,37 +3,70 @@ package com.gu.sfContactMerge
 import org.scalatest.{Assertion, Matchers}
 import play.api.libs.json._
 
+import scala.util.{Failure, Success, Try}
+
 object JsonMatchers {
 
   implicit class JsonMatcher(private val actual: String) extends Matchers {
 
-    def jsonMatches[C: OFormat](expected: C): Assertion = {
-      val expectedJson: JsResult[WithoutExtras[C]] = JsSuccess(WithoutExtras(expected))
-      val actualJson: JsResult[WithoutExtras[C]] = Json.parse(actual).validate[WithoutExtras[C]]
+    def jsonMatchesFormat[FORMAT: OFormat](expected: FORMAT): Assertion = {
+      val expectedJson: JsResult[WithoutExtras[FORMAT]] = JsSuccess(WithoutExtras(expected))
+      val actualJson: JsResult[WithoutExtras[FORMAT]] = Json.parse(actual).validate[WithoutExtras[FORMAT]]
       actualJson should be(expectedJson)
     }
 
   }
 
-  case class JsEmbedded[C](c: C)
+  /*
+  This lets us model in case classes data types where there's a json object where one of the values is a string that
+  itself contains serialised json.
+  It will deserialise the json for the assertion in the test, ensuring that there
+  are no extra fields while it's doing so.
+   */
+  case class JsStringContainingJson[CONTAINED](embeddedJsonType: CONTAINED)
 
-  implicit def eW[C: OFormat]: Writes[JsEmbedded[C]] = (o: JsEmbedded[C]) =>
-    JsString(Json.prettyPrint(Json.toJsObject(o.c)))
+  implicit def embeddedJsonWrites[CONTAINED: OFormat]: Writes[JsStringContainingJson[CONTAINED]] =
+    (objectToWrite: JsStringContainingJson[CONTAINED]) =>
+      JsString(Json.prettyPrint(Json.toJsObject(objectToWrite.embeddedJsonType)))
 
-  implicit def eR[C: OFormat]: Reads[JsEmbedded[C]] = (jsValue: JsValue) =>
-    JsPath.read[String].reads(jsValue).flatMap { stringContainingEmbeddedJson =>
-      val jsValue = Json.parse(stringContainingEmbeddedJson)
-      val maybeC = jsValue.validate[C]
-      val withExtrasCheck = maybeC.flatMap { c =>
-        val backToJsValue: JsValue = Json.toJsObject(c)
-        if (sameStructure(backToJsValue, jsValue))
-          JsSuccess(c)
-        else JsError(s"extra fields, $backToJsValue == $jsValue")
-      }
-      withExtrasCheck.map(c => JsEmbedded(c))
-    }
+  implicit def embeddedJsonReads[CONTAINED: OFormat]: Reads[JsStringContainingJson[CONTAINED]] =
+    (jsValueToRead: JsValue) =>
+      for {
+        stringContainingEmbeddedJson <- JsPath.read[String].reads(jsValueToRead)
+        embeddedJsValue <- Try(Json.parse(stringContainingEmbeddedJson)) match {
+          case Success(s) => JsSuccess(s)
+          case Failure(t) => JsError(t.toString)
+        }
+        contained <- embeddedJsValue.validate[CONTAINED]
+        containedWithoutExtraFields <- wrapContainedEnsuringNoExtras(embeddedJsValue, contained)
+      } yield JsStringContainingJson(containedWithoutExtraFields)
 
-  def sameStructure: (JsValue, JsValue) => Boolean = {
+  /*
+  When this class wraps something, the deserialiser will refuse to deserialise if there are any fields
+  that are not defined specifically.  This is mostly used internally by the matchers.
+   */
+  case class WithoutExtras[CONTAINED](contained: CONTAINED)
+
+  implicit def withoutExtrasWrites[C: OFormat]: Writes[WithoutExtras[C]] =
+    (objectToWrite: WithoutExtras[C]) =>
+      Json.toJson(objectToWrite.contained)
+
+  implicit def withoutExtrasReads[CONTAINED: OFormat]: Reads[WithoutExtras[CONTAINED]] =
+    (jsValueToRead: JsValue) =>
+      for {
+        contained <- implicitly[Reads[CONTAINED]].reads(jsValueToRead)
+        containedWithoutExtraFields <- wrapContainedEnsuringNoExtras(jsValueToRead, contained)
+      } yield WithoutExtras(containedWithoutExtraFields)
+
+  def wrapContainedEnsuringNoExtras[CONTAINED: OFormat](jsValue: JsValue, contained: CONTAINED): JsResult[CONTAINED] = {
+    val backToJsValue: JsValue = Json.toJsObject(contained)
+    if (doesntHaveExtraFields(backToJsValue, jsValue))
+      JsSuccess(contained)
+    else
+      JsError(s"extra fields, $backToJsValue == $jsValue")
+  }
+
+  def doesntHaveExtraFields: (JsValue, JsValue) => Boolean = {
     case (o1: JsObject, o2: JsObject) =>
       if (o1.keys == o2.keys) {
         // check what's inside
@@ -41,29 +74,12 @@ object JsonMatchers {
           (for {
             v1 <- o1.value.get(key)
             v2 <- o2.value.get(key)
-          } yield sameStructure(v1, v2)).getOrElse(false /*won't happen*/ )
+          } yield doesntHaveExtraFields(v1, v2)).getOrElse(false /*won't happen*/ )
         }
-        println(s"keysMatch $keysMatch")
         !keysMatch.contains(false)
       } else false
     case (s1: JsArray, s2: JsArray) => false // may need to check inside JsArray too later
     case (v1, v2) => true //don't care about the content, will be chceck by the normal equals
   }
-
-  /*
-  This class wraps a class so that when we deserialise json into the object contained, it will ensure no extra fields whatsoever
-   */
-  case class WithoutExtras[C](c: C)
-
-  implicit def weW[C: OFormat]: Writes[WithoutExtras[C]] = (o: WithoutExtras[C]) =>
-    Json.toJson(o.c)
-
-  implicit def weR[C: OFormat]: Reads[WithoutExtras[C]] = (jsValue: JsValue) =>
-    implicitly[Reads[C]].reads(jsValue).flatMap { c =>
-      val backToJsValue: JsValue = Json.toJsObject(c)
-      if (sameStructure(backToJsValue, jsValue))
-        JsSuccess(WithoutExtras(c))
-      else JsError(s"extra fields, $backToJsValue == $jsValue")
-    }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsonMatchers.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sfContactMerge/JsonMatchers.scala
@@ -1,0 +1,60 @@
+package com.gu.sfContactMerge
+
+import org.scalatest.{Assertion, Matchers}
+import play.api.libs.json._
+
+object JsonMatchers {
+
+  implicit class JsonMatcher(private val actual: String) extends Matchers {
+
+    def jsonMatches[C: OFormat](expected: C): Assertion = {
+      val expectedJson: JsResult[WithoutExtras[C]] = JsSuccess(WithoutExtras(expected))
+      val actualJson: JsResult[WithoutExtras[C]] = Json.parse(actual).validate[WithoutExtras[C]]
+      actualJson should be(expectedJson)
+    }
+
+  }
+
+  // *** //
+
+  case class JsEmbeddded[C](c: C, origIgnoredInComparison: Option[String] = None) {
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case JsEmbeddded(objc, _) => c.equals(objc)
+      case _ => false
+    }
+
+    override def hashCode(): Int = c.hashCode
+
+    override def toString: String = s"JsEmbeddded(${c.toString})"
+  }
+
+  implicit def eW[C: OFormat]: Writes[JsEmbeddded[C]] = (o: JsEmbeddded[C]) =>
+    JsString(o.origIgnoredInComparison.getOrElse(s"missing orig (salt ${scala.util.Random.nextInt})"))
+
+  implicit def eR[C: OFormat]: Reads[JsEmbeddded[C]] = (jsValue: JsValue) =>
+    JsPath.read[String].reads(jsValue).flatMap { stringContainingEmbeddedJson =>
+      val jsValue = Json.parse(stringContainingEmbeddedJson)
+      val maybeC = jsValue.validate[C]
+      val withExtrasCheck = maybeC.flatMap { c =>
+        val backToJsValue: JsValue = Json.toJsObject(c)
+        if (backToJsValue == jsValue)
+          JsSuccess(c)
+        else JsError("extra fields")
+      }
+      withExtrasCheck.map(c => JsEmbeddded(c, Some(stringContainingEmbeddedJson)))
+    }
+
+  case class WithoutExtras[C](c: C)
+
+  implicit def weW[C: OFormat]: Writes[WithoutExtras[C]] = (o: WithoutExtras[C]) =>
+    Json.toJson(o.c)
+
+  implicit def weR[C: OFormat]: Reads[WithoutExtras[C]] = (jsValue: JsValue) =>
+    implicitly[Reads[C]].reads(jsValue).flatMap { c =>
+      val backToJsValue: JsValue = Json.toJsObject(c)
+      if (backToJsValue == jsValue)
+        JsSuccess(WithoutExtras(c))
+      else JsError("extra fields")
+    }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,5 +9,6 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311"
+  val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
 
 }


### PR DESCRIPTION
This PR adds a new template lambda for merging contacts.

I also removed all the unneeded deps from the handler as they are transitively imported from the libs.  Saves a lot of duplication.  We should do likewise in the other lambdas.

I also added a better way of comparing JSON from the end to end tests, I hope, thoughts appreciated though!  It was a lot more messy than I expected.

Ready for a review apart from the cloudformation which I need to test in CODE and make it work properly.  Take a look at the rest especially at the json matcher stuff see if it's worthwhile @pvighi @jacobwinch @twrichards @paulbrown1982 