### PR TITLE
add prod target domain name for custom domain name

### DIFF
--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -23,7 +23,7 @@ Mappings:
         PROD:
             ApiName: sf-contact-merge-api-PROD
             DomainName: sf-contact-merge-prod.membership.guardianapis.com
-            ApiGatewayTargetDomainName: tbc.execute-api.eu-west-1.amazonaws.com
+            ApiGatewayTargetDomainName: d-66g24d7g2k.execute-api.eu-west-1.amazonaws.com
 
 Resources:
     SfContactMergeRole:


### PR DESCRIPTION
just a quick update following https://github.com/guardian/zuora-auto-cancel/pull/126 to add in the actual target domain name that's been allocated in prod.
@pvighi @jacobwinch 