### PR TITLE
Identity Cookie Decoding now uses environment specific keys

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -70,7 +70,7 @@ object Handler extends Logging {
           .toApiGatewayOp("raise sf case")
       } yield raiseCaseResponse
 
-    def steps(stage:Stage)(sfRequests: LazySalesforceAuthenticatedReqMaker)(apiGatewayRequest: ApiGatewayRequest) =
+    def steps(stage: Stage)(sfRequests: LazySalesforceAuthenticatedReqMaker)(apiGatewayRequest: ApiGatewayRequest) =
       (for {
         identityId <- IdentityCookieToIdentityId(apiGatewayRequest.headers, stage)
         sfRequests <- sfRequests()
@@ -88,7 +88,7 @@ object Handler extends Logging {
     case class UpdateCasePathParams(caseId: String)
     implicit val pathParamReads = Json.reads[UpdateCasePathParams]
 
-    def steps(stage:Stage)(sfRequests: LazySalesforceAuthenticatedReqMaker)(apiGatewayRequest: ApiGatewayRequest) =
+    def steps(stage: Stage)(sfRequests: LazySalesforceAuthenticatedReqMaker)(apiGatewayRequest: ApiGatewayRequest) =
       (for {
         _ <- IdentityCookieToIdentityId(apiGatewayRequest.headers, stage) // TODO verify case belongs to identity user
         sfRequests <- sfRequests()

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityId.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityId.scala
@@ -1,19 +1,25 @@
 package com.gu.identity
 
-import com.gu.identity.cookie.{IdentityCookieDecoder, ProductionKeys}
+import com.gu.identity.cookie.{IdentityCookieDecoder, PreProductionKeys, ProductionKeys}
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse._
+import com.gu.util.config.Stage
 import com.gu.util.reader.Types._
 
 object IdentityCookieToIdentityId extends Logging {
 
-  def apply(headersOption: Option[Map[String, String]]): ApiGatewayOp[String] = for {
-    headers <- headersOption.toApiGatewayContinueProcessing(badRequest, "no headers")
-    cookieHeader <- headers.get("Cookie").toApiGatewayContinueProcessing(badRequest, "no cookie")
-    scGuU <- extractCookieHeaderValue(cookieHeader, "SC_GU_U")
-    cookieDecoder = new IdentityCookieDecoder(new ProductionKeys) // TODO review keys selection
-    userFromScGuU <- cookieDecoder.getUserDataForScGuU(scGuU).toApiGatewayContinueProcessing(unauthorized)
-  } yield userFromScGuU.getId
+  def apply(headersOption: Option[Map[String, String]], stage: Stage): ApiGatewayOp[String] = {
+
+    lazy val keys = if(stage.isProd) new ProductionKeys else new PreProductionKeys
+
+    for {
+      headers <- headersOption.toApiGatewayContinueProcessing(badRequest, "no headers")
+      cookieHeader <- headers.get("Cookie").toApiGatewayContinueProcessing(badRequest, "no cookie")
+      scGuU <- extractCookieHeaderValue(cookieHeader, "SC_GU_U")
+      cookieDecoder = new IdentityCookieDecoder(keys)
+      userFromScGuU <- cookieDecoder.getUserDataForScGuU(scGuU).toApiGatewayContinueProcessing(unauthorized)
+    } yield userFromScGuU.getId
+  }
 
   private def extractCookieHeaderValue(cookieHeader: String, specificCookieName: String): ApiGatewayOp[String] = {
     val specificCookieValueOption = for {

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityId.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityId.scala
@@ -1,6 +1,6 @@
 package com.gu.identity
 
-import com.gu.identity.cookie.{IdentityCookieDecoder, PreProductionKeys}
+import com.gu.identity.cookie.{IdentityCookieDecoder, ProductionKeys}
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse._
 import com.gu.util.reader.Types._
@@ -11,7 +11,7 @@ object IdentityCookieToIdentityId extends Logging {
     headers <- headersOption.toApiGatewayContinueProcessing(badRequest, "no headers")
     cookieHeader <- headers.get("Cookie").toApiGatewayContinueProcessing(badRequest, "no cookie")
     scGuU <- extractCookieHeaderValue(cookieHeader, "SC_GU_U")
-    cookieDecoder = new IdentityCookieDecoder(new PreProductionKeys) // TODO review keys selection
+    cookieDecoder = new IdentityCookieDecoder(new ProductionKeys) // TODO review keys selection
     userFromScGuU <- cookieDecoder.getUserDataForScGuU(scGuU).toApiGatewayContinueProcessing(unauthorized)
   } yield userFromScGuU.getId
 

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityId.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityId.scala
@@ -8,18 +8,15 @@ import com.gu.util.reader.Types._
 
 object IdentityCookieToIdentityId extends Logging {
 
-  def apply(headersOption: Option[Map[String, String]], stage: Stage): ApiGatewayOp[String] = {
-
-    lazy val keys = if(stage.isProd) new ProductionKeys else new PreProductionKeys
-
+  def apply(headersOption: Option[Map[String, String]], stage: Stage): ApiGatewayOp[String] =
     for {
       headers <- headersOption.toApiGatewayContinueProcessing(badRequest, "no headers")
       cookieHeader <- headers.get("Cookie").toApiGatewayContinueProcessing(badRequest, "no cookie")
       scGuU <- extractCookieHeaderValue(cookieHeader, "SC_GU_U")
+      keys = if(stage.isProd) new ProductionKeys else new PreProductionKeys
       cookieDecoder = new IdentityCookieDecoder(keys)
       userFromScGuU <- cookieDecoder.getUserDataForScGuU(scGuU).toApiGatewayContinueProcessing(unauthorized)
     } yield userFromScGuU.getId
-  }
 
   private def extractCookieHeaderValue(cookieHeader: String, specificCookieName: String): ApiGatewayOp[String] = {
     val specificCookieValueOption = for {


### PR DESCRIPTION
The 'stage' is now passed into the identity cookie checking to determine whether to use `ProductionKeys` or `PreProductionKeys` for decoding the cookie (in order to extract the identity id).