### PR TITLE
update config readme as we split the configs now

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ If you are changing the ET emails, it is worth running EmailClientSystemTest wit
 ---
 
 ## Howto update config
-At the moment we just use S3 for config.
+We use S3 for config at present.  We have it split out into suitable files so that each lambda
+only gets what it needs.  It will also help with automated key rotation.
 
 If you're making an addition, you can just copy the file from S3 for PROD and CODE, then update and upload.
 Check the version in the AwsS3.scala ConfigLoad object.
-`aws s3 cp s3://gu-reader-revenue-private/membership/payment-failure-lambdas/CODE/payment-failure-lambdas.private.v<VERSION>.json /etc/gu/CODE/ --profile membership`
+`aws s3 cp s3://gu-reader-revenue-private/membership/support-service-lambdas/CODE/<config-name>-CODE.v<VERSION>.json /etc/gu/CODE/ --profile membership`
 Then do the reverse to upload again.
 
 If you're making a change that you only want to go live on deployment (and have the ability to roll back

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ If you are changing the ET emails, it is worth running EmailClientSystemTest wit
 ---
 
 ## Howto update config
-We use S3 for config at present.  We have it split out into suitable files so that each lambda
-only gets what it needs.  It will also help with automated key rotation.
+We store private config in S3.  The config for different services (e.g. Zuora and Stripe) are split out into separate files so that each lambda only has access to the secrets it needs.  This will also help with automated key rotation.
 
 If you're making an addition, you can just copy the file from S3 for PROD and CODE, then update and upload.
 Check the version in the AwsS3.scala ConfigLoad object.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you are changing the ET emails, it is worth running EmailClientSystemTest wit
 ---
 
 ## Howto update config
-We store private config in S3.  The config for different services (e.g. Zuora and Stripe) are split out into separate files so that each lambda only has access to the secrets it needs.  This will also help with automated key rotation.
+We store private config in S3.  The config for different services (e.g. Zuora and Stripe) is split out into separate files so that each lambda only has access to the secrets it needs.  This will also help with automated key rotation.
 
 If you're making an addition, you can just copy the file from S3 for PROD and CODE, then update and upload.
 Check the version in the AwsS3.scala ConfigLoad object.


### PR DESCRIPTION
After we merged https://github.com/guardian/zuora-auto-cancel/pull/131 I realised we have a section about how the config works in the readme.  I thought I would tweak it to reflect how I think things work now.

I'm not sure how important it is to have here, given none of us thought about it, and people would generally ask how it works anyway.  But it may be handy for new people, or separated into a new file.

@pvighi @jacobwinch @twrichards as normal with readme updates, please push any tidyup and comments directly to the branch, i.e. edit it in place.  Then I'll merge it in a day or two assuming it has a +1