### PR TITLE
stop us building a zuora query with an empty OR

### DIFF
--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/GetActiveZuoraAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/GetActiveZuoraAccounts.scala
@@ -9,12 +9,12 @@ import com.gu.util.zuora.ZuoraQuery.{QueryResult, ZuoraQuerier}
 import play.api.libs.json.Json
 import scalaz.{-\/, \/-}
 
-object HasActiveZuoraAccounts {
+object GetActiveZuoraAccounts {
 
   case class IdentityQueryResponse(Id: String)
   implicit val reads = Json.reads[IdentityQueryResponse]
 
-  def apply(identityId: IdentityId, zuoraQuerier: ZuoraQuerier): ApiGatewayOp[List[AccountId]] = {
+  def apply(zuoraQuerier: ZuoraQuerier)(identityId: IdentityId): ApiGatewayOp[List[AccountId]] = {
 
     def searchForAccounts = {
 

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
@@ -25,14 +25,14 @@ object IdentityRetentionSteps extends Logging {
       (for {
         queryStringParameters <- apiGatewayRequest.queryParamsAsCaseClass[UrlParams]()
         identityId <- extractIdentityId(queryStringParameters)
-        possibleAccounts <- HasActiveZuoraAccounts(identityId, zuoraQuerier)
+        possibleAccounts <- GetActiveZuoraAccounts(zuoraQuerier)(identityId)
         accounts <- ToNel(possibleAccounts).toApiGatewayContinueProcessing(ApiGatewayResponse.notFound("no active zuora accounts"))
         subs <- SubscriptionsForAccounts(zuoraQuerier)(accounts)
       } yield RelationshipForSubscriptions(subs)).apiResponse
   }, false)
 
   def extractIdentityId(queryStringParams: UrlParams): ApiGatewayOp[IdentityId] = {
-    validate((queryStringParams.identityId)) match {
+    validate(queryStringParams.identityId) match {
       case Some(id) => ContinueProcessing(id)
       case None => ReturnWithResponse(ApiGatewayResponse.badRequest)
     }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
@@ -6,7 +6,7 @@ import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types.ApiGatewayOp
 import ApiGatewayOp._
-import com.gu.util.zuora.SafeQueryBuilder.ToNel
+import com.gu.util.zuora.SafeQueryBuilder.MaybeNonEmptyList
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
 import com.gu.util.reader.Types._
@@ -26,7 +26,7 @@ object IdentityRetentionSteps extends Logging {
         queryStringParameters <- apiGatewayRequest.queryParamsAsCaseClass[UrlParams]()
         identityId <- extractIdentityId(queryStringParameters)
         possibleAccounts <- GetActiveZuoraAccounts(zuoraQuerier)(identityId)
-        accounts <- ToNel(possibleAccounts).toApiGatewayContinueProcessing(ApiGatewayResponse.notFound("no active zuora accounts"))
+        accounts <- MaybeNonEmptyList(possibleAccounts).toApiGatewayContinueProcessing(ApiGatewayResponse.notFound("no active zuora accounts"))
         subs <- SubscriptionsForAccounts(zuoraQuerier)(accounts)
       } yield RelationshipForSubscriptions(subs)).apiResponse
   }, false)

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
@@ -20,7 +20,7 @@ object SubscriptionsForAccounts {
 
   implicit val reads = Json.reads[SubscriptionsQueryResponse]
 
-  def buildQuery(activeAccounts: List[AccountId]): ClientFailableOp[SafeQuery] =
+  def buildQuery(activeAccounts: ::[AccountId]): ClientFailableOp[SafeQuery] =
     for {
       or <- OrTraverse(activeAccounts) { acc =>
         zoql"""
@@ -38,7 +38,7 @@ object SubscriptionsForAccounts {
         """
     } yield subscriptionsQuery
 
-  def apply(zuoraQuerier: ZuoraQuerier)(activeAccounts: List[AccountId]): ApiGatewayOp[List[SubscriptionsQueryResponse]] = {
+  def apply(zuoraQuerier: ZuoraQuerier)(activeAccounts: ::[AccountId]): ApiGatewayOp[List[SubscriptionsQueryResponse]] = {
 
     def searchForSubscriptions =
       for {

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/SubscriptionsForAccounts.scala
@@ -9,6 +9,7 @@ import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SafeQuery}
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
+import scalaz.NonEmptyList
 
 object SubscriptionsForAccounts {
 
@@ -20,7 +21,7 @@ object SubscriptionsForAccounts {
 
   implicit val reads = Json.reads[SubscriptionsQueryResponse]
 
-  def buildQuery(activeAccounts: ::[AccountId]): ClientFailableOp[SafeQuery] =
+  def buildQuery(activeAccounts: NonEmptyList[AccountId]): ClientFailableOp[SafeQuery] =
     for {
       or <- OrTraverse(activeAccounts) { acc =>
         zoql"""
@@ -38,7 +39,7 @@ object SubscriptionsForAccounts {
         """
     } yield subscriptionsQuery
 
-  def apply(zuoraQuerier: ZuoraQuerier)(activeAccounts: ::[AccountId]): ApiGatewayOp[List[SubscriptionsQueryResponse]] = {
+  def apply(zuoraQuerier: ZuoraQuerier)(activeAccounts: NonEmptyList[AccountId]): ApiGatewayOp[List[SubscriptionsQueryResponse]] = {
 
     def searchForSubscriptions =
       for {

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/HasActiveZuoraAccountsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/HasActiveZuoraAccountsTest.scala
@@ -1,6 +1,6 @@
 package com.gu.identityRetention
 
-import com.gu.identityRetention.HasActiveZuoraAccounts.IdentityQueryResponse
+import com.gu.identityRetention.GetActiveZuoraAccounts.IdentityQueryResponse
 import com.gu.identityRetention.Types.AccountId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.zuora.RestRequestMaker.GenericError
@@ -15,19 +15,19 @@ class HasActiveZuoraAccountsTest extends FlatSpec with Matchers {
   val singleZuoraAccount = QueryResult[IdentityQueryResponse](List(IdentityQueryResponse("acc123")), 1, true, None)
 
   it should "return a left(404) if the identity id is not linked to any Zuora accounts" in {
-    val zuoraCheck = HasActiveZuoraAccounts.processQueryResult(\/-(noZuoraAccounts))
+    val zuoraCheck = GetActiveZuoraAccounts.processQueryResult(\/-(noZuoraAccounts))
     val expected = -\/(IdentityRetentionApiResponses.canBeDeleted)
     zuoraCheck.toDisjunction should be(expected)
   }
 
   it should "return a left(500) if the call to Zuora fails" in {
-    val zuoraCheck = HasActiveZuoraAccounts.processQueryResult(-\/(GenericError("Zuora response was a 500")))
+    val zuoraCheck = GetActiveZuoraAccounts.processQueryResult(-\/(GenericError("Zuora response was a 500")))
     val expected = -\/(ApiGatewayResponse.internalServerError("Failed to retrieve the identity user's details from Zuora"))
     zuoraCheck.toDisjunction should be(expected)
   }
 
   it should "return a list of account ids if we find an identity id linked to a billing account" in {
-    val zuoraCheck = HasActiveZuoraAccounts.processQueryResult(\/-(singleZuoraAccount))
+    val zuoraCheck = GetActiveZuoraAccounts.processQueryResult(\/-(singleZuoraAccount))
     val expected = \/-(List(AccountId("acc123")))
     zuoraCheck.toDisjunction should be(expected)
   }

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
@@ -6,6 +6,7 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identityRetention.Types.AccountId
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
@@ -14,7 +15,7 @@ class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
 
   it should "successfull query multiple accounts" taggedAs EffectsTest in {
 
-    val testAccountIds = List(
+    val testAccountIds = ToNel.literal(
       AccountId("2c92c0f86371efdc0163871a9ad72274"),
       AccountId("2c92c0f86371f0360163871d94eb0e68")
     )

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsEffectsTest.scala
@@ -6,16 +6,15 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identityRetention.Types.AccountId
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
-import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.\/-
+import scalaz.{NonEmptyList, \/-}
 
 class SubscriptionsForAccountsEffectsTest extends FlatSpec with Matchers {
 
   it should "successfull query multiple accounts" taggedAs EffectsTest in {
 
-    val testAccountIds = ToNel.literal(
+    val testAccountIds = NonEmptyList(
       AccountId("2c92c0f86371efdc0163871a9ad72274"),
       AccountId("2c92c0f86371f0360163871d94eb0e68")
     )

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
@@ -1,14 +1,13 @@
 package com.gu.identityRetention
 
 import com.gu.identityRetention.Types.AccountId
-import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.\/-
+import scalaz.{NonEmptyList, \/-}
 
 class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
 
   it should "build a valid query for a single account" in {
-    val query = SubscriptionsForAccounts.buildQuery(ToNel.literal(
+    val query = SubscriptionsForAccounts.buildQuery(NonEmptyList(
       AccountId("acc123")
     ))
     val expectedQuery = s"select id, name, status, termEndDate from subscription where status != 'Expired' and accountId = 'acc123'"
@@ -16,7 +15,7 @@ class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
   }
 
   it should "build a valid query for multiple accounts" in {
-    val query = SubscriptionsForAccounts.buildQuery(ToNel.literal(
+    val query = SubscriptionsForAccounts.buildQuery(NonEmptyList(
       AccountId("acc123"),
       AccountId("acc321")
     ))

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/SubscriptionsForAccountsTest.scala
@@ -1,13 +1,14 @@
 package com.gu.identityRetention
 
 import com.gu.identityRetention.Types.AccountId
+import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 
 class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
 
   it should "build a valid query for a single account" in {
-    val query = SubscriptionsForAccounts.buildQuery(List(
+    val query = SubscriptionsForAccounts.buildQuery(ToNel.literal(
       AccountId("acc123")
     ))
     val expectedQuery = s"select id, name, status, termEndDate from subscription where status != 'Expired' and accountId = 'acc123'"
@@ -15,7 +16,7 @@ class SubscriptionsForAccountsTest extends FlatSpec with Matchers {
   }
 
   it should "build a valid query for multiple accounts" in {
-    val query = SubscriptionsForAccounts.buildQuery(List(
+    val query = SubscriptionsForAccounts.buildQuery(ToNel.literal(
       AccountId("acc123"),
       AccountId("acc321")
     ))

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccounts.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccounts.scala
@@ -2,23 +2,26 @@ package com.gu.sf_contact_merge
 
 import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
-import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, ToNel}
+import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, MaybeNonEmptyList}
 import com.gu.util.zuora.ZuoraQuery.ZuoraQuerier
 import play.api.libs.json.Json
-import scalaz.{-\/, \/-}
+import scalaz.{-\/, NonEmptyList, \/-}
 
 object GetZuoraEmailsForAccounts {
 
   case class AccountId(value: String) extends AnyVal
 
   case class EmailAddress(value: String) extends AnyVal
-  def apply(zuoraQuerier: ZuoraQuerier)(accountIds: ::[AccountId]): ClientFailableOp[List[Option[EmailAddress]]] =
+  def apply(zuoraQuerier: ZuoraQuerier)(accountIds: NonEmptyList[AccountId]): ClientFailableOp[List[Option[EmailAddress]]] = {
+
+    val getEmails = GetEmails(zuoraQuerier)_
+    val getContacts = GetContacts(zuoraQuerier)_
+
     for {
-      billToContacts <- GetContacts(zuoraQuerier)(accountIds)
-      emailAddresses <- ToNel(billToContacts).map { emailAddresses =>
-        GetEmails(zuoraQuerier)(emailAddresses)
-      }.getOrElse(\/-(Nil))
+      billToContacts <- getContacts(accountIds)
+      emailAddresses <- MaybeNonEmptyList(billToContacts).map(getEmails).getOrElse(\/-(Nil))
     } yield emailAddresses
+  }
 
   case class ContactId(value: String) extends AnyVal
 
@@ -27,7 +30,7 @@ object GetZuoraEmailsForAccounts {
     case class WireAccount(BillToId: String)
     implicit val readWireAccount = Json.reads[WireAccount]
 
-    def apply(zuoraQuerier: ZuoraQuerier)(accountIds: ::[AccountId]): ClientFailableOp[List[ContactId]] =
+    def apply(zuoraQuerier: ZuoraQuerier)(accountIds: NonEmptyList[AccountId]): ClientFailableOp[List[ContactId]] =
       for {
         or <- OrTraverse(accountIds) { accountId =>
           zoql"""Id = ${accountId.value}"""
@@ -44,7 +47,7 @@ object GetZuoraEmailsForAccounts {
     case class WireContact(WorkEmail: Option[String])
     implicit val readWireContact = Json.reads[WireContact]
 
-    def apply(zuoraQuerier: ZuoraQuerier)(contactIds: ::[ContactId]): ClientFailableOp[List[Option[EmailAddress]]] =
+    def apply(zuoraQuerier: ZuoraQuerier)(contactIds: NonEmptyList[ContactId]): ClientFailableOp[List[Option[EmailAddress]]] =
       for {
         or <- OrTraverse(contactIds) { accountId =>
           zoql"""Id = ${accountId.value}"""

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -19,9 +19,9 @@ class EndToEndTest extends FlatSpec with Matchers {
   it should "accept a request in the format we expect" in {
 
     val expected = ExpectedJsonFormat(
-      "404",
-      JsStringContainingJson(ExpectedBodyFormat("passed the prereq check")),
-      Map("Content-Type" -> "application/json")
+      statusCode = "404",
+      body = JsStringContainingJson(ExpectedBodyFormat(message = "passed the prereq check")),
+      headers = Map("Content-Type" -> "application/json")
     )
 
     val body =

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetContactsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetContactsTest.scala
@@ -3,6 +3,7 @@ package com.gu.sf_contact_merge
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.sf_contact_merge.GetZuoraEmailsForAccounts.AccountId
+import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
@@ -14,7 +15,7 @@ class GetContactsTest extends FlatSpec with Matchers {
   it should "work" in {
 
     val getContacts = GetZuoraEmailsForAccounts.GetContacts(ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass"))))_
-    val actual = getContacts(List("2c92c0f9624bbc5f016253e573970b16", "2c92c0f8644618e30164652a558c6e20").map(AccountId.apply))
+    val actual = getContacts(ToNel.literal(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8644618e30164652a558c6e20")))
 
     actual.map(_.map(_.value)) should be(\/-(List("2c92c0f8644618e30164652a55986e21", "2c92c0f9624bbc5f016253e5739b0b17")))
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetContactsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetContactsTest.scala
@@ -14,10 +14,17 @@ class GetContactsTest extends FlatSpec with Matchers {
 
   it should "work" in {
 
-    val getContacts = GetZuoraEmailsForAccounts.GetContacts(ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass"))))_
-    val actual = getContacts(ToNel.literal(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8644618e30164652a558c6e20")))
+    val zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass")))
+    val getContacts = GetZuoraEmailsForAccounts.GetContacts(zuoraQuerier)_
+    val actual = getContacts(ToNel.literal(
+      AccountId("acid1"),
+      AccountId("acid2")
+    ))
 
-    actual.map(_.map(_.value)) should be(\/-(List("2c92c0f8644618e30164652a55986e21", "2c92c0f9624bbc5f016253e5739b0b17")))
+    actual.map(_.map(_.value)) should be(\/-(List(
+      "b2id1",
+      "b2id2"
+    )))
 
   }
 
@@ -26,18 +33,18 @@ class GetContactsTest extends FlatSpec with Matchers {
 object GetContactsTest {
 
   val accountQueryRequest =
-    """{"queryString":"SELECT BillToId FROM Account WHERE Id = '2c92c0f9624bbc5f016253e573970b16' or Id = '2c92c0f8644618e30164652a558c6e20'"}"""
+    """{"queryString":"SELECT BillToId FROM Account WHERE Id = 'acid1' or Id = 'acid2'"}"""
 
   val accountQueryResponse =
     """{
       |    "records": [
       |        {
-      |            "BillToId": "2c92c0f8644618e30164652a55986e21",
-      |            "Id": "2c92c0f8644618e30164652a558c6e20"
+      |            "BillToId": "b2id1",
+      |            "Id": "acid1"
       |        },
       |        {
-      |            "BillToId": "2c92c0f9624bbc5f016253e5739b0b17",
-      |            "Id": "2c92c0f9624bbc5f016253e573970b16"
+      |            "BillToId": "b2id2",
+      |            "Id": "acid2"
       |        }
       |    ],
       |    "size": 2,

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetContactsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetContactsTest.scala
@@ -3,10 +3,9 @@ package com.gu.sf_contact_merge
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.sf_contact_merge.GetZuoraEmailsForAccounts.AccountId
-import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.\/-
+import scalaz.{NonEmptyList, \/-}
 
 class GetContactsTest extends FlatSpec with Matchers {
 
@@ -16,7 +15,7 @@ class GetContactsTest extends FlatSpec with Matchers {
 
     val zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass")))
     val getContacts = GetZuoraEmailsForAccounts.GetContacts(zuoraQuerier)_
-    val actual = getContacts(ToNel.literal(
+    val actual = getContacts(NonEmptyList(
       AccountId("acid1"),
       AccountId("acid2")
     ))

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetEmailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetEmailsTest.scala
@@ -3,6 +3,7 @@ package com.gu.sf_contact_merge
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.sf_contact_merge.GetZuoraEmailsForAccounts.ContactId
+import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
@@ -14,7 +15,7 @@ class GetEmailsTest extends FlatSpec with Matchers {
   it should "work" in {
 
     val getContacts = GetZuoraEmailsForAccounts.GetEmails(ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass"))))_
-    val actual = getContacts(List("2c92c0f8644618e30164652a55986e21", "2c92c0f9624bbc5f016253e5739b0b17").map(ContactId.apply))
+    val actual = getContacts(ToNel.literal(ContactId("2c92c0f8644618e30164652a55986e21"), ContactId("2c92c0f9624bbc5f016253e5739b0b17")))
 
     actual.map(_.map(_.map(_.value))) should be(\/-(List(Some("peppa.pig@guardian.co.uk"), None)))
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetEmailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetEmailsTest.scala
@@ -14,8 +14,12 @@ class GetEmailsTest extends FlatSpec with Matchers {
 
   it should "work" in {
 
-    val getContacts = GetZuoraEmailsForAccounts.GetEmails(ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass"))))_
-    val actual = getContacts(ToNel.literal(ContactId("2c92c0f8644618e30164652a55986e21"), ContactId("2c92c0f9624bbc5f016253e5739b0b17")))
+    val zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass")))
+    val getContacts = GetZuoraEmailsForAccounts.GetEmails(zuoraQuerier)_
+    val actual = getContacts(ToNel.literal(
+      ContactId("cid1"),
+      ContactId("cid2")
+    ))
 
     actual.map(_.map(_.map(_.value))) should be(\/-(List(Some("peppa.pig@guardian.co.uk"), None)))
 
@@ -26,17 +30,17 @@ class GetEmailsTest extends FlatSpec with Matchers {
 object GetEmailsTest {
 
   val contactQueryRequest =
-    """{"queryString":"SELECT WorkEmail FROM Contact WHERE Id = '2c92c0f8644618e30164652a55986e21' or Id = '2c92c0f9624bbc5f016253e5739b0b17'"}"""
+    """{"queryString":"SELECT WorkEmail FROM Contact WHERE Id = 'cid1' or Id = 'cid2'"}"""
 
   val contactQueryResponse =
     """{
       |    "records": [
       |        {
       |            "WorkEmail": "peppa.pig@guardian.co.uk",
-      |            "Id": "2c92c0f8644618e30164652a55986e21"
+      |            "Id": "cid1"
       |        },
       |        {
-      |            "Id": "2c92c0f9624bbc5f016253e5739b0b17"
+      |            "Id": "cid2"
       |        }
       |    ],
       |    "size": 2,

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetEmailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetEmailsTest.scala
@@ -3,10 +3,9 @@ package com.gu.sf_contact_merge
 import com.gu.effects.TestingRawEffects
 import com.gu.effects.TestingRawEffects.{HTTPResponse, POSTRequest}
 import com.gu.sf_contact_merge.GetZuoraEmailsForAccounts.ContactId
-import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.\/-
+import scalaz.{NonEmptyList, \/-}
 
 class GetEmailsTest extends FlatSpec with Matchers {
 
@@ -16,7 +15,7 @@ class GetEmailsTest extends FlatSpec with Matchers {
 
     val zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(mock.response, ZuoraRestConfig("http://server", "user", "pass")))
     val getContacts = GetZuoraEmailsForAccounts.GetEmails(zuoraQuerier)_
-    val actual = getContacts(ToNel.literal(
+    val actual = getContacts(NonEmptyList(
       ContactId("cid1"),
       ContactId("cid2")
     ))

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccountsEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccountsEffectsTest.scala
@@ -6,6 +6,7 @@ import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -15,7 +16,7 @@ class GetZuoraEmailsForAccountsEffectsTest extends FlatSpec with Matchers {
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig].toApiGatewayOp("parse config")
       getZuoraEmailsForAccounts = GetZuoraEmailsForAccounts(ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig))) _
-      testData = List("2c92c0f9624bbc5f016253e573970b16", "2c92c0f8646e0a6601646ff9b98e7b5f").map(AccountId.apply)
+      testData = ToNel.literal(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8646e0a6601646ff9b98e7b5f"))
       maybeEmailAddresses <- getZuoraEmailsForAccounts(testData).toApiGatewayOp("get zuora emails for accounts")
     } yield maybeEmailAddresses
     actual should be(ContinueProcessing(List(Some(EmailAddress("peppa.pig@guardian.co.uk")), None)))

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccountsEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccountsEffectsTest.scala
@@ -13,13 +13,19 @@ import org.scalatest.{FlatSpec, Matchers}
 class GetZuoraEmailsForAccountsEffectsTest extends FlatSpec with Matchers {
 
   it should "return the right emails" taggedAs EffectsTest in {
+
+    val testData = ToNel.literal(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8646e0a6601646ff9b98e7b5f"))
+
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig].toApiGatewayOp("parse config")
       getZuoraEmailsForAccounts = GetZuoraEmailsForAccounts(ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig))) _
-      testData = ToNel.literal(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8646e0a6601646ff9b98e7b5f"))
       maybeEmailAddresses <- getZuoraEmailsForAccounts(testData).toApiGatewayOp("get zuora emails for accounts")
     } yield maybeEmailAddresses
-    actual should be(ContinueProcessing(List(Some(EmailAddress("peppa.pig@guardian.co.uk")), None)))
+
+    actual should be(ContinueProcessing(List(
+      Some(EmailAddress("peppa.pig@guardian.co.uk")),
+      None
+    )))
   }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccountsEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/GetZuoraEmailsForAccountsEffectsTest.scala
@@ -6,15 +6,15 @@ import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import com.gu.util.reader.Types._
-import com.gu.util.zuora.SafeQueryBuilder.ToNel
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.NonEmptyList
 
 class GetZuoraEmailsForAccountsEffectsTest extends FlatSpec with Matchers {
 
   it should "return the right emails" taggedAs EffectsTest in {
 
-    val testData = ToNel.literal(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8646e0a6601646ff9b98e7b5f"))
+    val testData = NonEmptyList(AccountId("2c92c0f9624bbc5f016253e573970b16"), AccountId("2c92c0f8646e0a6601646ff9b98e7b5f"))
 
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig].toApiGatewayOp("parse config")

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeZuoraQuerier.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeZuoraQuerier.scala
@@ -1,0 +1,22 @@
+package com.gu.zuora.fake
+
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
+import com.gu.util.zuora.ZuoraQuery.{QueryResult, ZuoraQuerier}
+import com.gu.util.zuora.{SafeQueryBuilder, ZuoraQuery}
+import play.api.libs.json.{Json, Reads}
+import scalaz.-\/
+import scalaz.syntax.std.either._
+
+object FakeZuoraQuerier {
+
+  def apply(expectedQuery: String, response: String): ZuoraQuery.ZuoraQuerier = new ZuoraQuerier {
+    override def apply[QUERYRECORD: Reads](query: SafeQueryBuilder.SafeQuery): ClientFailableOp[ZuoraQuery.QueryResult[QUERYRECORD]] = {
+      if (query.queryString == expectedQuery) {
+        Json.parse(response).validate[QueryResult[QUERYRECORD]].asEither.disjunction.leftMap(err => GenericError(err.toString))
+      } else {
+        -\/(GenericError("unexpected query"))
+      }
+    }
+  }
+
+}

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -64,9 +64,20 @@ object SafeQueryBuilder {
 
   }
 
+  object ToNel {
+    def apply[A](list: List[A]): Option[::[A]] =
+      list match {
+        case Nil => None
+        case account :: accounts =>
+          Some(::(account, accounts))
+      }
+    def literal[A](first: A, rest: A*): ::[A] =
+      ::(first, List(rest: _*))
+  }
+
   object OrTraverse {
-    def apply[A](queries: List[A])(f: A => ClientFailableOp[SafeQuery]): ClientFailableOp[SafeQuery] = {
-      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SafeQuery(_))
+    def apply[A](queries: ::[A])(f: A => ClientFailableOp[SafeQuery]): ClientFailableOp[SafeQuery] = {
+      queries.toList.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SafeQuery(_))
     }
   }
 

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
@@ -3,7 +3,7 @@ package com.gu.util.zuora
 import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
 import scalaz.std.list.listInstance
 import scalaz.syntax.traverse.ToTraverseOps
-import scalaz.{-\/, \/-}
+import scalaz.{-\/, NonEmptyList, \/-}
 
 import scala.annotation.implicitNotFound
 
@@ -64,20 +64,18 @@ object SafeQueryBuilder {
 
   }
 
-  object ToNel {
-    def apply[A](list: List[A]): Option[::[A]] =
+  object MaybeNonEmptyList {
+    def apply[A](list: List[A]): Option[NonEmptyList[A]] =
       list match {
         case Nil => None
         case account :: accounts =>
-          Some(::(account, accounts))
+          Some(NonEmptyList(account, accounts: _*))
       }
-    def literal[A](first: A, rest: A*): ::[A] =
-      ::(first, List(rest: _*))
   }
 
   object OrTraverse {
-    def apply[A](queries: ::[A])(f: A => ClientFailableOp[SafeQuery]): ClientFailableOp[SafeQuery] = {
-      queries.toList.traverseU(f.andThen(_.map(_.queryString))).map(_.mkString(" or ")).map(new SafeQuery(_))
+    def apply[A](queries: NonEmptyList[A])(f: A => ClientFailableOp[SafeQuery]): ClientFailableOp[SafeQuery] = {
+      queries.traverseU(f.andThen(_.map(_.queryString))).map(_.list.toList.mkString(" or ")).map(new SafeQuery(_))
     }
   }
 

--- a/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
@@ -2,7 +2,7 @@ package com.gu.util
 
 import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
-import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SafeQuery}
+import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SafeQuery, ToNel}
 import org.scalatest._
 import scalaz.{-\/, \/-}
 
@@ -74,7 +74,7 @@ class SafeQueryBuilderApplyTest extends FlatSpec with Matchers {
   }
 
   it should "use a List in insert clause" in {
-    val ids = List("anna", "bill")
+    val ids = ToNel.literal("anna", "bill")
     val actual = for {
       insert <- OrTraverse(ids)({ id => zoql"""id = $id""" })
       wholeQuery <- zoql"""select hi from table where $insert"""

--- a/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/SafeQueryBuilderTest.scala
@@ -2,9 +2,9 @@ package com.gu.util
 
 import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError}
 import com.gu.util.zuora.SafeQueryBuilder.Implicits._
-import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SafeQuery, ToNel}
+import com.gu.util.zuora.SafeQueryBuilder.{OrTraverse, SafeQuery}
 import org.scalatest._
-import scalaz.{-\/, \/-}
+import scalaz.{-\/, NonEmptyList, \/-}
 
 class SafeQueryBuilderEscapeTest extends FlatSpec with Matchers {
 
@@ -74,7 +74,7 @@ class SafeQueryBuilderApplyTest extends FlatSpec with Matchers {
   }
 
   it should "use a List in insert clause" in {
-    val ids = ToNel.literal("anna", "bill")
+    val ids = NonEmptyList("anna", "bill")
     val actual = for {
       insert <- OrTraverse(ids)({ id => zoql"""id = $id""" })
       wholeQuery <- zoql"""select hi from table where $insert"""


### PR DESCRIPTION
It turned out the query builder I wrote the other week handled OR by generating an empty string if there are no clauses in the OR.  Call it lack of testing.

zuora was just kicking out the query as the WHERE clause was empty.
```
{ "queryString": "SELECT WorkEmail FROM Contact WHERE" }
```
"You have an error in your ZOQL syntax"

It doesn't really make sense to have an OR clause with no clauses inside (unless you're a philosopher, in which case it means the condition is never satisfied)

I thought of a couple of approaches, from just trusting the input and putting in a 1=0 default clause (zuora won't accept antthing like that unfortauntely) to getting the individual operations to filter it (more boiler plate to remember) and in the end I decided to try making it a compile error (OrTraverse takes a non empty list)

I wasn't sure whether to use the scalaz one, so I just used the normal list.  The drawback is that the standard operators like to upcast to a normal list at every opportunity.

See what you think, the result is below.

@jacobwinch @pvighi @paulbrown1982 @twrichards 