### PR TITLE
add zuora contact update logic to sf contact merge lambda

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/UpdateAccountSFLinks.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/UpdateAccountSFLinks.scala
@@ -1,0 +1,22 @@
+package com.gu.sf_contact_merge
+
+import com.gu.sf_contact_merge.GetZuoraEmailsForAccounts.AccountId
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, RequestsPUT}
+import play.api.libs.json.{JsSuccess, Json, Reads}
+
+object UpdateAccountSFLinks {
+
+  case class Request(
+    crmId: String,
+    sfContactId__c: String
+  )
+  implicit val writes = Json.writes[Request]
+  implicit val unitReads: Reads[Unit] = Reads(_ => JsSuccess(()))
+
+  def apply(zuoraRequests: RequestsPUT)(crmId: String, sfContactId: String)(account: AccountId): ClientFailableOp[Unit] = {
+    val request = Request(crmId, sfContactId)
+    val path = s"accounts/${account.value}" // TODO danger - we shoudn't go building urls with string concatenation!
+    zuoraRequests.put[Request, Unit](request, path)
+  }
+
+}

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -19,8 +19,8 @@ class EndToEndTest extends FlatSpec with Matchers {
   it should "accept a request in the format we expect" in {
 
     val expected = ExpectedJsonFormat(
-      statusCode = "404",
-      body = JsStringContainingJson(ExpectedBodyFormat(message = "passed the prereq check")),
+      statusCode = "200",
+      body = JsStringContainingJson(ExpectedBodyFormat(message = "Success")),
       headers = Map("Content-Type" -> "application/json")
     )
 
@@ -118,9 +118,15 @@ object EndToEndTest {
       |    "done": true
       |}""".stripMargin
 
+  val updateAccountRequestBody = """{"crmId":"sfcont","sfContactId__c":"sfacc"}"""
+
+  val updateAccountResponse = HTTPResponse(200, """{"Success": true}""")
+
   val mock = new TestingRawEffects(postResponses = Map(
     POSTRequest("/action/query", accountQueryRequest) -> HTTPResponse(200, accountQueryResponse),
-    POSTRequest("/action/query", contactQueryRequest) -> HTTPResponse(200, contactQueryResponse)
+    POSTRequest("/action/query", contactQueryRequest) -> HTTPResponse(200, contactQueryResponse),
+    POSTRequest("/accounts/2c92c0f9624bbc5f016253e573970b16", updateAccountRequestBody, "PUT") -> updateAccountResponse,
+    POSTRequest("/accounts/2c92c0f8644618e30164652a558c6e20", updateAccountRequestBody, "PUT") -> updateAccountResponse
   ))
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/UpdateAccountSFLinksTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/UpdateAccountSFLinksTest.scala
@@ -1,0 +1,38 @@
+package com.gu.sf_contact_merge
+
+import com.gu.sf_contact_merge.GetZuoraEmailsForAccounts.AccountId
+import com.gu.zuora.fake.FakeRequestsPut
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json._
+import scalaz.\/-
+
+class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
+
+  it should "handle an email and a missing email with a fake querier" in {
+
+    val expectedUrl = """accounts/1234"""
+
+    val response = JsObject(Map("Success" -> JsBoolean(true)))
+    val expectedInput = Json.parse(
+      """
+        |{
+        |    "sfContactId__c": "johnjohn_c",
+        |    "crmId": "crmIdjohn"
+        |    }
+      """.stripMargin
+    )
+
+    val (requestsMade, fake) = FakeRequestsPut(expectedUrl, expectedInput, response)
+    val operation = UpdateAccountSFLinks(fake)_
+    val actual = operation(
+      "crmIdjohn",
+      "johnjohn_c"
+    )(AccountId("1234"))
+
+    actual should be(\/-(()))
+    requestsMade() should be(List(expectedInput))
+
+  }
+
+}
+

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/UpdateAccountSFLinksTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/UpdateAccountSFLinksTest.scala
@@ -22,8 +22,8 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
       """.stripMargin
     )
 
-    val (requestsMade, fake) = FakeRequestsPut(expectedUrl, expectedInput, response)
-    val operation = UpdateAccountSFLinks(fake)_
+    val (requestsMade, fakePutter) = FakeRequestsPut(expectedUrl, expectedInput, response)
+    val operation = UpdateAccountSFLinks(fakePutter)_
     val actual = operation(
       "crmIdjohn",
       "johnjohn_c"

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeRequestsPut.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeRequestsPut.scala
@@ -8,7 +8,7 @@ import scalaz.syntax.std.either._
 object FakeRequestsPut {
   def apply(expectedUrl: String, expectedInput: JsValue, response: JsValue): (() => List[JsValue], RequestsPUT) = {
     var requestsMade: List[JsValue] = List()
-    val requestsPUT = new RequestsPUT() {
+    val fakePutter = new RequestsPUT() {
       override def put[REQ: Writes, RESP: Reads](req: REQ, path: String): ClientFailableOp[RESP] = {
         val actualJson = Json.toJson(req)
         requestsMade = actualJson :: requestsMade
@@ -18,6 +18,6 @@ object FakeRequestsPut {
           -\/(GenericError("not found a fake response for that"))
       }
     }
-    (() => requestsMade, requestsPUT)
+    (() => requestsMade, fakePutter)
   }
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeRequestsPut.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeRequestsPut.scala
@@ -8,7 +8,7 @@ import scalaz.syntax.std.either._
 object FakeRequestsPut {
   def apply(expectedUrl: String, expectedInput: JsValue, response: JsValue): (() => List[JsValue], RequestsPUT) = {
     var requestsMade: List[JsValue] = List()
-    (() => requestsMade, new RequestsPUT() {
+    val requestsPUT = new RequestsPUT() {
       override def put[REQ: Writes, RESP: Reads](req: REQ, path: String): ClientFailableOp[RESP] = {
         val actualJson = Json.toJson(req)
         requestsMade = actualJson :: requestsMade
@@ -17,6 +17,7 @@ object FakeRequestsPut {
         else
           -\/(GenericError("not found a fake response for that"))
       }
-    })
+    }
+    (() => requestsMade, requestsPUT)
   }
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeRequestsPut.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/zuora/fake/FakeRequestsPut.scala
@@ -1,0 +1,22 @@
+package com.gu.zuora.fake
+
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, GenericError, RequestsPUT}
+import play.api.libs.json.{JsValue, Json, Reads, Writes}
+import scalaz.-\/
+import scalaz.syntax.std.either._
+
+object FakeRequestsPut {
+  def apply(expectedUrl: String, expectedInput: JsValue, response: JsValue): (() => List[JsValue], RequestsPUT) = {
+    var requestsMade: List[JsValue] = List()
+    (() => requestsMade, new RequestsPUT() {
+      override def put[REQ: Writes, RESP: Reads](req: REQ, path: String): ClientFailableOp[RESP] = {
+        val actualJson = Json.toJson(req)
+        requestsMade = actualJson :: requestsMade
+        if (path == expectedUrl && actualJson == expectedInput)
+          response.validate[RESP].asEither.disjunction.leftMap(err => GenericError(err.toString))
+        else
+          -\/(GenericError("not found a fake response for that"))
+      }
+    })
+  }
+}

--- a/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
+++ b/lib/effects/src/test/scala/com/gu/effects/TestingRawEffects.scala
@@ -40,7 +40,8 @@ class TestingRawEffects(
         } else {
           val reqBody = body(req.body)
           logger.info(s"HTTP ${req.method} body is $reqBody")
-          postResponses.get(POSTRequest(path, reqBody, req.method)).orElse(responses.get(path)) // use get response
+          val incomingRequest = POSTRequest(path, reqBody, req.method)
+          postResponses.get(incomingRequest).orElse(responses.get(path)) // use get response
         }
       val HTTPResponse(code, response) = presetResponse.getOrElse(
         HTTPResponse(defaultCode, """{"success": true}""")

--- a/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/zuora/RestRequestMaker.scala
@@ -45,7 +45,16 @@ object RestRequestMaker extends Logging {
 
   case class DownloadStream(stream: InputStream, lengthBytes: Long)
 
-  class Requests(headers: Map[String, String], baseUrl: String, getResponse: Request => Response, jsonIsSuccessful: JsValue => ClientFailableOp[Unit]) {
+  trait RequestsPUT {
+    def put[REQ: Writes, RESP: Reads](req: REQ, path: String): ClientFailableOp[RESP]
+  }
+
+  class Requests(
+    headers: Map[String, String],
+    baseUrl: String,
+    getResponse: Request => Response,
+    jsonIsSuccessful: JsValue => ClientFailableOp[Unit]
+  ) extends RequestsPUT {
     // this can be a class and still be cohesive because every single method in the class needs every single value.  so we are effectively partially
     // applying everything with these params
 


### PR DESCRIPTION
This adds the final step to the contact updating.

The overall piece of work is to merge together several SF contacts where they have the same email address etc.  This will help the call centre to find the reader, and also help with retention of data where we still have a need to keep it.

The matching logic happens in a salesforce custom report, then this lambda will take the list of IDs, check that they really do all have the same email address, and then update them all to have the supplied SF contact and account ids.

Note that these IDs are not validated by the lambda, even to check the format.  Not sure if that's classed as a risk?

@pvighi @paulbrown1982 @abhichawla @jacobwinch please comment!