### PR TITLE
remove all the duplicated deps from the handlers

### DIFF
--- a/handlers/cancellation-sf-cases/build.sbt
+++ b/handlers/cancellation-sf-cases/build.sbt
@@ -15,10 +15,5 @@ riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Cancellation SF 
 riffRaffArtifactResources += (file("handlers/cancellation-sf-cases/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  logging,
-  awsS3,
-  playJson,
-  scalatest,
-  jacksonDatabind,
   "com.gu.identity" %% "identity-cookie" % "3.160"
 )

--- a/handlers/catalog-service/build.sbt
+++ b/handlers/catalog-service/build.sbt
@@ -13,12 +13,6 @@ riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Catalog Service"
 riffRaffArtifactResources += (file("handlers/catalog-service/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.265",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
 )
 
 resolvers ++= Seq(

--- a/handlers/digital-subscription-expiry/build.sbt
+++ b/handlers/digital-subscription-expiry/build.sbt
@@ -13,13 +13,6 @@ riffRaffManifestProjectName := "MemSub::Subscriptions::Lambdas::Digital Subscrip
 riffRaffArtifactResources += (file("handlers/digital-subscription-expiry/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.265",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "com.typesafe.play" %% "play-json" % "2.6.9",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "com.gu" %% "content-authorisation-common" % "0.4"
 )
 

--- a/handlers/identity-backfill/build.sbt
+++ b/handlers/identity-backfill/build.sbt
@@ -13,13 +13,5 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Identity Backfill"
 riffRaffArtifactResources += (file("handlers/identity-backfill/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
-  "log4j" % "log4j" % "1.2.17",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "com.typesafe.play" %% "play-json" % "2.6.9",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
   "com.gu" %% "support-internationalisation" % "0.9"
 )

--- a/handlers/identity-retention/build.sbt
+++ b/handlers/identity-retention/build.sbt
@@ -13,12 +13,4 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Identity Retention"
 riffRaffArtifactResources += (file("handlers/identity-retention/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.311",
-  "log4j" % "log4j" % "1.2.17",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "com.typesafe.play" %% "play-json" % "2.6.9",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
 )

--- a/handlers/zuora-retention/build.sbt
+++ b/handlers/zuora-retention/build.sbt
@@ -13,12 +13,6 @@ riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Retention"
 riffRaffArtifactResources += (file("handlers/zuora-retention/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.265",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
@pvighi and I were discussing about how we did a lot of improvements to the latest lambdas, but due to the high level of duplication we often don't go back and apply the same changes elsewhere.
Of course it would be nice to properly reduce that duplication, so I decided to make a start with one that we mentioned.

I tried clean compile assembly and it seemed to work and run all the tests.  Once this branch builds I'll deploy to CODE. and try some.

@paulbrown1982 @jacobwinch 