### PR TITLE
add data types and ids for contributions plan ids

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -84,7 +84,7 @@ object Handler {
       Stage("CODE") -> RecordTypeId("012g0000000DZmNAAW"),
       Stage("DEV") -> RecordTypeId("STANDARD_TEST_DUMMY")
     )
-    mappings.get(stage).toApiGatewayContinueProcessing(ApiGatewayResponse.internalServerError(s"missing config for stage $stage"))
+    mappings.get(stage).toApiGatewayContinueProcessing(ApiGatewayResponse.internalServerError(s"missing standard record type for stage $stage"))
   }
 
   def syncableSFToIdentity(sfRequests: ApiGatewayOp[Requests], stage: Stage)(sFContactId: Types.SFContactId): ApiGatewayOp[Unit] =

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -56,12 +56,12 @@ object Handler extends Logging {
       // todo ideally we should add an id to the fields in zuora so we don't have to hard code
       Stage("PROD") -> ContributionsZuoraIds(
         monthly = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92c0f85ab269be015acd9d014549b7"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85ab2696b015acd9eeb6150ab")
+          productRatePlanId = ProductRatePlanId("2c92a0fc5aacfadd015ad24db4ff5e97"),
+          productRatePlanChargeId = ProductRatePlanChargeId("2c92a0fc5aacfadd015ad250bf2c6d38")
         ),
         annual = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92c0f95e1d5c9c015e38f8c87d19a1"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f95e1d5c9c015e38f8c8ac19a3")
+          productRatePlanId = ProductRatePlanId("2c92a0fc5e1dc084015e37f58c200eea"),
+          productRatePlanChargeId = ProductRatePlanChargeId("2c92a0fc5e1dc084015e37f58c7b0f34")
         )
       ),
       Stage("CODE") -> ContributionsZuoraIds(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -46,4 +46,37 @@ object Handler extends Logging {
 
   }
 
+  case class ProductRatePlanId(value: String) extends AnyVal
+  case class ProductRatePlanChargeId(value: String) extends AnyVal
+  case class PlanAndCharge(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
+  case class ContributionsZuoraIds(monthly: PlanAndCharge, annual: PlanAndCharge)
+
+  def zuoraIdsForStage(stage: Stage): ApiGatewayOp[ContributionsZuoraIds] = {
+    val mappings = Map(
+      // todo ideally we should add an id to the fields in zuora so we don't have to hard code
+      Stage("PROD") -> ContributionsZuoraIds(
+        monthly = PlanAndCharge(
+          productRatePlanId = ProductRatePlanId("2c92c0f85ab269be015acd9d014549b7"),
+          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85ab2696b015acd9eeb6150ab")
+        ),
+        annual = PlanAndCharge(
+          productRatePlanId = ProductRatePlanId("2c92c0f95e1d5c9c015e38f8c87d19a1"),
+          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f95e1d5c9c015e38f8c8ac19a3")
+        )
+      ),
+      Stage("CODE") -> ContributionsZuoraIds(
+        monthly = PlanAndCharge(
+          productRatePlanId = ProductRatePlanId("2c92c0f85ab269be015acd9d014549b7"),
+          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85ab2696b015acd9eeb6150ab")
+        ),
+        annual = PlanAndCharge(
+          productRatePlanId = ProductRatePlanId("2c92c0f95e1d5c9c015e38f8c87d19a1"),
+          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f95e1d5c9c015e38f8c8ac19a3")
+        )
+      )
+      // probably don't need dev as we'd just pass in the actual object in the test
+    )
+    mappings.get(stage).toApiGatewayContinueProcessing(ApiGatewayResponse.internalServerError(s"missing zuora ids for stage $stage"))
+  }
+
 }


### PR DESCRIPTION
We need the plan ids in the checks (to make sure the contributors don't have an existing contribution) and also to subscribe them to the corect plan.  So we are going to work separately on the two parts, but add this shared code first so we can make progress separately.
Since the zuora IDs are not secret, it makes more sense to let the compiler validate the object rather than trying to deal with JSON and messing with config that's only checked at deploy/run time.
@pvighi @david-pepper 