### PR TITLE
add operation to create subscriptions in an existing zuora account

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -75,7 +75,11 @@ object CreateSubscription {
   def apply(
     planAndCharge: PlanAndCharge,
     post: RequestsPost[WireCreateRequest, WireSubscription]
-  )(createSubscription: CreateReq): ClientFailableOp[SubscriptionName] =
-    post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck).map(id => SubscriptionName(id.subscriptionNumber))
+  )(createSubscription: CreateReq): ClientFailableOp[SubscriptionName] = {
+    val maybeWireSubscription = post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck)
+    maybeWireSubscription.map { wireSubscription =>
+      SubscriptionName(wireSubscription.subscriptionNumber)
+    }
+  }
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -1,0 +1,79 @@
+package com.gu.newproduct.api.addsubscription.zuora
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import com.gu.newproduct.api.addsubscription.Handler.PlanAndCharge
+import com.gu.newproduct.api.addsubscription.ZuoraAccountId
+import com.gu.util.zuora.RestRequestMaker._
+import play.api.libs.json.{JsSuccess, Json, Reads}
+
+object CreateSubscription {
+
+  object WireModel {
+
+    implicit val readsResponse: Reads[Unit] = _ => JsSuccess(())
+
+    case class ChargeOverrides(
+      price: Double,
+      productRatePlanChargeId: String
+    )
+    implicit val writesCharge = Json.writes[ChargeOverrides]
+    case class SubscribeToRatePlans(
+      productRatePlanId: String,
+      chargeOverrides: List[ChargeOverrides]
+    )
+    implicit val writesSubscribe = Json.writes[SubscribeToRatePlans]
+    case class WireCreateRequest(
+      //runBilling: Boolean = true,
+      //collect: Boolean = true,
+      accountKey: String,
+      autoRenew: Boolean = true,
+      contractEffectiveDate: String,
+      termType: String = "TERMED",
+      renewalTerm: Int = 12,
+      initialTerm: Int = 12,
+      subscribeToRatePlans: List[SubscribeToRatePlans],
+      AcquisitionCase__c: String
+    )
+    implicit val writesRequest = Json.writes[WireCreateRequest]
+  }
+
+  import WireModel._
+
+  def createRequest(createSubscription: CreateReq, planAndCharge: PlanAndCharge): WireCreateRequest = {
+    import createSubscription._
+    WireCreateRequest(
+      accountKey = accountId.value,
+      contractEffectiveDate = start.format(DateTimeFormatter.ISO_LOCAL_DATE),
+      AcquisitionCase__c = acquisitionCase.value,
+      subscribeToRatePlans = List(
+        SubscribeToRatePlans(
+          productRatePlanId = planAndCharge.productRatePlanId.value,
+          chargeOverrides = List(
+            ChargeOverrides(
+              price = amountMinorUnits.toDouble / 100,
+              productRatePlanChargeId = planAndCharge.productRatePlanChargeId.value
+            )
+          )
+        )
+      )
+    )
+  }
+
+  case class CaseId(value: String) extends AnyVal
+
+  case class CreateReq(
+    accountId: ZuoraAccountId,
+    amountMinorUnits: Int,
+    start: LocalDate,
+    acquisitionCase: CaseId
+  )
+
+  def apply(
+    planAndCharge: PlanAndCharge,
+    post: RequestsPost[WireCreateRequest, Unit]
+  )(createSubscription: CreateReq): ClientFailableOp[Unit] =
+    post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck)
+
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -6,13 +6,14 @@ import java.time.format.DateTimeFormatter
 import com.gu.newproduct.api.addsubscription.Handler.PlanAndCharge
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.util.zuora.RestRequestMaker._
-import play.api.libs.json.{JsSuccess, Json, Reads}
+import play.api.libs.json.{Json, Reads}
 
 object CreateSubscription {
 
   object WireModel {
 
-    implicit val readsResponse: Reads[Unit] = _ => JsSuccess(())
+    case class WireSubscription(subscriptionNumber: String)
+    implicit val readsResponse: Reads[WireSubscription] = Json.reads[WireSubscription]
 
     case class ChargeOverrides(
       price: Double,
@@ -68,10 +69,12 @@ object CreateSubscription {
     acquisitionCase: CaseId
   )
 
+  case class SubscriptionName(value: String) extends AnyVal
+
   def apply(
     planAndCharge: PlanAndCharge,
-    post: RequestsPost[WireCreateRequest, Unit]
-  )(createSubscription: CreateReq): ClientFailableOp[Unit] =
-    post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck)
+    post: RequestsPost[WireCreateRequest, WireSubscription]
+  )(createSubscription: CreateReq): ClientFailableOp[SubscriptionName] =
+    post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck).map(id => SubscriptionName(id.subscriptionNumber))
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -5,7 +5,8 @@ import java.time.format.DateTimeFormatter
 
 import com.gu.newproduct.api.addsubscription.Handler.PlanAndCharge
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
-import com.gu.util.zuora.RestRequestMaker._
+import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
+import com.gu.util.resthttp.Types.ClientFailableOp
 import play.api.libs.json.{Json, Reads}
 
 object CreateSubscription {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -25,8 +25,6 @@ object CreateSubscription {
     )
     implicit val writesSubscribe = Json.writes[SubscribeToRatePlans]
     case class WireCreateRequest(
-      //runBilling: Boolean = true,
-      //collect: Boolean = true,
       accountKey: String,
       autoRenew: Boolean = true,
       contractEffectiveDate: String,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -19,11 +19,12 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
   import ZuoraDevContributions._
 
   it should "create subscription in account" taggedAs EffectsTest in {
+    val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
     val request = CreateSubscription.CreateReq(
       ZuoraAccountId("2c92c0f864a214c30164a8b5accb650b"),
       100,
       LocalDate.now,
-      CaseId("hellocaseId")
+      validCaseIdToAvoidCausingSFErrors
     )
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -29,12 +29,13 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
-      post: RequestsPost[WireCreateRequest, Unit] = zuoraDeps.post[WireCreateRequest, Unit]
+      post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
       res <- CreateSubscription(monthlyIds, post)(request)
     } yield res
-    val expected = ()
-    actual shouldBe \/-(expected)
-    // TODO should check that it was really created
+    withClue(actual) {
+      actual.map(_.value.substring(0, 3)) shouldBe \/-("A-S")
+    }
+    // ideally should check that it was really created with the right fields
   }
 }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -9,7 +9,7 @@ import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel._
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
-import com.gu.util.zuora.RestRequestMaker.RequestsPost
+import com.gu.util.resthttp.RestRequestMaker.RequestsPost
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
@@ -30,7 +30,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
-      res <- CreateSubscription(monthlyIds, post)(request)
+      res <- CreateSubscription(monthlyIds, post)(request).toDisjunction
     } yield res
     withClue(actual) {
       actual.map(_.value.substring(0, 3)) shouldBe \/-("A-S")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -1,0 +1,46 @@
+package com.gu.newproduct.api.addsubscription.zuora
+
+import java.time.LocalDate
+
+import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.newproduct.api.addsubscription.Handler.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
+import com.gu.newproduct.api.addsubscription.ZuoraAccountId
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel._
+import com.gu.test.EffectsTest
+import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.zuora.RestRequestMaker.RequestsPost
+import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+
+class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
+
+  import ZuoraDevContributions._
+
+  it should "create subscription in account" taggedAs EffectsTest in {
+    val request = CreateSubscription.CreateReq(
+      ZuoraAccountId("2c92c0f864a214c30164a8b5accb650b"),
+      100,
+      LocalDate.now,
+      CaseId("hellocaseId")
+    )
+    val actual = for {
+      zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
+      zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
+      post: RequestsPost[WireCreateRequest, Unit] = zuoraDeps.post[WireCreateRequest, Unit]
+      res <- CreateSubscription(monthlyIds, post)(request)
+    } yield res
+    val expected = ()
+    actual shouldBe \/-(expected)
+    // TODO should check that it was really created
+  }
+}
+
+object ZuoraDevContributions {
+
+  val monthlyIds = PlanAndCharge(
+    productRatePlanId = ProductRatePlanId("2c92c0f85a6b134e015a7fcd9f0c7855"),
+    productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85a6b1352015a7fcf35ab397c")
+  )
+}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -6,9 +6,9 @@ import com.gu.newproduct.api.addsubscription.Handler.{PlanAndCharge, ProductRate
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest, WireSubscription}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CaseId, CreateReq, SubscriptionName}
-import com.gu.util.zuora.RestRequestMaker.{GenericError, RequestsPost, WithCheck}
+import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
+import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.{-\/, \/-}
 
 class CreateSubscriptionTest extends FlatSpec with Matchers {
 
@@ -35,8 +35,8 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
     )
     val accF: RequestsPost[WireCreateRequest, WireSubscription] = {
       case (req, "subscriptions", WithCheck) if req == expectedReq =>
-        \/-(WireSubscription("a-s123"))
-      case in => -\/(GenericError(s"bad request: $in"))
+        ClientSuccess(WireSubscription("a-s123"))
+      case in => GenericError(s"bad request: $in")
     }
     val createReq = CreateReq(
       accountId = ZuoraAccountId("zac"),
@@ -45,7 +45,7 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       acquisitionCase = CaseId("casecase")
     )
     val actual = CreateSubscription(ids, accF)(createReq)
-    actual shouldBe \/-(SubscriptionName("a-s123"))
+    actual shouldBe ClientSuccess(SubscriptionName("a-s123"))
   }
 }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -4,8 +4,8 @@ import java.time.LocalDate
 
 import com.gu.newproduct.api.addsubscription.Handler.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest}
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CaseId, CreateReq}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest, WireSubscription}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CaseId, CreateReq, SubscriptionName}
 import com.gu.util.zuora.RestRequestMaker.{GenericError, RequestsPost, WithCheck}
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.{-\/, \/-}
@@ -33,9 +33,9 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
         )
       )
     )
-    val accF: RequestsPost[WireCreateRequest, Unit] = {
+    val accF: RequestsPost[WireCreateRequest, WireSubscription] = {
       case (req, "subscriptions", WithCheck) if req == expectedReq =>
-        \/-(())
+        \/-(WireSubscription("a-s123"))
       case in => -\/(GenericError(s"bad request: $in"))
     }
     val createReq = CreateReq(
@@ -45,7 +45,7 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       acquisitionCase = CaseId("casecase")
     )
     val actual = CreateSubscription(ids, accF)(createReq)
-    actual shouldBe \/-(())
+    actual shouldBe \/-(SubscriptionName("a-s123"))
   }
 }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -1,0 +1,51 @@
+package com.gu.newproduct.api.addsubscription.zuora
+
+import java.time.LocalDate
+
+import com.gu.newproduct.api.addsubscription.Handler.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
+import com.gu.newproduct.api.addsubscription.ZuoraAccountId
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CaseId, CreateReq}
+import com.gu.util.zuora.RestRequestMaker.{GenericError, RequestsPost, WithCheck}
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.{-\/, \/-}
+
+class CreateSubscriptionTest extends FlatSpec with Matchers {
+
+  it should "get account as object" in {
+
+    val ids = PlanAndCharge(
+      productRatePlanId = ProductRatePlanId("hiProductRatePlanId"),
+      productRatePlanChargeId = ProductRatePlanChargeId("hiProductRatePlanChargeId")
+    )
+    val expectedReq = WireCreateRequest(
+      accountKey = "zac",
+      autoRenew = true,
+      contractEffectiveDate = "2018-07-17",
+      termType = "TERMED",
+      renewalTerm = 12,
+      initialTerm = 12,
+      AcquisitionCase__c = "casecase",
+      subscribeToRatePlans = List(
+        SubscribeToRatePlans(
+          productRatePlanId = "hiProductRatePlanId",
+          chargeOverrides = List(ChargeOverrides(price = 1.25, productRatePlanChargeId = "hiProductRatePlanChargeId"))
+        )
+      )
+    )
+    val accF: RequestsPost[WireCreateRequest, Unit] = {
+      case (req, "subscriptions", WithCheck) if req == expectedReq =>
+        \/-(())
+      case in => -\/(GenericError(s"bad request: $in"))
+    }
+    val createReq = CreateReq(
+      accountId = ZuoraAccountId("zac"),
+      amountMinorUnits = 125,
+      start = LocalDate.of(2018, 7, 17),
+      acquisitionCase = CaseId("casecase")
+    )
+    val actual = CreateSubscription(ids, accF)(createReq)
+    actual shouldBe \/-(())
+  }
+}
+

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountSummaryEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountSummaryEffectsTest.scala
@@ -6,9 +6,9 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel._
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount._
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
-import com.gu.util.resthttp.Types.ClientSuccess
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
 
 class GetAccountSummaryEffectsTest extends FlatSpec with Matchers {
 
@@ -24,6 +24,6 @@ class GetAccountSummaryEffectsTest extends FlatSpec with Matchers {
       autoPay = AutoPay(true),
       accountBalanceMinorUnits = AccountBalanceMinorUnits(0)
     )
-    actual shouldBe ClientSuccess(expected)
+    actual shouldBe \/-(expected)
   }
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountTest.scala
@@ -18,7 +18,7 @@ class GetAccountTest extends FlatSpec with Matchers {
     )
     val accF: RequestsGet[ZuoraAccount] = {
       case ("object/account/2c92c0f9624bbc5f016253e573970b16", WithoutCheck) => \/-(acc)
-      case _ => -\/(GenericError("bad request"))
+      case in => -\/(GenericError(s"bad request: $in"))
     }
     val actual = GetAccount(accF)(ZuoraAccountId("2c92c0f9624bbc5f016253e573970b16"))
     actual shouldBe \/-(AccountSummary(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethodStatusEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethodStatusEffectsTest.scala
@@ -5,9 +5,9 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.PaymentMethodId
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethodStatus._
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
-import com.gu.util.resthttp.Types.ClientSuccess
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
 
 class GetPaymentMethodStatusEffectsTest extends FlatSpec with Matchers {
 
@@ -19,7 +19,7 @@ class GetPaymentMethodStatusEffectsTest extends FlatSpec with Matchers {
     } yield {
       res
     }
-    actual shouldBe ClientSuccess(Active)
+    actual shouldBe \/-(Active)
   }
 }
 

--- a/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
+++ b/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
@@ -77,7 +77,7 @@ class RestRequestMakerTest extends AsyncFlatSpec {
 
   it should "return a left[String] if the body of a successful response cannot be de-serialized to that case class" in {
     val either = RestRequestMaker.toResult[BasicAccountInfo](validZuoraNoOtherFields)
-    val result = either.mapResponse(first => GenericError(first.message.split(":")(0)))
+    val result = either.mapFailure(first => GenericError(first.message.split(":")(0)))
     assert(result == GenericError("Error when converting Zuora response to case class"))
   }
 

--- a/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
+++ b/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
@@ -70,17 +70,16 @@ class RestRequestMakerTest extends AsyncFlatSpec {
     response
   }
 
-  def internalServerError(message: String) = GenericError(message)
-
   "convertResponseToCaseClass" should "return a left[String] for an unsuccessful response code" in {
     val response = constructTestResponse(500)
     val either = RestRequestMaker.httpIsSuccessful(response)
-    assert(either == -\/(internalServerError("Request to Zuora was unsuccessful")))
+    assert(either == -\/(GenericError("Request to Zuora was unsuccessful")))
   }
 
   it should "return a left[String] if the body of a successful response cannot be de-serialized to that case class" in {
     val either = RestRequestMaker.toResult[BasicAccountInfo](validZuoraNoOtherFields)
-    assert(either == -\/(internalServerError("Error when converting Zuora response to case class")))
+    val result = either.leftMap(first => GenericError(first.message.split(":")(0)))
+    assert(result == -\/(GenericError("Error when converting Zuora response to case class")))
   }
 
   it should "return a right[T] if the body of a successful response deserializes to T" in {

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraQuery.scala
@@ -1,6 +1,6 @@
 package com.gu.util.zuora
 
-import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests}
+import com.gu.util.zuora.RestRequestMaker.{ClientFailableOp, Requests, WithoutCheck}
 import com.gu.util.zuora.SafeQueryBuilder.SafeQuery
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -34,7 +34,7 @@ object ZuoraQuery {
   // in order to allow partial application with unapplied type parameter, we need to use a trait
   def apply(requests: Requests): ZuoraQuerier = new ZuoraQuerier {
     def apply[QUERYRECORD: Reads](query: SafeQuery): ClientFailableOp[QueryResult[QUERYRECORD]] =
-      requests.post(query, s"action/query", true): ClientFailableOp[QueryResult[QUERYRECORD]]
+      requests.post(query, s"action/query", WithoutCheck): ClientFailableOp[QueryResult[QUERYRECORD]]
   }
 
   trait ZuoraQuerier {

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -28,7 +28,10 @@ object ZuoraRestRequestMaker extends Logging {
         ().right
       case JsSuccess(ZuoraErrorResponse(reasons), _) => {
         logger.error(s"Zuora rejected our call $bodyAsJson")
-        if (reasons.exists(_.code.toString.endsWith("40"))) NotFound("Received a 'not found' response from Zuora").left else GenericError("Received a failure result from Zuora").left
+        if (reasons.exists(_.code.toString.endsWith("40")))
+          NotFound("Received a 'not found' response from Zuora").left
+        else
+          GenericError(s"Received a failure result from Zuora: $reasons").left
 
       }
       case error: JsError => {

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -65,7 +65,7 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
 
   it should "return a left[String] if the body of a successful http response has a zuora failed in it" in {
     val either = ZuoraRestRequestMaker.zuoraIsSuccessful(validFailedUpdateSubscriptionResult)
-    val result = either.mapResponse(first => GenericError(first.message.split(":")(0)))
+    val result = either.mapFailure(first => GenericError(first.message.split(":")(0)))
     assert(result == GenericError("Received a failure result from Zuora"))
   }
 

--- a/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
+++ b/lib/zuora/src/test/scala/com/gu/util/ZuoraRestServiceTest.scala
@@ -59,16 +59,15 @@ class ZuoraRestServiceTest extends AsyncFlatSpec {
     response
   }
 
-  def internalServerError(message: String) = GenericError(message)
-
   it should "return a left[String] if the body of a successful response cannot be de-serialized with a zuora success response" in {
     val either = ZuoraRestRequestMaker.zuoraIsSuccessful(dummyJson)
-    assert(either == -\/(internalServerError("Error when reading common fields from zuora")))
+    assert(either == -\/(GenericError("Error when reading common fields from zuora")))
   }
 
   it should "return a left[String] if the body of a successful http response has a zuora failed in it" in {
     val either = ZuoraRestRequestMaker.zuoraIsSuccessful(validFailedUpdateSubscriptionResult)
-    assert(either == -\/(internalServerError("Received a failure result from Zuora")))
+    val result = either.leftMap(first => GenericError(first.message.split(":")(0)))
+    assert(result == -\/(GenericError("Received a failure result from Zuora")))
   }
 
   case class BasicAccountInfo(id: String, balance: Double, defaultPaymentMethod: PaymentMethodId)


### PR DESCRIPTION
This adds a new operation to call zuora with a new subscription.  This gets the appropriate product ids and account ids and can make the right subscription.
@pvighi @david-pepper 