### PR TITLE
accept a cancellationCase when creating a new contribution

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityUser.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityUser.scala
@@ -17,8 +17,8 @@ object IdentityCookieToIdentityUser extends Logging {
     headersOption: Option[Map[String, String]]
   ): ApiGatewayOp[IdentityUser] =
     for {
-      headers <- headersOption.toApiGatewayContinueProcessing(badRequest, "no headers")
-      cookieHeader <- headers.get("Cookie").toApiGatewayContinueProcessing(badRequest, "no cookie")
+      headers <- headersOption.toApiGatewayContinueProcessing(badRequest("no headers"))
+      cookieHeader <- headers.get("Cookie").toApiGatewayContinueProcessing(badRequest("no cookie"))
       scGuU <- extractCookieHeaderValue(cookieHeader, "SC_GU_U")
       guU <- extractCookieHeaderValue(cookieHeader, "GU_U")
       identityUser <- cookiesToIdentityUser(scGuU, guU).toApiGatewayContinueProcessing(unauthorized)
@@ -30,7 +30,7 @@ object IdentityCookieToIdentityUser extends Logging {
       keyValue <- keyValues.find(keyValue => keyValue.trim startsWith (specificCookieName + '='))
     } yield keyValue.substring(keyValue.indexOf('=') + 1)
 
-    specificCookieValueOption.toApiGatewayContinueProcessing(badRequest, specificCookieName + " cookie is missing")
+    specificCookieValueOption.toApiGatewayContinueProcessing(badRequest(specificCookieName + " cookie is missing"))
   }
 
   def defaultCookiesToIdentityUser(isProd: Boolean)(scGuU: String, guU: String) = {

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
@@ -34,7 +34,7 @@ object DigitalSubscriptionExpirySteps extends Logging {
 
     def steps(apiGatewayRequest: ApiGatewayRequest): ApiResponse = {
       (for {
-        expiryRequest <- apiGatewayRequest.bodyAsCaseClass[DigitalSubscriptionExpiryRequest](DigitalSubscriptionApiResponses.badRequest)
+        expiryRequest <- apiGatewayRequest.bodyAsCaseClass[DigitalSubscriptionExpiryRequest](Some(DigitalSubscriptionApiResponses.badRequest))
         _ <- getEmergencyTokenExpiry(expiryRequest.subscriberId)
         subscriptionId = SubscriptionId(expiryRequest.subscriberId.trim.dropWhile(_ == '0'))
         subscriptionResult <- getSubscription(subscriptionId)

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
@@ -34,7 +34,7 @@ object IdentityRetentionSteps extends Logging {
   def extractIdentityId(queryStringParams: UrlParams): ApiGatewayOp[IdentityId] = {
     validate(queryStringParams.identityId) match {
       case Some(id) => ContinueProcessing(id)
-      case None => ReturnWithResponse(ApiGatewayResponse.badRequest)
+      case None => ReturnWithResponse(ApiGatewayResponse.badRequest("no identity id"))
     }
   }
 

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionStepsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionStepsTest.scala
@@ -16,7 +16,7 @@ class IdentityRetentionStepsTest extends FlatSpec with Matchers {
 
   it should "return a bad response if the query string value contains a ZOQL injection attempt" in {
     val result = IdentityRetentionSteps.extractIdentityId(UrlParams(identityId = "123 or status='Active"))
-    val expected = -\/(ApiGatewayResponse.badRequest)
+    val expected = -\/(ApiGatewayResponse.badRequest("no identity id"))
     result.toDisjunction should be(expected)
   }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -2,6 +2,7 @@ package com.gu.newproduct.api.addsubscription
 
 import java.time.LocalDate
 
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
 import scala.util.{Failure, Success, Try}
@@ -14,6 +15,7 @@ case class AddSubscriptionRequest(
   acquisitionSource: String,
   createdByCSR: String,
   amountMinorUnits: Int,
+  cancellationCase: CaseId
 )
 
 object AddSubscriptionRequest {
@@ -24,6 +26,7 @@ object AddSubscriptionRequest {
     acquisitionSource: String,
     createdByCSR: String,
     amountMinorUnits: Int,
+    cancellationCase: String
   ) {
     def toAddSubscriptionRequest = {
       val maybeParsedRequest = Try(LocalDate.parse(startDate)).map { parsedStartDate =>
@@ -32,7 +35,8 @@ object AddSubscriptionRequest {
           startDate = parsedStartDate,
           acquisitionSource = this.acquisitionSource,
           createdByCSR = this.createdByCSR,
-          amountMinorUnits = this.amountMinorUnits
+          amountMinorUnits = this.amountMinorUnits,
+          CaseId(cancellationCase)
         )
       }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -2,7 +2,6 @@ package com.gu.newproduct.api.addsubscription
 
 import java.time.LocalDate
 
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
 import scala.util.{Failure, Success, Try}
@@ -17,6 +16,8 @@ case class AddSubscriptionRequest(
   amountMinorUnits: Int,
   cancellationCase: CaseId
 )
+
+case class CaseId(value: String) extends AnyVal
 
 object AddSubscriptionRequest {
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 import com.gu.newproduct.api.addsubscription.Handler.PlanAndCharge
-import com.gu.newproduct.api.addsubscription.ZuoraAccountId
+import com.gu.newproduct.api.addsubscription.{CaseId, ZuoraAccountId}
 import com.gu.util.zuora.RestRequestMaker._
 import play.api.libs.json.{Json, Reads}
 
@@ -59,8 +59,6 @@ object CreateSubscription {
       )
     )
   }
-
-  case class CaseId(value: String) extends AnyVal
 
   case class CreateReq(
     accountId: ZuoraAccountId,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
@@ -2,6 +2,7 @@ package com.gu.newproduct.api.addsubscription
 
 import java.time.LocalDate
 
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsError, Json}
 
@@ -13,7 +14,8 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
         |   "startDate":"2018-07-11",
         |   "acquisitionSource":"CSR",
         |   "createdByCSR":"CSRName",
-        |   "amountMinorUnits": 123
+        |   "amountMinorUnits": 123,
+        |   "cancellationCase": "5006E000005b5cf"
         |}
       """.stripMargin
 
@@ -24,7 +26,8 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
       startDate = LocalDate.of(2018, 7, 11),
       acquisitionSource = "CSR",
       createdByCSR = "CSRName",
-      amountMinorUnits = 123
+      amountMinorUnits = 123,
+      cancellationCase = CaseId("5006E000005b5cf")
     )
   }
 
@@ -37,7 +40,8 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
         |   "productRatePlanChargeId":"rateplanChargeId",
         |   "acquisitionSource":"CSR",
         |   "createdByCSR":"CSRName",
-        |   "amountMinorUnits": 220
+        |   "amountMinorUnits": 220,
+        |   "cancellationCase": "5006E000005b5cf"
         |}
       """.stripMargin
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
@@ -2,7 +2,6 @@ package com.gu.newproduct.api.addsubscription
 
 import java.time.LocalDate
 
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsError, Json}
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -4,8 +4,7 @@ import java.time.LocalDate
 
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.newproduct.api.addsubscription.Handler.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
-import com.gu.newproduct.api.addsubscription.ZuoraAccountId
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.CaseId
+import com.gu.newproduct.api.addsubscription.{CaseId, ZuoraAccountId}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel._
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -3,9 +3,9 @@ package com.gu.newproduct.api.addsubscription.zuora
 import java.time.LocalDate
 
 import com.gu.newproduct.api.addsubscription.Handler.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
-import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest, WireSubscription}
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CaseId, CreateReq, SubscriptionName}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CreateReq, SubscriptionName}
+import com.gu.newproduct.api.addsubscription.{CaseId, ZuoraAccountId}
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
 import org.scalatest.{FlatSpec, Matchers}

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -63,7 +63,7 @@ object Handler {
     (for {
       input <- req.bodyAsCaseClass[WireSfContactRequest]()
       someAccountIds = input.billingAccountZuoraIds.map(AccountId.apply)
-      accountIds <- MaybeNonEmptyList(someAccountIds).toApiGatewayContinueProcessing(ApiGatewayResponse.badRequest)
+      accountIds <- MaybeNonEmptyList(someAccountIds).toApiGatewayContinueProcessing(ApiGatewayResponse.badRequest("no account ids supplied"))
       emailAddresses <- getZuoraEmails(accountIds).toApiGatewayOp("get zuora emails")
       _ <- AssertSameEmails(emailAddresses)
       updateAccount = updateAccountSFLinks(input.fullContactId, input.accountId)

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -64,9 +64,9 @@ object ApiGatewayResponse extends Logging {
     toJsonBody(ResponseBody(s"Processing is not required: $reason"))
   )
 
-  val badRequest = ApiResponse(
+  def badRequest(reason: String) = ApiResponse(
     "400",
-    toJsonBody(ResponseBody("Failure to parse JSON successfully"))
+    toJsonBody(ResponseBody(s"Failure to parse JSON successfully: $reason"))
   )
 
   val unauthorized = ApiResponse(

--- a/lib/handler/src/main/scala/com/gu/util/config/LoadConfigModule.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/LoadConfigModule.scala
@@ -51,7 +51,7 @@ object LoadConfigModule extends Logging {
   def toDisjunction[A](t: Try[A]) = t match {
     case Success(s) => \/-(s)
     case Failure(e) =>
-      logger.error("error parsing json", e)
+      logger.error(s"error parsing json: ${e.toString}")
       -\/(ConfigFailure(e.toString))
   }
 

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -106,25 +106,6 @@ object Types extends Logging {
         case None => ReturnWithResponse(NoneResponse)
       }
 
-    def toApiGatewayContinueProcessing(NoneResponse: ApiResponse, debugMessage: String) =
-      theOption match {
-        case Some(value) => ContinueProcessing(value)
-        case None => {
-          logger.debug(debugMessage)
-          ReturnWithResponse(NoneResponse)
-        }
-      }
-
-  }
-
-  implicit class OptionApiResponseOps(theOption: Option[ApiResponse]) {
-
-    def toApiGatewayReturnResponse[A](NoneContinue: A = ()): ApiGatewayOp[A] =
-      theOption match {
-        case Some(value) => ReturnWithResponse(value)
-        case None => ContinueProcessing(NoneContinue)
-      }
-
   }
 
   implicit class BooleanOps[A](is: Boolean) {

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -2,7 +2,7 @@ package com.gu.util.reader
 
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse
-import com.gu.util.apigateway.ApiGatewayResponse.{badRequest, internalServerError}
+import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import play.api.libs.json.{JsError, JsResult, JsSuccess}
@@ -76,12 +76,12 @@ object Types extends Logging {
   // handy classes for converting things
   implicit class JsResultOps[A](jsResult: JsResult[A]) {
 
-    def toApiGatewayOp(response: ApiResponse = badRequest): ApiGatewayOp[A] = {
+    def toApiGatewayOp(): ApiGatewayOp[A] = {
       jsResult match {
         case JsSuccess(value, _) => ContinueProcessing(value)
         case JsError(error) => {
           logger.error(s"Error when deserializing JSON from API Gateway: $error")
-          ReturnWithResponse(response)
+          ReturnWithResponse(ApiGatewayResponse.internalServerError("Error when deserializing JSON from API Gateway"))
         }
       }
     }

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
@@ -1,9 +1,10 @@
 package com.gu.util.apigateway
 
-import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import play.api.libs.json.{JsResult, JsSuccess, Json}
+import scalaz.-\/
 
 class ApiGatewayHandlerReadsTest extends FlatSpec {
 
@@ -113,7 +114,9 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
       "wrongParamName" -> "someValue"
     ))
     val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
-    noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams](ApiGatewayResponse.badRequest) shouldBe ReturnWithResponse(ApiGatewayResponse.badRequest)
+    val actual = noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams]()
+    val expected = -\/("400")
+    actual.toDisjunction.leftMap(_.statusCode) shouldBe expected
   }
 
   it should "deserialise ApiGatewayHandlerParams with no query string" in {


### PR DESCRIPTION
This adds the cancellationCase to the request object for new contribution.
I also added some code to report better validation errors when the input is incorrect, together with the 400 bad request response.

This PR is based on the branch of the previous one https://github.com/guardian/zuora-auto-cancel/pull/146 , so it will need to be reviewed once that is merged to get the actual diff.  Everything is mixed up at the moment.