### PR TITLE
Connect the prereq check to new product handler api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -14,7 +14,7 @@ case class AddSubscriptionRequest(
   acquisitionSource: String,
   createdByCSR: String,
   amountMinorUnits: Int,
-  cancellationCase: CaseId
+  acquisitionCase: CaseId
 )
 
 case class CaseId(value: String) extends AnyVal
@@ -27,7 +27,7 @@ object AddSubscriptionRequest {
     acquisitionSource: String,
     createdByCSR: String,
     amountMinorUnits: Int,
-    cancellationCase: String
+    acquisitionCase: String
   ) {
     def toAddSubscriptionRequest = {
       val maybeParsedRequest = Try(LocalDate.parse(startDate)).map { parsedStartDate =>
@@ -37,7 +37,7 @@ object AddSubscriptionRequest {
           acquisitionSource = this.acquisitionSource,
           createdByCSR = this.createdByCSR,
           amountMinorUnits = this.amountMinorUnits,
-          CaseId(cancellationCase)
+          CaseId(acquisitionCase)
         )
       }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -4,7 +4,7 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
+import com.gu.newproduct.api.addsubscription.zuora.{CreateSubscription, GetAccount, GetAccountSubscriptions, GetPaymentMethodStatus}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CreateReq, SubscriptionName}
 import com.gu.util.Logging
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
@@ -18,6 +18,10 @@ import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientFailableOp
 import TypeConvert._
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{WireCreateRequest, WireSubscription}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
+import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethodStatus.PaymentMethodWire
+import com.gu.util.resthttp.RestRequestMaker
 
 object Handler extends Logging {
 
@@ -31,16 +35,19 @@ object Handler extends Logging {
 
 object Steps {
 
-  def addSubscriptionSteps(createMonthlyContribution: CreateReq => ClientFailableOp[SubscriptionName])(apiGatewayRequest: ApiGatewayRequest): ApiResponse = {
+  def addSubscriptionSteps(
+    prerequesiteCheck: ZuoraAccountId => ApiGatewayOp[Unit],
+    createMonthlyContribution: CreateReq => ClientFailableOp[SubscriptionName]
+  )(apiGatewayRequest: ApiGatewayRequest): ApiResponse = {
     (for {
       request <- apiGatewayRequest.bodyAsCaseClass[AddSubscriptionRequest]().withLogging("parsed request")
-      // validation goes here
+      _ <- prerequesiteCheck(request.zuoraAccountId)
       req = CreateReq(request.zuoraAccountId, request.amountMinorUnits, request.startDate, request.cancellationCase)
       subscriptionName <- createMonthlyContribution(req).toApiGatewayOp("create monthly contribution")
     } yield ApiGatewayResponse(body = AddedSubscription(subscriptionName.value), statusCode = "200")).apiResponse
   }
 
-  def runWithEffects(response: Request => Response, stage: Stage, fetchString: StringFromS3): ApiGatewayOp[(TrustedApiConfig, Operation)] = {
+  def runWithEffects(response: Request => Response, stage: Stage, fetchString: StringFromS3): ApiGatewayOp[(TrustedApiConfig, Operation)] =
     for {
       zuoraIds <- ZuoraIds.zuoraIdsForStage(stage)
       loadConfig = LoadConfigModule(stage, fetchString)
@@ -48,12 +55,23 @@ object Steps {
       trustedApiConfig <- loadConfig[TrustedApiConfig].toApiGatewayOp("load trusted api config")
       zuoraClient = ZuoraRestRequestMaker(response, zuoraConfig)
       createMonthlyContribution = CreateSubscription(zuoraIds.monthly, zuoraClient.post[WireCreateRequest, WireSubscription]) _
+      prerequesiteCheck = wiredPrereqCheck(zuoraIds, zuoraClient)
       configuredOp = Operation.noHealthcheck(
-        steps = addSubscriptionSteps(createMonthlyContribution),
+        steps = addSubscriptionSteps(prerequesiteCheck, createMonthlyContribution),
         shouldAuthenticate = false
       )
     } yield (trustedApiConfig, configuredOp)
-  }
+
+  def wiredPrereqCheck(
+    zuoraIds: ZuoraIds.ContributionsZuoraIds,
+    zuoraClient: RestRequestMaker.Requests
+  ): ZuoraAccountId => ApiGatewayOp[Unit] =
+    PrerequesiteCheck(
+      GetAccount(zuoraClient.get[ZuoraAccount]),
+      GetPaymentMethodStatus(zuoraClient.get[PaymentMethodWire]),
+      GetAccountSubscriptions(zuoraClient.get[ZuoraSubscriptionsResponse]),
+      List(zuoraIds.monthly.productRatePlanId, zuoraIds.annual.productRatePlanId)
+    )
 
 }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -42,7 +42,7 @@ object Steps {
     (for {
       request <- apiGatewayRequest.bodyAsCaseClass[AddSubscriptionRequest]().withLogging("parsed request")
       _ <- prerequesiteCheck(request.zuoraAccountId)
-      req = CreateReq(request.zuoraAccountId, request.amountMinorUnits, request.startDate, request.cancellationCase)
+      req = CreateReq(request.zuoraAccountId, request.amountMinorUnits, request.startDate, request.acquisitionCase)
       subscriptionName <- createMonthlyContribution(req).toApiGatewayOp("create monthly contribution")
     } yield ApiGatewayResponse(body = AddedSubscription(subscriptionName.value), statusCode = "200")).apiResponse
   }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
@@ -14,7 +14,7 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
         |   "acquisitionSource":"CSR",
         |   "createdByCSR":"CSRName",
         |   "amountMinorUnits": 123,
-        |   "cancellationCase": "5006E000005b5cf"
+        |   "acquisitionCase": "5006E000005b5cf"
         |}
       """.stripMargin
 
@@ -26,7 +26,7 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
       acquisitionSource = "CSR",
       createdByCSR = "CSRName",
       amountMinorUnits = 123,
-      cancellationCase = CaseId("5006E000005b5cf")
+      acquisitionCase = CaseId("5006E000005b5cf")
     )
   }
 
@@ -40,7 +40,7 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
         |   "acquisitionSource":"CSR",
         |   "createdByCSR":"CSRName",
         |   "amountMinorUnits": 220,
-        |   "cancellationCase": "5006E000005b5cf"
+        |   "acquisitionCase": "5006E000005b5cf"
         |}
       """.stripMargin
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
@@ -29,7 +29,7 @@ class StepsTest extends FlatSpec with Matchers {
       else ReturnWithResponse(ApiGatewayResponse.internalServerError(s"whoops: $accountId was wrong for prereq check"))
 
     val requestInput = JsObject(Map(
-      "cancellationCase" -> JsString("case"),
+      "acquisitionCase" -> JsString("case"),
       "amountMinorUnits" -> JsNumber(123),
       "startDate" -> JsString("2018-07-18"),
       "zuoraAccountId" -> JsString("acccc"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
@@ -9,7 +9,7 @@ import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.reader.Types.ApiGatewayOp
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.resthttp.Types
-import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
+import com.gu.util.resthttp.Types.ClientSuccess
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json._
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
@@ -20,9 +20,10 @@ class StepsTest extends FlatSpec with Matchers {
 
     val expectedIn = CreateReq(ZuoraAccountId("acccc"), 123, LocalDate.of(2018, 7, 18), CaseId("case"))
 
-    def fakeCreate(in: CreateSubscription.CreateReq): Types.ClientFailableOp[CreateSubscription.SubscriptionName] =
-      if (in == expectedIn) ClientSuccess(SubscriptionName("well done"))
-      else GenericError(s"whoops: $in should have been $expectedIn")
+    def fakeCreate(in: CreateSubscription.CreateReq): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
+      in shouldBe expectedIn
+      ClientSuccess(SubscriptionName("well done"))
+    }
 
     def fakeCheck(accountId: ZuoraAccountId): ApiGatewayOp[Unit] =
       if (accountId.value == "acccc") ContinueProcessing(())


### PR DESCRIPTION
This just wires in the prereq checking code into the main handler and adds it to the steps test.

We don't have a specific health check and it's not called from runscope yet.  This needs fixing at some point.

@pvighi @david-pepper 

I have also updated cancellationCase to acquisitionCase as I accidentally called it the wrong thing previously