### PR TITLE
tech debt: separate "Auth by url param" from "API gateway handler"

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -36,7 +36,7 @@ object Handler extends Logging {
   case class SfRequests(normal: LazySalesforceAuthenticatedReqMaker, test: LazySalesforceAuthenticatedReqMaker)
 
   def raiseCase(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffectsDontTestAtThisLevel(
+    runForLegacyTestsSeeTestingMd(
       IdentityCookieToIdentityUser.defaultCookiesToIdentityUser(RawEffects.stage.isProd),
       RaiseCase.steps,
       RawEffects.response,
@@ -102,7 +102,7 @@ object Handler extends Logging {
   implicit val pathParamReads = Json.reads[CasePathParams]
 
   def updateCase(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffectsDontTestAtThisLevel(
+    runForLegacyTestsSeeTestingMd(
       IdentityCookieToIdentityUser.defaultCookiesToIdentityUser(RawEffects.stage.isProd),
       UpdateCase.steps,
       RawEffects.response,
@@ -125,7 +125,7 @@ object Handler extends Logging {
 
   }
 
-  def runWithEffectsDontTestAtThisLevel(
+  def runForLegacyTestsSeeTestingMd(
     cookieValuesToIdentityUser: CookieValuesToIdentityUser,
     steps: Steps,
     response: Request => Response,

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -36,7 +36,7 @@ object Handler extends Logging {
   case class SfRequests(normal: LazySalesforceAuthenticatedReqMaker, test: LazySalesforceAuthenticatedReqMaker)
 
   def raiseCase(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffects(
+    runWithEffectsDontTestAtThisLevel(
       IdentityCookieToIdentityUser.defaultCookiesToIdentityUser(RawEffects.stage.isProd),
       RaiseCase.steps,
       RawEffects.response,
@@ -102,7 +102,7 @@ object Handler extends Logging {
   implicit val pathParamReads = Json.reads[CasePathParams]
 
   def updateCase(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffects(
+    runWithEffectsDontTestAtThisLevel(
       IdentityCookieToIdentityUser.defaultCookiesToIdentityUser(RawEffects.stage.isProd),
       UpdateCase.steps,
       RawEffects.response,
@@ -125,15 +125,23 @@ object Handler extends Logging {
 
   }
 
-  def runWithEffects(
+  def runWithEffectsDontTestAtThisLevel(
     cookieValuesToIdentityUser: CookieValuesToIdentityUser,
     steps: Steps,
     response: Request => Response,
     stage: Stage,
     fetchString: StringFromS3,
     lambdaIO: LambdaIO
-  ) = {
+  ) =
+    ApiGatewayHandler(lambdaIO)(operationForEffects(cookieValuesToIdentityUser, steps, response, stage, fetchString))
 
+  def operationForEffects(
+    cookieValuesToIdentityUser: CookieValuesToIdentityUser,
+    steps: Steps,
+    response: Request => Response,
+    stage: Stage,
+    fetchString: StringFromS3
+  ): ApiGatewayOp[Operation] = {
     val loadConfig = LoadConfigModule(stage, fetchString)
 
     def healthcheckSteps(sfRequests: SfRequests) = () =>
@@ -142,45 +150,39 @@ object Handler extends Logging {
         _ <- sfRequests.test()
       } yield ApiGatewayResponse.successfulExecution).apiResponse
 
-    def operation(identityTestUsersConfig: IdentityTestUserConfig): Operation = {
-
-      val sfRequestsNormal: LazySalesforceAuthenticatedReqMaker = () =>
-        for {
-          config <- loadNormalSfConfig.toApiGatewayOp("load 'normal' SF config")
-          sfRequests <- SalesforceAuthenticate(response, config)
-        } yield sfRequests
-
-      val sfRequestsTest: LazySalesforceAuthenticatedReqMaker = () =>
-        for {
-          config <- loadTestSfConfig.toApiGatewayOp("load 'test' SF config")
-          sfRequests <- SalesforceAuthenticate(response, config)
-        } yield sfRequests
-
-      def sfBackendForIdentityCookieHeader(headers: HeadersOption): IdentityAndSfRequestsApiGatewayOp = {
-        for {
-          identityUser <- IdentityCookieToIdentityUser(cookieValuesToIdentityUser)(headers)
-          sfRequests <- if (IsIdentityTestUser(identityTestUsersConfig)(identityUser)) sfRequestsTest() else sfRequestsNormal()
-        } yield IdentityAndSfRequests(identityUser, sfRequests)
-      }
-
-      Operation(
-        steps(sfBackendForIdentityCookieHeader),
-        healthcheckSteps(SfRequests(sfRequestsNormal, sfRequestsTest)),
-        shouldAuthenticate = false //TODO this could be removed when 'trustedApiConfig' is an Option
-      )
-
-    }
-
     def loadNormalSfConfig = loadConfig[SFAuthConfig](SFAuthConfig.location, SFAuthConfig.reads)
+
     def loadTestSfConfig = loadConfig[SFAuthConfig](SFAuthTestConfig.location, SFAuthTestConfig.reads)
 
-    ApiGatewayHandler(lambdaIO)(for {
+    for {
       identityTestUsersConfig <- loadConfig[IdentityTestUserConfig].toApiGatewayOp("load identity 'test-users' config")
-      //TODO line below can be removed since 'shouldAuthenticate = false'
-      trustedApiConfig <- loadConfig[TrustedApiConfig].toApiGatewayOp("load trusted api config")
-      configuredOp = operation(identityTestUsersConfig)
-    } yield (trustedApiConfig, configuredOp))
+      configuredOp = {
 
+        val sfRequestsNormal: LazySalesforceAuthenticatedReqMaker = () =>
+          for {
+            config <- loadNormalSfConfig.toApiGatewayOp("load 'normal' SF config")
+            sfRequests <- SalesforceAuthenticate(response, config)
+          } yield sfRequests
+
+        val sfRequestsTest: LazySalesforceAuthenticatedReqMaker = () =>
+          for {
+            config <- loadTestSfConfig.toApiGatewayOp("load 'test' SF config")
+            sfRequests <- SalesforceAuthenticate(response, config)
+          } yield sfRequests
+
+        def sfBackendForIdentityCookieHeader(headers: HeadersOption): IdentityAndSfRequestsApiGatewayOp = {
+          for {
+            identityUser <- IdentityCookieToIdentityUser(cookieValuesToIdentityUser)(headers)
+            sfRequests <- if (IsIdentityTestUser(identityTestUsersConfig)(identityUser)) sfRequestsTest() else sfRequestsNormal()
+          } yield IdentityAndSfRequests(identityUser, sfRequests)
+        }
+
+        Operation(
+          steps(sfBackendForIdentityCookieHeader),
+          healthcheckSteps(SfRequests(sfRequestsNormal, sfRequestsTest))
+        )
+
+      }
+    } yield configuredOp
   }
-
 }

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -73,7 +73,7 @@ object Runner extends Matchers {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffects(
+    Handler.runWithEffectsDontTestAtThisLevel(
       fakeCookiesToIdentityUser,
       steps,
       RawEffects.response,

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -73,7 +73,7 @@ object Runner extends Matchers {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffectsDontTestAtThisLevel(
+    Handler.runForLegacyTestsSeeTestingMd(
       fakeCookiesToIdentityUser,
       steps,
       RawEffects.response,

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpirySteps.scala
@@ -49,7 +49,7 @@ object DigitalSubscriptionExpirySteps extends Logging {
       } yield subscriptionEndDate).apiResponse
 
     }
-    Operation.noHealthcheck(steps, false)
+    Operation.noHealthcheck(steps)
 
   }
 

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -22,37 +22,41 @@ object Handler extends Logging {
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, RawEffects.now, LambdaIO(inputStream, outputStream, context))
+    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, RawEffects.now, LambdaIO(inputStream, outputStream, context))
 
-  def runWithEffects(
+  def runWithEffectsDontTestAtThisLevel(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,
     now: () => LocalDateTime,
     lambdaIO: LambdaIO
-  ): Unit = {
-    def operation =
-      (zuoraRestConfig: ZuoraRestConfig, emergencyTokensConfig: EmergencyTokensConfig) => {
+  ): Unit =
+    ApiGatewayHandler(lambdaIO)(operationForEffects(stage, fetchString, response, now))
 
-        val emergencyTokens = EmergencyTokens(emergencyTokensConfig)
-        val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
-        val today = () => now().toLocalDate
-        DigitalSubscriptionExpirySteps(
-          getEmergencyTokenExpiry = GetTokenExpiry(emergencyTokens, today),
-          getSubscription = GetSubscription(zuoraRequests),
-          setActivationDate = (SetActivationDate(zuoraRequests, now) _).andThen(_.toApiGatewayOp(s"zuora SetActivationDate fail")),
-          getAccountSummary = (GetAccountSummary(zuoraRequests) _).andThen(_.toApiGatewayOp(s"zuora GetAccountSummary fail")),
-          getSubscriptionExpiry = GetSubscriptionExpiry(today),
-          skipActivationDateUpdate = SkipActivationDateUpdate.apply
-        )
-      }
+  def operationForEffects(
+    stage: Stage,
+    fetchString: StringFromS3,
+    response: Request => Response,
+    now: () => LocalDateTime
+  ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
     val loadConfig = LoadConfigModule(stage, fetchString)
-    ApiGatewayHandler(lambdaIO)(for {
-      zuoraConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      emergencyTokensConf <- loadConfig[EmergencyTokensConfig].toApiGatewayOp("load emergency tokens config")
-      trustedApiConf <- loadConfig[TrustedApiConfig].toApiGatewayOp("load trusted api config")
-      configuredOp = operation(zuoraConfig, emergencyTokensConf)
-    } yield (trustedApiConf, configuredOp))
+    for {
+      zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      emergencyTokensConfig <- loadConfig[EmergencyTokensConfig].toApiGatewayOp("load emergency tokens config")
+    } yield {
+      val emergencyTokens = EmergencyTokens(emergencyTokensConfig)
+      val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
+      val today = () => now().toLocalDate
+      DigitalSubscriptionExpirySteps(
+        getEmergencyTokenExpiry = GetTokenExpiry(emergencyTokens, today),
+        getSubscription = GetSubscription(zuoraRequests),
+        setActivationDate = (SetActivationDate(zuoraRequests, now) _).andThen(_.toApiGatewayOp(s"zuora SetActivationDate fail")),
+        getAccountSummary = (GetAccountSummary(zuoraRequests) _).andThen(_.toApiGatewayOp(s"zuora GetAccountSummary fail")),
+        getSubscriptionExpiry = GetSubscriptionExpiry(today),
+        skipActivationDateUpdate = SkipActivationDateUpdate.apply
+      )
+    }
   }
+
 }
 

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/Handler.scala
@@ -22,9 +22,9 @@ object Handler extends Logging {
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, RawEffects.now, LambdaIO(inputStream, outputStream, context))
+    runForLegacyTestsSeeTestingMd(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, RawEffects.now, LambdaIO(inputStream, outputStream, context))
 
-  def runWithEffectsDontTestAtThisLevel(
+  def runForLegacyTestsSeeTestingMd(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
@@ -70,7 +70,7 @@ object Runner {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, now, LambdaIO(stream, os, null))
+    Handler.runForLegacyTestsSeeTestingMd(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, now, LambdaIO(stream, os, null))
 
     val responseString = new String(os.toByteArray, "UTF-8")
     responseString

--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryHandlerEffectsTest.scala
@@ -70,7 +70,7 @@ object Runner {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, now, LambdaIO(stream, os, null))
+    Handler.runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, now, LambdaIO(stream, os, null))
 
     val responseString = new String(os.toByteArray, "UTF-8")
     responseString

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -30,9 +30,9 @@ object Handler {
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
+    runForLegacyTestsSeeTestingMd(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
 
-  def runWithEffectsDontTestAtThisLevel(
+  def runForLegacyTestsSeeTestingMd(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -16,7 +16,7 @@ import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
 import com.gu.util.config.LoadConfigModule.StringFromS3
-import com.gu.util.config.{LoadConfigModule, Stage, TrustedApiConfig}
+import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.ClientFailableOp
@@ -30,14 +30,17 @@ object Handler {
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
+    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
 
-  def runWithEffects(
+  def runWithEffectsDontTestAtThisLevel(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,
     lambdaIO: LambdaIO
-  ): Unit = {
+  ): Unit =
+    ApiGatewayHandler(lambdaIO)(operationForEffects(stage, fetchString, response))
+
+  def operationForEffects(stage: Stage, fetchString: StringFromS3, response: Request => Response): ApiGatewayOp[Operation] = {
     def operation(
       zuoraRestConfig: ZuoraRestConfig,
       sfConfig: SFAuthConfig,
@@ -45,7 +48,7 @@ object Handler {
     ) = {
       val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       val zuoraQuerier = ZuoraQuery(zuoraRequests)
-      val getByEmail: EmailAddress => \/[GetByEmail.ApiError, IdentityId] = GetByEmail(response, identityConfig)
+      val getByEmail: EmailAddress => GetByEmail.ApiError \/ IdentityId = GetByEmail(response, identityConfig)
       val countZuoraAccounts: IdentityId => ClientFailableOp[Int] = CountZuoraAccountsForIdentityId(zuoraQuerier)
       lazy val sfRequests: ApiGatewayOp[Requests] = SalesforceAuthenticate(response, sfConfig)
 
@@ -53,9 +56,9 @@ object Handler {
         steps = IdentityBackfillSteps(
           PreReqCheck(
             getByEmail,
-            GetZuoraAccountsForEmail(zuoraQuerier)_ andThen PreReqCheck.getSingleZuoraAccountForEmail,
+            GetZuoraAccountsForEmail(zuoraQuerier) _ andThen PreReqCheck.getSingleZuoraAccountForEmail,
             countZuoraAccounts andThen PreReqCheck.noZuoraAccountsForIdentityId,
-            GetZuoraSubTypeForAccount(zuoraQuerier)_ andThen PreReqCheck.acceptableReaderType,
+            GetZuoraSubTypeForAccount(zuoraQuerier) _ andThen PreReqCheck.acceptableReaderType,
             syncableSFToIdentity(sfRequests, stage)
           ),
           AddIdentityIdToAccount(zuoraRequests),
@@ -70,15 +73,14 @@ object Handler {
     }
 
     val loadConfig = LoadConfigModule(stage, fetchString)
-    ApiGatewayHandler(lambdaIO)(for {
+    val fOperation = for {
       zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
       sfAuthConfig <- loadConfig[SFAuthConfig].toApiGatewayOp("load sfAuth config")
       identityConfig <- loadConfig[IdentityConfig].toApiGatewayOp("load identity config")
-      trustedApiConfig <- loadConfig[TrustedApiConfig].toApiGatewayOp("load trustedApi config")
       configuredOp = operation(zuoraRestConfig, sfAuthConfig, identityConfig)
 
-    } yield (trustedApiConfig, configuredOp))
-
+    } yield configuredOp
+    fOperation
   }
 
   def standardRecordTypeForStage(stage: Stage): ApiGatewayOp[RecordTypeId] = {

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -75,7 +75,7 @@ object Runner {
     val config = new TestingRawEffects(200, responses, postResponses)
 
     //execute
-    Handler.runWithEffects(
+    Handler.runWithEffectsDontTestAtThisLevel(
       Stage("DEV"),
       FakeFetchString.fetchString,
       config.response,

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -75,7 +75,7 @@ object Runner {
     val config = new TestingRawEffects(200, responses, postResponses)
 
     //execute
-    Handler.runWithEffectsDontTestAtThisLevel(
+    Handler.runForLegacyTestsSeeTestingMd(
       Stage("DEV"),
       FakeFetchString.fetchString,
       config.response,

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
@@ -19,7 +19,7 @@ class HealthCheckSystemTest extends FlatSpec with Matchers {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(stream, os, null))
+    Handler.runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(stream, os, null))
 
     val responseString = new String(os.toByteArray, "UTF-8")
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/HealthCheckSystemTest.scala
@@ -19,7 +19,7 @@ class HealthCheckSystemTest extends FlatSpec with Matchers {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(stream, os, null))
+    Handler.runForLegacyTestsSeeTestingMd(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(stream, os, null))
 
     val responseString = new String(os.toByteArray, "UTF-8")
 

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Handler.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Handler.scala
@@ -16,10 +16,10 @@ object Handler {
 
   // Referenced in Cloudformation
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    runWithEffectsDontTestAtThisLevel(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(inputStream, outputStream, context))
+    runForLegacyTestsSeeTestingMd(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(inputStream, outputStream, context))
   }
 
-  def runWithEffectsDontTestAtThisLevel(response: Request => Response, stage: Stage, fetchString: StringFromS3, lambdaIO: LambdaIO) =
+  def runForLegacyTestsSeeTestingMd(response: Request => Response, stage: Stage, fetchString: StringFromS3, lambdaIO: LambdaIO) =
     ApiGatewayHandler(lambdaIO)(operationForEffects(response, stage, fetchString))
 
   def operationForEffects(response: Request => Response, stage: Stage, fetchString: StringFromS3): ApiGatewayOp[Operation] = {

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Handler.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/Handler.scala
@@ -7,7 +7,7 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.util.apigateway.ApiGatewayHandler
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.config.LoadConfigModule.StringFromS3
-import com.gu.util.config.{LoadConfigModule, Stage, TrustedApiConfig}
+import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
@@ -16,24 +16,18 @@ object Handler {
 
   // Referenced in Cloudformation
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    runWithEffects(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(inputStream, outputStream, context))
+    runWithEffectsDontTestAtThisLevel(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(inputStream, outputStream, context))
   }
 
-  def runWithEffects(response: Request => Response, stage: Stage, fetchString: StringFromS3, lambdaIO: LambdaIO) = {
+  def runWithEffectsDontTestAtThisLevel(response: Request => Response, stage: Stage, fetchString: StringFromS3, lambdaIO: LambdaIO) =
+    ApiGatewayHandler(lambdaIO)(operationForEffects(response, stage, fetchString))
 
-    def operation: ZuoraRestConfig => Operation = zuoraRestConfig => {
+  def operationForEffects(response: Request => Response, stage: Stage, fetchString: StringFromS3): ApiGatewayOp[Operation] = {
+    val loadConfig = LoadConfigModule(stage, fetchString)
+    loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config").map { zuoraRestConfig =>
       val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       val zuoraQuerier = ZuoraQuery(zuoraRequests)
       IdentityRetentionSteps(zuoraQuerier)
     }
-
-    val loadConfig = LoadConfigModule(stage, fetchString)
-    ApiGatewayHandler(lambdaIO)(for {
-      zuoraConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      trustedApiConfig <- loadConfig[TrustedApiConfig].toApiGatewayOp("load trusted api config")
-      configuredOp = operation(zuoraConfig)
-    } yield (trustedApiConfig, configuredOp))
-
   }
-
 }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/IdentityRetentionSteps.scala
@@ -29,7 +29,7 @@ object IdentityRetentionSteps extends Logging {
         accounts <- MaybeNonEmptyList(possibleAccounts).toApiGatewayContinueProcessing(ApiGatewayResponse.notFound("no active zuora accounts"))
         subs <- SubscriptionsForAccounts(zuoraQuerier)(accounts)
       } yield RelationshipForSubscriptions(subs)).apiResponse
-  }, false)
+  })
 
   def extractIdentityId(queryStringParams: UrlParams): ApiGatewayOp[IdentityId] = {
     validate(queryStringParams.identityId) match {

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerEffectsTest.scala
@@ -41,7 +41,7 @@ class IdentityRetentionHandlerEffectsTest extends FlatSpec with Matchers {
   def runWithMock(mockRequest: String): String = {
     val stream = new ByteArrayInputStream(mockRequest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     val output = new ByteArrayOutputStream()
-    Handler.runWithEffects(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(stream, output, null))
+    Handler.runWithEffectsDontTestAtThisLevel(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(stream, output, null))
     new String(output.toByteArray, "UTF-8")
   }
 

--- a/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerEffectsTest.scala
+++ b/handlers/identity-retention/src/test/scala/com/gu/identityRetention/IdentityRetentionHandlerEffectsTest.scala
@@ -41,7 +41,7 @@ class IdentityRetentionHandlerEffectsTest extends FlatSpec with Matchers {
   def runWithMock(mockRequest: String): String = {
     val stream = new ByteArrayInputStream(mockRequest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     val output = new ByteArrayOutputStream()
-    Handler.runWithEffectsDontTestAtThisLevel(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(stream, output, null))
+    Handler.runForLegacyTestsSeeTestingMd(RawEffects.response, RawEffects.stage, GetFromS3.fetchString, LambdaIO(stream, output, null))
     new String(output.toByteArray, "UTF-8")
   }
 

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -28,10 +28,10 @@ object Handler {
 
   // Referenced in Cloudformation
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
+    runForLegacyTestsSeeTestingMd(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
   }
 
-  def runWithEffectsDontTestAtThisLevel(stage: Stage, fetchString: StringFromS3, getResponse: Request => Response, lambdaIO: LambdaIO) =
+  def runForLegacyTestsSeeTestingMd(stage: Stage, fetchString: StringFromS3, getResponse: Request => Response, lambdaIO: LambdaIO) =
     ApiGatewayHandler(lambdaIO) {
       operationForEffects(stage, fetchString, getResponse)
     }

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -9,7 +9,7 @@ import com.gu.sf_contact_merge.TypeConvert._
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse, ResponseModels}
 import com.gu.util.config.LoadConfigModule.StringFromS3
-import com.gu.util.config.{LoadConfigModule, Stage, TrustedApiConfig}
+import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientFailableOp
@@ -28,26 +28,27 @@ object Handler {
 
   // Referenced in Cloudformation
   def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit = {
-    runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
+    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
   }
 
-  def runWithEffects(stage: Stage, fetchString: StringFromS3, getResponse: Request => Response, lambdaIO: LambdaIO) = {
-
-    val loadConfig = LoadConfigModule(stage, fetchString)
+  def runWithEffectsDontTestAtThisLevel(stage: Stage, fetchString: StringFromS3, getResponse: Request => Response, lambdaIO: LambdaIO) =
     ApiGatewayHandler(lambdaIO) {
-      for {
-        trustedApiConfig <- loadConfig[TrustedApiConfig].toApiGatewayOp("load trusted Api config")
-        zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load trusted Api config")
-        requests = ZuoraRestRequestMaker(getResponse, zuoraRestConfig)
-        zuoraQuerier = ZuoraQuery(requests)
-        wiredSteps = steps(
-          GetZuoraEmailsForAccounts(zuoraQuerier),
-          UpdateAccountSFLinks(requests)
-        )_
-        configuredOp = Operation.noHealthcheck(wiredSteps, false)
-      } yield (trustedApiConfig, configuredOp)
+      operationForEffects(stage, fetchString, getResponse)
     }
 
+  def operationForEffects(stage: Stage, fetchString: StringFromS3, getResponse: Request => Response): ApiGatewayOp[Operation] = {
+    val loadConfig = LoadConfigModule(stage, fetchString)
+    val fConfig = for {
+      zuoraRestConfig <- loadConfig[ZuoraRestConfig].toApiGatewayOp("load trusted Api config")
+      requests = ZuoraRestRequestMaker(getResponse, zuoraRestConfig)
+      zuoraQuerier = ZuoraQuery(requests)
+      wiredSteps = steps(
+        GetZuoraEmailsForAccounts(zuoraQuerier),
+        UpdateAccountSFLinks(requests)
+      ) _
+      configuredOp = Operation.noHealthcheck(wiredSteps)
+    } yield configuredOp
+    fConfig
   }
 
   case class WireSfContactRequest(

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -53,7 +53,7 @@ object Runner {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffectsDontTestAtThisLevel(
+    Handler.runForLegacyTestsSeeTestingMd(
       Stage("DEV"),
       FakeFetchString.fetchString,
       EndToEndTest.mock.response,

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -53,7 +53,7 @@ object Runner {
     val os = new ByteArrayOutputStream()
 
     //execute
-    Handler.runWithEffects(
+    Handler.runWithEffectsDontTestAtThisLevel(
       Stage("DEV"),
       FakeFetchString.fetchString,
       EndToEndTest.mock.response,

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -47,13 +47,16 @@ object ApiGatewayHandler extends Logging {
     steps: ApiGatewayRequest => ApiResponse,
     healthcheck: () => ApiResponse
   ) {
-    def prependValidationStep(validate: ApiGatewayRequest => ApiGatewayOp[Unit]): Operation = {
-      def newSteps(request: ApiGatewayRequest): ApiResponse =
+
+    def prependRequestValidationToSteps(validate: ApiGatewayRequest => ApiGatewayOp[Unit]): Operation = {
+      val validateAndRunSteps: ApiGatewayRequest => ApiResponse = { request =>
         (for {
           _ <- validate(request)
           result = steps(request)
         } yield result).apiResponse
-      Operation(newSteps, healthcheck)
+      }
+      Operation(validateAndRunSteps, healthcheck)
+
     }
 
   }

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayHandler.scala
@@ -4,25 +4,22 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.util.Logging
-import com.gu.util.apigateway.ApiGatewayResponse.{outputForAPIGateway, unauthorized}
-import com.gu.util.apigateway.Auth.{RequestAuth, credentialsAreValid}
+import com.gu.util.apigateway.ApiGatewayHandlerParams.UrlParamsWire
+import com.gu.util.apigateway.ApiGatewayResponse.outputForAPIGateway
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.config.TrustedApiConfig
-import com.gu.util.reader.Types.ApiGatewayOp._
 import com.gu.util.reader.Types._
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.Json
 
 import scala.io.Source
 import scala.util.Try
 
-case class ApiGatewayHandlerParams(apiToken: Option[String], isHealthcheck: Boolean)
+case class ApiGatewayHandlerParams(isHealthcheck: Boolean)
 
 object ApiGatewayHandlerParams {
-  case class UrlParamsWire(apiToken: Option[String], isHealthcheck: Option[String]) {
-    def toApiHandlerParams = ApiGatewayHandlerParams(apiToken, isHealthcheck.contains("true"))
+  case class UrlParamsWire(isHealthcheck: Option[String]) {
+    def toApiHandlerParams = ApiGatewayHandlerParams(isHealthcheck.contains("true"))
   }
-  val wireReads = Json.reads[UrlParamsWire]
-  implicit val reads: Reads[ApiGatewayHandlerParams] = json => wireReads.reads(json).map(_.toApiHandlerParams)
+  implicit val wireReads = Json.reads[UrlParamsWire]
 }
 
 object ApiGatewayHandler extends Logging {
@@ -46,46 +43,41 @@ object ApiGatewayHandler extends Logging {
     }
   }
 
-  def isAuthorised(
-    shouldAuthenticate: Boolean,
-    requestAuth: Option[RequestAuth],
-    trustedApiConfig: TrustedApiConfig
-  ): Boolean = {
-    !shouldAuthenticate || credentialsAreValid(requestAuth, trustedApiConfig)
-
-  }
-
   case class Operation(
     steps: ApiGatewayRequest => ApiResponse,
-    healthcheck: () => ApiResponse,
-    shouldAuthenticate: Boolean = true
-  )
-  object Operation {
-    def noHealthcheck(steps: ApiGatewayRequest => ApiResponse, shouldAuthenticate: Boolean = true) =
-      Operation(steps, () => ApiGatewayResponse.successfulExecution, shouldAuthenticate)
+    healthcheck: () => ApiResponse
+  ) {
+    def prependValidationStep(validate: ApiGatewayRequest => ApiGatewayOp[Unit]): Operation = {
+      def newSteps(request: ApiGatewayRequest): ApiResponse =
+        (for {
+          _ <- validate(request)
+          result = steps(request)
+        } yield result).apiResponse
+      Operation(newSteps, healthcheck)
+    }
+
   }
 
-  def apply(
-    lambdaIO: LambdaIO
-  )(
-    fConfigOp: ApiGatewayOp[(TrustedApiConfig, Operation)]
-  ): Unit = {
+  object Operation {
+    def noHealthcheck(steps: ApiGatewayRequest => ApiResponse) =
+      Operation(steps, () => ApiGatewayResponse.successfulExecution)
+  }
+
+  def apply(lambdaIO: LambdaIO)(fConfigOp: ApiGatewayOp[Operation]): Unit = {
 
     import lambdaIO._
 
-    val response = for {
-      configOp <- fConfigOp
-      (trustedApiConf, operation) = configOp
-      apiGatewayRequest <- parseApiGatewayRequest(inputStream)
-      queryParams <- apiGatewayRequest.queryParamsAsCaseClass[ApiGatewayHandlerParams]()
-      response <- if (queryParams.isHealthcheck)
-        ContinueProcessing(operation.healthcheck()).withLogging("healthcheck")
-      else
-        for {
-          _ <- isAuthorised(operation.shouldAuthenticate, queryParams.apiToken.map(RequestAuth(_)), trustedApiConf)
-            .toApiGatewayContinueProcessing(unauthorized).withLogging("authentication")
-        } yield operation.steps(apiGatewayRequest).withLogging("steps")
-    } yield response
+    val response =
+      for {
+        operation <- fConfigOp
+        apiGatewayRequest <- parseApiGatewayRequest(inputStream)
+        queryParams <- apiGatewayRequest.queryParamsAsCaseClass[UrlParamsWire]().map(_.toApiHandlerParams)
+      } yield {
+        if (queryParams.isHealthcheck)
+          operation.healthcheck().withLogging("healthcheck")
+        else
+          operation.steps(apiGatewayRequest).withLogging("steps")
+      }
 
     outputForAPIGateway(outputStream, response.apiResponse)
   }

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/Auth.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/Auth.scala
@@ -1,15 +1,39 @@
 package com.gu.util.apigateway
 
 import com.gu.util.Logging
-import com.gu.util.config.TrustedApiConfig
+import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
+import com.gu.util.config.ConfigLocation
+import com.gu.util.config.ConfigReads.ConfigFailure
+import com.gu.util.reader.Types.{ApiGatewayOp, _}
+import play.api.libs.json.{Json, Reads}
+import scalaz.\/
 
 object Auth extends Logging {
-  case class RequestAuth(apiToken: String)
 
-  def credentialsAreValid(maybeRequestAuth: Option[RequestAuth], trustedApiConfig: TrustedApiConfig): Boolean =
-    maybeRequestAuth.exists { requestAuth =>
-      requestAuth.apiToken == trustedApiConfig.apiToken
-    }
+  case class RequestAuth(apiToken: Option[String])
+
+  object RequestAuth {
+    implicit val reads: Reads[RequestAuth] = Json.reads[RequestAuth]
+  }
+
+  case class TrustedApiConfig(apiToken: String, tenantId: String)
+
+  object TrustedApiConfig {
+    implicit val location = ConfigLocation[TrustedApiConfig](path = "trustedApi", version = 1)
+    implicit val apiConfigReads = Json.reads[TrustedApiConfig]
+  }
+
+  def apply(loadConfigModule: ConfigFailure \/ TrustedApiConfig)(apiGatewayRequest: ApiGatewayRequest): ApiGatewayOp[Unit] = {
+    for {
+      trustedApiConfig <- loadConfigModule.toApiGatewayOp("load trusted Api config")
+      requestAuth <- apiGatewayRequest.queryParamsAsCaseClass[RequestAuth]()
+      _ <- credentialsAreValid(trustedApiConfig, requestAuth)
+        .toApiGatewayContinueProcessing(unauthorized).withLogging("authentication")
+    } yield ()
+  }
+
+  def credentialsAreValid(trustedApiConfig: TrustedApiConfig, requestAuth: RequestAuth): Boolean =
+    requestAuth.apiToken.contains(trustedApiConfig.apiToken)
 
   // Ensure that the correct Zuora environment is hitting the API
   def validTenant(trustedApiConfig: TrustedApiConfig, tenantId: String): Boolean = {

--- a/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
+++ b/lib/handler/src/main/scala/com/gu/util/config/ConfigModels.scala
@@ -42,13 +42,6 @@ object ETConfig {
   )(ETConfig.apply _)
 }
 
-case class TrustedApiConfig(apiToken: String, tenantId: String)
-
-object TrustedApiConfig {
-  implicit val location = ConfigLocation[TrustedApiConfig](path = "trustedApi", version = 1)
-  implicit val apiConfigReads = Json.reads[TrustedApiConfig]
-}
-
 case class StripeSecretKey(key: String) extends AnyVal
 
 object StripeSecretKey {
@@ -75,14 +68,6 @@ object StripeConfig {
   )(StripeConfig.apply _)
 }
 
-case class Config[StepsConfig](
-  stage: Stage,
-  trustedApiConfig: TrustedApiConfig,
-  stepsConfig: StepsConfig,
-  etConfig: ETConfig,
-  stripeConfig: StripeConfig
-)
-
 case class Stage(value: String) extends AnyVal {
   def isProd: Boolean = value == "PROD"
 }
@@ -100,14 +85,6 @@ case class ZuoraEnvironment(value: String) extends Logging {
 }
 
 object ConfigReads {
-
-  implicit def configReads[StepsConfig: Reads]: Reads[Config[StepsConfig]] = (
-    (JsPath \ "stage").read[String].map(Stage.apply) and
-    (JsPath \ "trustedApiConfig").read[TrustedApiConfig] and
-    (JsPath \ "stepsConfig").read[StepsConfig] and
-    (JsPath \ "etConfig").read[ETConfig] and
-    (JsPath \ "stripe").read[StripeConfig]
-  )(Config.apply[StepsConfig] _)
 
   case class ConfigFailure(error: String)
 

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/ApiGatewayHandlerReadsTest.scala
@@ -119,39 +119,25 @@ class ApiGatewayHandlerReadsTest extends FlatSpec {
     actual.toDisjunction.leftMap(_.statusCode) shouldBe expected
   }
 
-  it should "deserialise ApiGatewayHandlerParams with no query string" in {
-    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = None, body = None, headers = None)
-    val expected = ApiGatewayHandlerParams(apiToken = None, isHealthcheck = false)
-    noQueryParamsRequest.queryParamsAsCaseClass[ApiGatewayHandlerParams]() shouldBe ContinueProcessing(expected)
-
+  it should "deserialise correctly if all params are there" in {
+    val queryParams = Some(Map(
+      "testQueryParam" -> "someValue"
+    ))
+    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
+    val actual = noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams]()
+    val expected = ContinueProcessing(NonOptionalParams("someValue"))
+    actual shouldBe expected
   }
 
-  it should "deserialise ApiGatewayHandlerParams with token" in {
-    val request = ApiGatewayRequest(queryStringParameters = Some(Map("apiToken" -> "tokenValue")), body = None, headers = None)
-    val expected = ApiGatewayHandlerParams(apiToken = Some("tokenValue"), isHealthcheck = false)
-    request.queryParamsAsCaseClass[ApiGatewayHandlerParams]() shouldBe ContinueProcessing(expected)
-
+  it should "deserialise correctly even if extra stuff" in {
+    val queryParams = Some(Map(
+      "testQueryParam" -> "someValue",
+      "another" -> "someOtherValue"
+    ))
+    val noQueryParamsRequest = ApiGatewayRequest(queryStringParameters = queryParams, body = None, headers = None)
+    val actual = noQueryParamsRequest.queryParamsAsCaseClass[NonOptionalParams]()
+    val expected = ContinueProcessing(NonOptionalParams("someValue"))
+    actual shouldBe expected
   }
 
-  it should "deserialise ApiGatewayHandlerParams with isHealthcheck= true" in {
-    val request = ApiGatewayRequest(queryStringParameters = Some(Map("isHealthcheck" -> "true")), body = None, headers = None)
-    val expected = ApiGatewayHandlerParams(apiToken = None, isHealthcheck = true)
-
-    request.queryParamsAsCaseClass[ApiGatewayHandlerParams]() shouldBe ContinueProcessing(expected)
-
-  }
-
-  it should "deserialise ApiGatewayHandlerParams with isHealthcheck= false" in {
-    val request = ApiGatewayRequest(queryStringParameters = Some(Map("isHealthcheck" -> "false")), body = None, headers = None)
-    val expected = ApiGatewayHandlerParams(apiToken = None, isHealthcheck = false)
-
-    request.queryParamsAsCaseClass[ApiGatewayHandlerParams]() shouldBe ContinueProcessing(expected)
-  }
-
-  it should "deserialise ApiGatewayHandlerParams with isHealthcheck set to an invalid value" in {
-    val request = ApiGatewayRequest(queryStringParameters = Some(Map("isHealthcheck" -> "invalidValue")), body = None, headers = None)
-    val expected = ApiGatewayHandlerParams(apiToken = None, isHealthcheck = false)
-
-    request.queryParamsAsCaseClass[ApiGatewayHandlerParams]() shouldBe ContinueProcessing(expected)
-  }
 }

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/AuthTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/AuthTest.scala
@@ -1,7 +1,6 @@
 package com.gu.util.apigateway
 
 import com.gu.util.apigateway.Auth._
-import com.gu.util.config.TrustedApiConfig
 import org.scalatest.FlatSpec
 import play.api.libs.json.{JsValue, Json}
 
@@ -29,16 +28,16 @@ class AuthTest extends FlatSpec {
   }
 
   "deprecatedCredentialsAreValid" should "return false if the username query string is missing" in {
-    assert(credentialsAreValid(None, trustedApiConfig) == false)
+    assert(credentialsAreValid(trustedApiConfig, RequestAuth(None)) == false)
   }
   "credentialsAreValid" should "return true for correct credentials" in {
-    val requestAuth = Some(RequestAuth(apiToken = "correctPassword"))
-    assert(credentialsAreValid(requestAuth, trustedApiConfig) == true)
+    val requestAuth = RequestAuth(apiToken = Some("correctPassword"))
+    assert(credentialsAreValid(trustedApiConfig, requestAuth) == true)
   }
 
   "credentialsAreValid" should "return false for an incorrect password" in {
-    val requestAuth = Some(RequestAuth(apiToken = "incorrectPassword"))
-    assert(credentialsAreValid(requestAuth, trustedApiConfig) == false)
+    val requestAuth = RequestAuth(apiToken = Some("incorrectPassword"))
+    assert(credentialsAreValid(trustedApiConfig, requestAuth) == false)
   }
 
 }

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/AuthTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/AuthTest.scala
@@ -27,7 +27,7 @@ class AuthTest extends FlatSpec {
     sampleJson
   }
 
-  "deprecatedCredentialsAreValid" should "return false if the username query string is missing" in {
+  "credentialsAreValid" should "return false if the username query string is missing" in {
     assert(credentialsAreValid(trustedApiConfig, RequestAuth(None)) == false)
   }
   "credentialsAreValid" should "return true for correct credentials" in {

--- a/lib/handler/src/test/scala/com/gu/util/apigateway/OperationTest.scala
+++ b/lib/handler/src/test/scala/com/gu/util/apigateway/OperationTest.scala
@@ -1,0 +1,27 @@
+package com.gu.util.apigateway
+
+import com.gu.util.apigateway.ApiGatewayHandler.Operation
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+import org.scalatest.{FlatSpec, Matchers}
+
+class OperationTest extends FlatSpec with Matchers {
+
+  it should "map the operation properly when it succeeds" in {
+
+    val operation = Operation(_ => ApiGatewayResponse("200", "blah"), () => ApiGatewayResponse("0", "blah"))
+    val newOperation = operation.prependRequestValidationToSteps(req => ContinueProcessing(()))
+    val actual = newOperation.steps(ApiGatewayRequest(None, None, None, None))
+    actual.statusCode should be("200")
+
+  }
+
+  it should "map the operation properly when it fails" in {
+
+    val operation = Operation(_ => ApiGatewayResponse("200", "blah"), () => ApiGatewayResponse("0", "blah"))
+    val newOperation = operation.prependRequestValidationToSteps(req => ReturnWithResponse(ApiGatewayResponse("401", "blah")))
+    val actual = newOperation.steps(ApiGatewayRequest(None, None, None, None))
+    actual.statusCode should be("401")
+
+  }
+
+}

--- a/lib/s3ConfigValidator/src/test/scala/com/gu/test/S3ConfigFilesEffectsTest.scala
+++ b/lib/s3ConfigValidator/src/test/scala/com/gu/test/S3ConfigFilesEffectsTest.scala
@@ -2,8 +2,8 @@ package com.gu.test
 import com.gu.digitalSubscriptionExpiry.emergencyToken.EmergencyTokensConfig
 import com.gu.effects.GetFromS3
 import com.gu.identity.{IdentityConfig, IdentityTestUserConfig}
-import com.gu.salesforce.auth.SalesforceAuthenticate.SFAuthConfig
-import com.gu.salesforce.auth.SalesforceAuthenticate.SFAuthTestConfig
+import com.gu.salesforce.auth.SalesforceAuthenticate.{SFAuthConfig, SFAuthTestConfig}
+import com.gu.util.apigateway.Auth.TrustedApiConfig
 import com.gu.util.config._
 import com.gu.util.zuora.ZuoraRestConfig
 import org.scalatest.{FlatSpec, Matchers}

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -6,27 +6,30 @@ import java.time.LocalDateTime
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.paymentFailure.ZuoraEmailSteps
-import com.gu.util.apigateway.ApiGatewayHandler
-import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
-import com.gu.util.exacttarget.{ETClient, EmailSendSteps, FilterEmail}
-import com.gu.util.zuora.{ZuoraGetAccountSummary, ZuoraGetInvoiceTransactions, ZuoraRestConfig, ZuoraRestRequestMaker}
 import com.gu.util.Logging
+import com.gu.util.apigateway.{ApiGatewayHandler, Auth}
+import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.Auth.TrustedApiConfig
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config._
+import com.gu.util.exacttarget.{ETClient, EmailSendSteps, FilterEmail}
 import com.gu.util.reader.Types._
+import com.gu.util.zuora.{ZuoraGetAccountSummary, ZuoraGetInvoiceTransactions, ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
 
 object AutoCancelHandler extends App with Logging {
 
-  def runWithEffects(
+  def operationForEffects(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,
-    now: () => LocalDateTime,
-    lambdaIO: LambdaIO
-  ): Unit = {
-    def operation(zuoraRestConfig: ZuoraRestConfig, etConfig: ETConfig): ApiGatewayHandler.Operation = {
-
+    now: () => LocalDateTime
+  ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
+    val loadConfigModule = LoadConfigModule(stage, fetchString)
+    for {
+      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+      etConfig <- loadConfigModule[ETConfig].toApiGatewayOp("load et config")
+    } yield {
       val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       AutoCancelSteps(
         AutoCancel.apply(zuoraRequests),
@@ -36,22 +39,16 @@ object AutoCancelHandler extends App with Logging {
           EmailSendSteps(ETClient.sendEmail(response, etConfig), FilterEmail(stage)),
           ZuoraGetInvoiceTransactions(ZuoraRestRequestMaker(response, zuoraRestConfig))
         )
-      )
+      ).prependValidationStep(Auth(loadConfigModule[TrustedApiConfig]))
     }
-    val loadConfigModule = LoadConfigModule(stage, fetchString)
-    ApiGatewayHandler(lambdaIO)(for {
-      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      etconfig <- loadConfigModule[ETConfig].toApiGatewayOp("load et config")
-      trustedApiConfig <- loadConfigModule[TrustedApiConfig].toApiGatewayOp("load trusted Api config")
-      configuredOp = operation(zuoraRestConfig, etconfig)
-    } yield (trustedApiConfig, configuredOp))
-
   }
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, RawEffects.now, LambdaIO(inputStream, outputStream, context))
+    ApiGatewayHandler(LambdaIO(inputStream, outputStream, context)) {
+      operationForEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, RawEffects.now)
+    }
 
 }

--- a/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelHandler.scala
@@ -39,7 +39,7 @@ object AutoCancelHandler extends App with Logging {
           EmailSendSteps(ETClient.sendEmail(response, etConfig), FilterEmail(stage)),
           ZuoraGetInvoiceTransactions(ZuoraRestRequestMaker(response, zuoraRestConfig))
         )
-      ).prependValidationStep(Auth(loadConfigModule[TrustedApiConfig]))
+      ).prependRequestValidationToSteps(Auth(loadConfigModule[TrustedApiConfig]))
     }
   }
 

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -32,7 +32,7 @@ object Lambda {
     loadConfigModule: ConfigFailure \/ TrustedApiConfig,
     wiredOperation: ApiGatewayOp[ApiGatewayHandler.Operation]
   ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
-    wiredOperation.map(_.prependValidationStep(Auth(loadConfigModule)))
+    wiredOperation.map(_.prependRequestValidationToSteps(Auth(loadConfigModule)))
   }
 
   def wiredOperation(stage: Stage, response: Request => Response, loadConfigModule: LoadConfigModule.PartialApply): ApiGatewayOp[ApiGatewayHandler.Operation] = {

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -18,7 +18,7 @@ import scalaz.\/
 
 object Lambda {
 
-  def runWithEffectsDontTestAtThisLevel(
+  def runForLegacyTestsSeeTestingMd(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,
@@ -56,6 +56,6 @@ object Lambda {
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
+    runForLegacyTestsSeeTestingMd(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
 
 }

--- a/src/main/scala/com/gu/paymentFailure/Lambda.scala
+++ b/src/main/scala/com/gu/paymentFailure/Lambda.scala
@@ -4,51 +4,58 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.util.apigateway.ApiGatewayHandler
+import com.gu.util.apigateway.{ApiGatewayHandler, Auth}
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.Auth.TrustedApiConfig
+import com.gu.util.config.ConfigReads.ConfigFailure
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config._
 import com.gu.util.exacttarget.{ETClient, EmailSendSteps, FilterEmail}
 import com.gu.util.reader.Types._
 import com.gu.util.zuora.{ZuoraGetInvoiceTransactions, ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
+import scalaz.\/
 
 object Lambda {
 
-  def runWithEffects(
+  def runWithEffectsDontTestAtThisLevel(
     stage: Stage,
     fetchString: StringFromS3,
     response: Request => Response,
     lambdaIO: LambdaIO
   ): Unit = {
-    def operation(
-      zuoraRestConfig: ZuoraRestConfig,
-      etConfig: ETConfig,
-      trustedApiConfig: TrustedApiConfig
-    ): ApiGatewayHandler.Operation =
-      PaymentFailureSteps(
-        ZuoraEmailSteps.sendEmailRegardingAccount(
-          EmailSendSteps(ETClient.sendEmail(response, etConfig), FilterEmail(stage)),
-          ZuoraGetInvoiceTransactions(ZuoraRestRequestMaker(response, zuoraRestConfig))
-        ),
-        etConfig.etSendIDs,
-        trustedApiConfig
-      )
     val loadConfigModule = LoadConfigModule(stage, fetchString)
-    ApiGatewayHandler(lambdaIO)(for {
+    ApiGatewayHandler(lambdaIO)(operationForEffects(loadConfigModule[TrustedApiConfig], wiredOperation(stage, response, loadConfigModule)))
+  }
+
+  def operationForEffects(
+    loadConfigModule: ConfigFailure \/ TrustedApiConfig,
+    wiredOperation: ApiGatewayOp[ApiGatewayHandler.Operation]
+  ): ApiGatewayOp[ApiGatewayHandler.Operation] = {
+    wiredOperation.map(_.prependValidationStep(Auth(loadConfigModule)))
+  }
+
+  def wiredOperation(stage: Stage, response: Request => Response, loadConfigModule: LoadConfigModule.PartialApply): ApiGatewayOp[ApiGatewayHandler.Operation] = {
+    for {
       zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      etconfig <- loadConfigModule[ETConfig].toApiGatewayOp("load et config")
+      etConfig <- loadConfigModule[ETConfig].toApiGatewayOp("load et config")
+      // we probably shouldn't combine zuora tenant ids and auth keys into the same secrets file, are tenant ids even secret?
       trustedApiConfig <- loadConfigModule[TrustedApiConfig].toApiGatewayOp("load trusted Api config")
-      configuredOp = operation(zuoraRestConfig, etconfig, trustedApiConfig)
 
-    } yield (trustedApiConfig, configuredOp))
-
+    } yield PaymentFailureSteps(
+      ZuoraEmailSteps.sendEmailRegardingAccount(
+        EmailSendSteps(ETClient.sendEmail(response, etConfig), FilterEmail(stage)),
+        ZuoraGetInvoiceTransactions(ZuoraRestRequestMaker(response, zuoraRestConfig))
+      ),
+      etConfig.etSendIDs,
+      trustedApiConfig
+    )
   }
 
   // this is the entry point
   // it's referenced by the cloudformation so make sure you keep it in step
   // it's the only part you can't test of the handler
   def handleRequest(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
-    runWithEffects(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
+    runWithEffectsDontTestAtThisLevel(RawEffects.stage, GetFromS3.fetchString, RawEffects.response, LambdaIO(inputStream, outputStream, context))
 
 }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -1,19 +1,18 @@
 package com.gu.paymentFailure
 
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
+import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
 import com.gu.util.apigateway.ApiGatewayResponse.{ResponseBody, toJsonBody, unauthorized}
-import com.gu.util.apigateway.Auth.validTenant
+import com.gu.util.apigateway.Auth.{TrustedApiConfig, validTenant}
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.config.ETConfig.ETSendIds
-import com.gu.util.config.TrustedApiConfig
 import com.gu.util.exacttarget.EmailRequest
-import com.gu.util.reader.Types.ApiGatewayOp.{ReturnWithResponse, ContinueProcessing}
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
-import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 
 object PaymentFailureSteps extends Logging {
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -33,7 +33,7 @@ object Lambda {
           zuoraClient,
           stripeChecker
         )
-      } yield configuredOp.prependValidationStep(Auth(loadConfigModule[TrustedApiConfig]))
+      } yield configuredOp.prependRequestValidationToSteps(Auth(loadConfigModule[TrustedApiConfig]))
     }
 
   }

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/Lambda.scala
@@ -4,8 +4,9 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.util.apigateway.ApiGatewayHandler
+import com.gu.util.apigateway.{ApiGatewayHandler, Auth}
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
+import com.gu.util.apigateway.Auth.TrustedApiConfig
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config._
 import com.gu.util.reader.Types._
@@ -20,21 +21,20 @@ object Lambda {
     response: Request => Response,
     lambdaIO: LambdaIO
   ): Unit = {
-    def operation(zuoraRestConfig: ZuoraRestConfig, stripeConfig: StripeConfig): ApiGatewayHandler.Operation =
-      SourceUpdatedSteps(
-        ZuoraRestRequestMaker(response, zuoraRestConfig),
-        StripeDeps(stripeConfig, new StripeSignatureChecker)
-      )
     val loadConfigModule = LoadConfigModule(stage, fetchString)
 
-    ApiGatewayHandler(lambdaIO)(for {
-      zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
-      stripeConfig <- loadConfigModule[StripeConfig].toApiGatewayOp("load stripe config")
-      trustedApiConfig <- loadConfigModule[TrustedApiConfig].toApiGatewayOp("load trusted Api config")
-
-      configuredOp = operation(zuoraRestConfig, stripeConfig)
-
-    } yield (trustedApiConfig, configuredOp))
+    ApiGatewayHandler(lambdaIO) {
+      for {
+        zuoraRestConfig <- loadConfigModule[ZuoraRestConfig].toApiGatewayOp("load zuora config")
+        stripeConfig <- loadConfigModule[StripeConfig].toApiGatewayOp("load stripe config")
+        zuoraClient = ZuoraRestRequestMaker(response, zuoraRestConfig)
+        stripeChecker = StripeDeps(stripeConfig, new StripeSignatureChecker)
+        configuredOp = SourceUpdatedSteps(
+          zuoraClient,
+          stripeChecker
+        )
+      } yield configuredOp.prependValidationStep(Auth(loadConfigModule[TrustedApiConfig]))
+    }
 
   }
 

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.effects.TestingRawEffects
 import com.gu.stripeCustomerSourceUpdated.{StripeDeps, StripeSignatureChecker}
+import com.gu.util.apigateway.Auth.TrustedApiConfig
 import com.gu.util.config.ETConfig.{ETSendId, ETSendIds}
 import com.gu.util.config._
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice}

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -1,9 +1,6 @@
 package com.gu.autoCancel
 
 import com.gu.autoCancel.AutoCancelSteps.AutoCancelUrlParams
-import com.gu.util.apigateway.Auth.RequestAuth
-import com.gu.util.apigateway.ApiGatewayHandler
-import com.gu.util.config.TrustedApiConfig
 import org.scalatest._
 import play.api.libs.json.{JsSuccess, Json}
 import scalaz.{-\/, \/-}
@@ -61,18 +58,6 @@ class AutoCancelHandlerTest extends FlatSpec {
       case \/-(_) => true
       case _ => false
     }, s"We got: $apiGatewayOp")
-  }
-
-  "authenticateCallout" should "return a left if the credentials are invalid" in {
-    val requestAuth = RequestAuth(apiToken = "incorrectRequestToken")
-    val trustedApiConfig = TrustedApiConfig(apiToken = "token", tenantId = "tenant")
-    assert(ApiGatewayHandler.isAuthorised(true, Some(requestAuth), trustedApiConfig) == false)
-  }
-
-  "authenticateCallout" should "return a right if the credentials are valid" in {
-    val requestAuth = RequestAuth(apiToken = "token")
-    val trustedApiConfig = TrustedApiConfig(apiToken = "token", tenantId = "tenant")
-    assert(ApiGatewayHandler.isAuthorised(true, Some(requestAuth), trustedApiConfig) == true)
   }
 
 }

--- a/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -23,7 +23,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     val os = new ByteArrayOutputStream()
     val config = new TestingRawEffects(200, EndToEndData.responses)
     //execute
-    Lambda.runWithEffectsDontTestAtThisLevel(
+    Lambda.runForLegacyTestsSeeTestingMd(
       Stage("DEV"),
       FakeFetchString.fetchString,
       config.response,

--- a/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/EndToEndHandlerTest.scala
@@ -23,7 +23,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
     val os = new ByteArrayOutputStream()
     val config = new TestingRawEffects(200, EndToEndData.responses)
     //execute
-    Lambda.runWithEffects(
+    Lambda.runWithEffectsDontTestAtThisLevel(
       Stage("DEV"),
       FakeFetchString.fetchString,
       config.response,


### PR DESCRIPTION
This is a bit of surgery left over from tech debt to separate out the Auth by URL param (needed for zuora and stripe as they don't allow x-api-key header)
I have done a little bit of other tidy at the same time, but hopefully nothing too much!
I need to test in code, please leave comments regarding things to fix before go live, and also things not needed to fix straight away as we can always add to the tech debt.
@pvighi @jacobwinch @paulbrown1982 @twrichards 