### PR TITLE
add logic to pass through case and source

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequest.scala
@@ -11,13 +11,15 @@ case class ZuoraAccountId(value: String) extends AnyVal
 case class AddSubscriptionRequest(
   zuoraAccountId: ZuoraAccountId,
   startDate: LocalDate,
-  acquisitionSource: String,
-  createdByCSR: String,
+  acquisitionSource: AcquisitionSource,
+  createdByCSR: CreatedByCSR,
   amountMinorUnits: Int,
   acquisitionCase: CaseId
 )
 
 case class CaseId(value: String) extends AnyVal
+case class AcquisitionSource(value: String) extends AnyVal
+case class CreatedByCSR(value: String) extends AnyVal
 
 object AddSubscriptionRequest {
 
@@ -34,8 +36,8 @@ object AddSubscriptionRequest {
         AddSubscriptionRequest(
           zuoraAccountId = ZuoraAccountId(zuoraAccountId),
           startDate = parsedStartDate,
-          acquisitionSource = this.acquisitionSource,
-          createdByCSR = this.createdByCSR,
+          acquisitionSource = AcquisitionSource(this.acquisitionSource),
+          createdByCSR = CreatedByCSR(this.createdByCSR),
           amountMinorUnits = this.amountMinorUnits,
           CaseId(acquisitionCase)
         )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -42,7 +42,14 @@ object Steps {
     (for {
       request <- apiGatewayRequest.bodyAsCaseClass[AddSubscriptionRequest]().withLogging("parsed request")
       _ <- prerequesiteCheck(request.zuoraAccountId)
-      req = CreateReq(request.zuoraAccountId, request.amountMinorUnits, request.startDate, request.acquisitionCase)
+      req = CreateReq(
+        request.zuoraAccountId,
+        request.amountMinorUnits,
+        request.startDate,
+        request.acquisitionCase,
+        request.acquisitionSource,
+        request.createdByCSR
+      )
       subscriptionName <- createMonthlyContribution(req).toApiGatewayOp("create monthly contribution")
     } yield ApiGatewayResponse(body = AddedSubscription(subscriptionName.value), statusCode = "200")).apiResponse
   }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -4,10 +4,11 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 import com.gu.newproduct.api.addsubscription.ZuoraIds.PlanAndCharge
-import com.gu.newproduct.api.addsubscription.{CaseId, ZuoraAccountId}
+import com.gu.newproduct.api.addsubscription.{AcquisitionSource, CaseId, CreatedByCSR, ZuoraAccountId}
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.ClientFailableOp
 import play.api.libs.json.{Json, Reads}
+import com.gu.util.resthttp.ClientFailableOpLogging.LogImplicit2
 
 object CreateSubscription {
 
@@ -34,7 +35,9 @@ object CreateSubscription {
       renewalTerm: Int = 12,
       initialTerm: Int = 12,
       subscribeToRatePlans: List[SubscribeToRatePlans],
-      AcquisitionCase__c: String
+      AcquisitionCase__c: String,
+      AcquisitionSource__c: String,
+      CreatedByCSR__c: String
     )
     implicit val writesRequest = Json.writes[WireCreateRequest]
   }
@@ -47,6 +50,8 @@ object CreateSubscription {
       accountKey = accountId.value,
       contractEffectiveDate = start.format(DateTimeFormatter.ISO_LOCAL_DATE),
       AcquisitionCase__c = acquisitionCase.value,
+      AcquisitionSource__c = acquisitionSource.value,
+      CreatedByCSR__c = createdByCSR.value,
       subscribeToRatePlans = List(
         SubscribeToRatePlans(
           productRatePlanId = planAndCharge.productRatePlanId.value,
@@ -65,7 +70,9 @@ object CreateSubscription {
     accountId: ZuoraAccountId,
     amountMinorUnits: Int,
     start: LocalDate,
-    acquisitionCase: CaseId
+    acquisitionCase: CaseId,
+    acquisitionSource: AcquisitionSource,
+    createdByCSR: CreatedByCSR
   )
 
   case class SubscriptionName(value: String) extends AnyVal
@@ -77,7 +84,7 @@ object CreateSubscription {
     val maybeWireSubscription = post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck)
     maybeWireSubscription.map { wireSubscription =>
       SubscriptionName(wireSubscription.subscriptionNumber)
-    }
+    }.withLogging("created subscription")
   }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/AddSubscriptionRequestTest.scala
@@ -23,8 +23,8 @@ class AddSubscriptionRequestTest extends FlatSpec with Matchers {
     actual shouldBe AddSubscriptionRequest(
       zuoraAccountId = ZuoraAccountId("accountkeyValue"),
       startDate = LocalDate.of(2018, 7, 11),
-      acquisitionSource = "CSR",
-      createdByCSR = "CSRName",
+      acquisitionSource = AcquisitionSource("CSR"),
+      createdByCSR = CreatedByCSR("CSRName"),
       amountMinorUnits = 123,
       acquisitionCase = CaseId("5006E000005b5cf")
     )

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/StepsTest.scala
@@ -18,7 +18,14 @@ class StepsTest extends FlatSpec with Matchers {
   case class ExpectedOut(subscriptionNumber: String)
   "it" should "run end to end with fakes" in {
 
-    val expectedIn = CreateReq(ZuoraAccountId("acccc"), 123, LocalDate.of(2018, 7, 18), CaseId("case"))
+    val expectedIn = CreateReq(
+      ZuoraAccountId("acccc"),
+      123,
+      LocalDate.of(2018, 7, 18),
+      CaseId("case"),
+      AcquisitionSource("CSR"),
+      CreatedByCSR("bob")
+    )
 
     def fakeCreate(in: CreateSubscription.CreateReq): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
       in shouldBe expectedIn

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel._
-import com.gu.newproduct.api.addsubscription.{CaseId, ZuoraAccountId}
+import com.gu.newproduct.api.addsubscription.{AcquisitionSource, CaseId, CreatedByCSR, ZuoraAccountId}
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.resthttp.RestRequestMaker.RequestsPost
@@ -23,7 +23,9 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
       ZuoraAccountId("2c92c0f864a214c30164a8b5accb650b"),
       100,
       LocalDate.now,
-      validCaseIdToAvoidCausingSFErrors
+      validCaseIdToAvoidCausingSFErrors,
+      AcquisitionSource("sourcesource"),
+      CreatedByCSR("csrcsr")
     )
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest, WireSubscription}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{CreateReq, SubscriptionName}
-import com.gu.newproduct.api.addsubscription.{CaseId, ZuoraAccountId}
+import com.gu.newproduct.api.addsubscription.{AcquisitionSource, CaseId, CreatedByCSR, ZuoraAccountId}
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
 import org.scalatest.{FlatSpec, Matchers}
@@ -26,6 +26,8 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       renewalTerm = 12,
       initialTerm = 12,
       AcquisitionCase__c = "casecase",
+      AcquisitionSource__c = "sourcesource",
+      CreatedByCSR__c = "csrcsr",
       subscribeToRatePlans = List(
         SubscribeToRatePlans(
           productRatePlanId = "hiProductRatePlanId",
@@ -42,7 +44,9 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       accountId = ZuoraAccountId("zac"),
       amountMinorUnits = 125,
       start = LocalDate.of(2018, 7, 17),
-      acquisitionCase = CaseId("casecase")
+      acquisitionCase = CaseId("casecase"),
+      acquisitionSource = AcquisitionSource("sourcesource"),
+      createdByCSR = CreatedByCSR("csrcsr")
     )
     val actual = CreateSubscription(ids, accF)(createReq)
     actual shouldBe ClientSuccess(SubscriptionName("a-s123"))

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/ClientFailableOpLogging.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/ClientFailableOpLogging.scala
@@ -1,13 +1,13 @@
-package com.gu.util.zuora.internal
+package com.gu.util.resthttp
 
-import com.gu.util.resthttp.Types.{ClientFailure, ClientFailableOp, ClientSuccess}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess}
 import org.apache.log4j.Logger
 
-trait Logging { // in future maybe put logging into a context so the messages stack together like a stack trace
+object ClientFailableOpLogging { // in future maybe put logging into a context so the messages stack together like a stack trace
 
   val logger = Logger.getLogger(getClass.getName)
 
-  protected implicit class LogImplicit2[A](apiGatewayOp: ClientFailableOp[A]) {
+  implicit class LogImplicit2[A](apiGatewayOp: ClientFailableOp[A]) {
 
     // this is just a handy method to add logging to the end of any for comprehension
     def withLogging(message: String): ClientFailableOp[A] = {


### PR DESCRIPTION
the AcquisitionSource__c and CreatedByCSR__c were not being populated by the service layer when a sub was created despite them being passed in.  This PR fixes that.
![image](https://user-images.githubusercontent.com/7304387/42936901-632fe608-8b45-11e8-90db-a017061eee00.png)

I also moved the ClientFailableOp logging object as it was unused and I needed it to see the sub id returned from the test.

@pvighi @david-pepper 