### PR TITLE
When raising SF case, will hand back Id of applicable recent case if possible (i.e. resume case)

### DIFF
--- a/handlers/cancellation-sf-cases/build.sbt
+++ b/handlers/cancellation-sf-cases/build.sbt
@@ -16,5 +16,6 @@ riffRaffArtifactResources += (file("handlers/cancellation-sf-cases/cfn.yaml"), "
 
 libraryDependencies ++= Seq(
   "com.gu.identity" %% "identity-cookie" % "3.160",
-  "com.gu" %% "identity-test-users" % "0.7"
+  "com.gu" %% "identity-test-users" % "0.7",
+  "ai.x" %% "play-json-extensions" % "0.10.0"
 )

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -95,7 +95,7 @@ object Handler extends Logging {
     )(
       reason: Reason,
       sfCase: CaseWithId
-    ): ClientFailableOp[Unit] = sfUpdateOp(sfCase.Id, JsObject(Map("Enquiry_Type__c" -> JsString(reason.value))))
+    ): ClientFailableOp[Unit] = sfUpdateOp(sfCase.id, JsObject(Map("Enquiry_Type__c" -> JsString(reason.value))))
 
     type TNewOrResumeCase = (ContactIdContainer, SubscriptionIdContainer, Option[CaseWithId]) => ApiGatewayOp[CaseWithId]
 

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityUser.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/identity/IdentityCookieToIdentityUser.scala
@@ -9,7 +9,9 @@ object IdentityCookieToIdentityUser extends Logging {
 
   type CookieValuesToIdentityUser = (String, String) => Option[IdentityUser]
 
-  case class IdentityUser(id: String, displayName: Option[String])
+  final case class IdentityId(value: String) extends AnyVal
+
+  case class IdentityUser(id: IdentityId, displayName: Option[String])
 
   def apply(
     cookiesToIdentityUser: CookieValuesToIdentityUser
@@ -40,7 +42,7 @@ object IdentityCookieToIdentityUser extends Logging {
       userFromScGuU <- cookieDecoder.getUserDataForScGuU(scGuU)
       userFromGuU <- cookieDecoder.getUserDataForGuU(guU)
       displayName = if (userFromScGuU.id equals userFromGuU.getUser.id) userFromGuU.getUser.publicFields.displayName else None
-    } yield IdentityUser(userFromScGuU.id, displayName)
+    } yield IdentityUser(IdentityId(userFromScGuU.id), displayName)
   }
 
 }

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
@@ -18,7 +18,7 @@ object SalesforceGenericIdLookup {
   case class LookupValue(value: String) extends AnyVal
   implicit val formatLookupValue = Jsonx.formatInline[LookupValue]
 
-  case class ResponseWithId(Id: String) //TODO genericise so Id is a single value class
+  case class ResponseWithId(Id: String)
   implicit val reads = Json.reads[ResponseWithId]
 
   def apply(sfRequests: Requests)(

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
@@ -6,12 +6,14 @@ import play.api.libs.json.Json
 
 object SalesforceGenericIdLookup {
 
-  type TSalesforceGenericIdLookup = (String, String, String) => ClientFailableOp[ResponseWithId]
+  case class SalesforceGenericIdLookupParams(sfObjectType: String, fieldName: String, lookupValue: String)
+
+  type TSalesforceGenericIdLookup = SalesforceGenericIdLookupParams => ClientFailableOp[ResponseWithId]
 
   case class ResponseWithId(Id: String)
   implicit val reads = Json.reads[ResponseWithId]
 
-  def apply(sfRequests: Requests)(sfObjectType: String, fieldName: String, value: String): ClientFailableOp[ResponseWithId] =
-    sfRequests.get(s"/services/data/v29.0/sobjects/${sfObjectType}/${fieldName}/${value}")
+  def apply(sfRequests: Requests)(params: SalesforceGenericIdLookupParams): ClientFailableOp[ResponseWithId] =
+    sfRequests.get(s"/services/data/v29.0/sobjects/${params.sfObjectType}/${params.fieldName}/${params.lookupValue}")
 
 }

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
@@ -1,19 +1,31 @@
 package com.gu.salesforce
 
+import ai.x.play.json.Jsonx
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.ClientFailableOp
 import play.api.libs.json.Json
 
 object SalesforceGenericIdLookup {
 
-  case class SalesforceGenericIdLookupParams(sfObjectType: String, fieldName: String, lookupValue: String)
+  type TSalesforceGenericIdLookup = (SfObjectType, FieldName, LookupValue) => ClientFailableOp[ResponseWithId]
 
-  type TSalesforceGenericIdLookup = SalesforceGenericIdLookupParams => ClientFailableOp[ResponseWithId]
+  case class SfObjectType(value: String) extends AnyVal
+  implicit val formatSfObjectType = Jsonx.formatInline[SfObjectType]
 
-  case class ResponseWithId(Id: String)
+  case class FieldName(value: String) extends AnyVal
+  implicit val formatFieldName = Jsonx.formatInline[FieldName]
+
+  case class LookupValue(value: String) extends AnyVal
+  implicit val formatLookupValue = Jsonx.formatInline[LookupValue]
+
+  case class ResponseWithId(Id: String) //TODO genericise so Id is a single value class
   implicit val reads = Json.reads[ResponseWithId]
 
-  def apply(sfRequests: Requests)(params: SalesforceGenericIdLookupParams): ClientFailableOp[ResponseWithId] =
-    sfRequests.get(s"/services/data/v29.0/sobjects/${params.sfObjectType}/${params.fieldName}/${params.lookupValue}")
+  def apply(sfRequests: Requests)(
+    sfObjectType: SfObjectType,
+    fieldName: FieldName,
+    lookupValue: LookupValue
+  ): ClientFailableOp[ResponseWithId] =
+    sfRequests.get[ResponseWithId](s"/services/data/v29.0/sobjects/${sfObjectType.value}/${fieldName.value}/${lookupValue.value}")
 
 }

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/cases/SalesforceCase.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/cases/SalesforceCase.scala
@@ -42,7 +42,7 @@ object SalesforceCase extends Logging {
       Subject: CaseSubject,
       Origin: String = CASE_ORIGIN
     )
-    implicit val writes = Json.writes[WireNewCase]
+    implicit val writesWireNewCase = Json.writes[WireNewCase]
 
     def apply(sfRequests: Requests)(newCase: WireNewCase): ClientFailableOp[CaseWithId] =
       sfRequests.post[WireNewCase, CaseWithId](newCase, caseSObjectsBaseUrl)

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/cases/SalesforceCase.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/cases/SalesforceCase.scala
@@ -7,11 +7,16 @@ import play.api.libs.json.{JsValue, Json, Reads}
 
 object SalesforceCase extends Logging {
 
-  private val caseBaseUrl = "/services/data/v29.0/sobjects/Case"
+  private val caseBaseUrl = "/services/data/v29.0"
+  private val caseSObjectsBaseUrl = caseBaseUrl + "/sobjects/Case"
+  private val caseSoqlQueryBaseUrl = caseBaseUrl + "/query/?q="
+
+  case class CaseWithId(Id: String)
+  implicit val caseWithIdReads = Json.reads[CaseWithId]
 
   object Raise {
 
-    type RaiseCase = NewCase => ClientFailableOp[RaiseCaseResponse]
+    type RaiseCase = NewCase => ClientFailableOp[CaseWithId]
 
     // NOTE : Case Owner is set by SF Rule based on Origin='Self Service'
     case class NewCase(
@@ -26,25 +31,51 @@ object SalesforceCase extends Logging {
     )
     implicit val writes = Json.writes[NewCase]
 
-    case class RaiseCaseResponse(id: String)
-    implicit val reads = Json.reads[RaiseCaseResponse]
-
-    def apply(sfRequests: Requests)(newCase: NewCase): ClientFailableOp[RaiseCaseResponse] =
-      sfRequests.post(newCase, caseBaseUrl)
+    def apply(sfRequests: Requests)(newCase: NewCase): ClientFailableOp[CaseWithId] =
+      sfRequests.post(newCase, caseSObjectsBaseUrl)
 
   }
 
   object Update {
 
     def apply(sfRequests: Requests)(caseId: String, body: JsValue): ClientFailableOp[Unit] =
-      sfRequests.patch(body, s"${caseBaseUrl}/${caseId}")
+      sfRequests.patch(body, s"$caseSObjectsBaseUrl/$caseId")
 
   }
 
   object GetById {
 
     def apply[ResponseType](sfRequests: Requests)(caseId: String)(implicit ev1: Reads[ResponseType]): ClientFailableOp[ResponseType] =
-      sfRequests.get(s"${caseBaseUrl}/${caseId}")
+      sfRequests.get[ResponseType](s"$caseSObjectsBaseUrl/$caseId")
+  }
+
+  object GetMostRecentCaseByContactId {
+
+    case class GetMostRecentCaseByContactIdParams(
+      contactId: String,
+      caseOrigin: String,
+      subscriptionId: String,
+      caseSubject: String,
+      limit: Int = 1
+    )
+    type TGetMostRecentCaseByContactId = GetMostRecentCaseByContactIdParams => ClientFailableOp[RecentCases]
+
+    case class RecentCases(records: List[CaseWithId])
+    implicit val readsCases = Json.reads[RecentCases]
+
+    def apply(sfRequests: Requests)(params: GetMostRecentCaseByContactIdParams): ClientFailableOp[RecentCases] = {
+      val soqlQuery = s"SELECT Id " +
+          s"FROM Case " +
+          s"WHERE ContactId = '${params.contactId}' " +
+          s"AND Origin = '${params.caseOrigin}' " +
+          s"AND CreatedDate = LAST_N_DAYS:3 " +
+          s"AND SF_Subscription__c = '${params.subscriptionId}' " +
+          s"AND Subject = '${params.caseSubject}' " +
+          s"ORDER BY CreatedDate DESC " +
+          s"LIMIT ${params.limit}"
+      logger.info(soqlQuery)
+      sfRequests.get[RecentCases](s"$caseSoqlQueryBaseUrl$soqlQuery")
+    }
   }
 
 }

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -25,7 +25,6 @@ class EndToEndHandlerEffectsTest extends FlatSpec with Matchers {
   def getCaseSteps(sfBackendForIdentityCookieHeader: SfBackendForIdentityCookieHeader)(apiGatewayRequest: ApiGatewayRequest) =
     (for {
       identityAndSfRequests <- sfBackendForIdentityCookieHeader(apiGatewayRequest.headers)
-      // TODO verify case belongs to identity user
       pathParams <- apiGatewayRequest.pathParamsAsCaseClass[CasePathParams]()
       sfGet = SalesforceCase.GetById[JsValue](identityAndSfRequests.sfRequests)_
       getCaseResponse <- sfGet(pathParams.caseId).toApiGatewayOp("get case detail")

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -46,20 +46,20 @@ class EndToEndHandlerEffectsTest extends FlatSpec with Matchers {
       Handler.RaiseCase.steps
     )
 
-    firstRaiseCaseResponse.Id shouldEqual secondRaiseCaseResponse.Id
+    firstRaiseCaseResponse.id shouldEqual secondRaiseCaseResponse.id
 
     val expectedDescription = "EndToEndTest"
 
     // update case by setting 'Description' field
     getResponse[JsValue](
-      updateCaseRequest(firstRaiseCaseResponse.Id.value, expectedDescription),
+      updateCaseRequest(firstRaiseCaseResponse.id.value, expectedDescription),
       Handler.UpdateCase.steps
     )
 
     // fetch the case to ensure the 'Description' field has been updated
     implicit val getDetailReads: Reads[GetCaseResponse] = Json.reads[GetCaseResponse]
     val getCaseDetailResponse = getResponse[GetCaseResponse](
-      getCaseDetailRequest(firstRaiseCaseResponse.Id.value),
+      getCaseDetailRequest(firstRaiseCaseResponse.id.value),
       getCaseSteps
     )
 

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -54,36 +54,41 @@ object ApiGatewayResponse extends Logging {
     ApiResponse(statusCode, bodyTxt)
   }
 
-  val successfulExecution = ApiResponse(
+  val successfulExecution = messageResponse(
     "200",
-    toJsonBody(ResponseBody("Success"))
+    "Success"
   )
 
-  def noActionRequired(reason: String) = ApiResponse(
+  def noActionRequired(reason: String) = messageResponse(
     "200",
-    toJsonBody(ResponseBody(s"Processing is not required: $reason"))
+    s"Processing is not required: $reason"
   )
 
-  def badRequest(reason: String) = ApiResponse(
+  def badRequest(reason: String) = messageResponse(
     "400",
-    toJsonBody(ResponseBody(s"Failure to parse JSON successfully: $reason"))
+    s"Failure to parse JSON successfully: $reason"
   )
 
-  val unauthorized = ApiResponse(
+  val unauthorized = messageResponse(
     "401",
-    toJsonBody(ResponseBody("Credentials are missing or invalid"))
+    "Credentials are missing or invalid"
   )
 
-  def notFound(message: String) = ApiResponse(
+  def forbidden(message: String) = messageResponse(
+    "403",
+    message
+  )
+
+  def notFound(message: String) = messageResponse(
     "404",
-    toJsonBody(ResponseBody(message))
+    message
   )
 
   def internalServerError(error: String) = {
     logger.error(s"Processing failed due to $error")
-    ApiResponse(
+    messageResponse(
       "500",
-      toJsonBody(ResponseBody(s"Internal server error"))
+      "Internal server error"
     )
   }
 


### PR DESCRIPTION
As anticipated, based on some users changing cancellation reason in the online flow, cases are being created which look like 'saves' when in fact the user goes on to cancel with a different reason. 

This change will address this problem. A 'suitable recent case' is as follows...
- same contactId as the authenticated user (obviously)
- same subject as the starting subject for new cases ("Online Cancellation Attempt")
- origin is self service
- case was created in the last 3 days
- same subscription as the raise case request

PLUS some refactoring and some old TODOs (update case now verifies case belongs to authenticated user)