### PR TITLE
do the SF PATCH request against SF not zuora!

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val `zuora-retention` = all(project in file("handlers/zuora-retention"))
 
 lazy val `sf-contact-merge` = all(project in file("handlers/sf-contact-merge"))
   .enablePlugins(RiffRaffArtifact)
-  .dependsOn(zuora, handler, effectsDepIncludingTestFolder, testDep)
+  .dependsOn(zuora, salesforce, handler, effectsDepIncludingTestFolder, testDep)
 
 lazy val `cancellation-sf-cases` = all(project in file("handlers/cancellation-sf-cases"))
   .enablePlugins(RiffRaffArtifact)

--- a/handlers/sf-contact-merge/cfn.yaml
+++ b/handlers/sf-contact-merge/cfn.yaml
@@ -56,7 +56,7 @@ Resources:
                             Action: s3:GetObject
                             Resource:
                             - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}.*.json
-                            - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/trustedApi-${Stage}.*.json
+                            - !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfAuth-${Stage}.*.json
     SfContactMergeLambda:
         Type: AWS::Lambda::Function
         Properties:

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -45,19 +45,18 @@ object Handler {
       sfConfig <- loadConfig[SFAuthConfig].toApiGatewayOp("load trusted Api config")
       sfRequests <- SalesforceAuthenticate(getResponse, sfConfig)
 
-      wiredSteps = Steps(
-        GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier, _),
-        ValidationSteps(_, _),
-        UpdateSteps(
-          UpdateSalesforceIdentityId(sfRequests.patch),
-          UpdateAccountSFLinks(requests.put),
-          _,
-          _,
-          _
-        ),
-        _: ApiGatewayRequest
-      )
-    } yield Operation.noHealthcheck(wiredSteps)
+    } yield Operation.noHealthcheck(Steps(
+      GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier, _),
+      ValidationSteps(_, _),
+      UpdateSteps(
+        UpdateSalesforceIdentityId(sfRequests.patch),
+        UpdateAccountSFLinks(requests.put),
+        _,
+        _,
+        _
+      ),
+      _
+    ))
   }
 
 }

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetContacts.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetContacts.scala
@@ -20,7 +20,7 @@ object GetContacts {
   case class WireAccount(BillToId: String, IdentityId__c: Option[String], sfContactId__c: String)
   implicit val readWireAccount = Json.reads[WireAccount]
 
-  def apply(zuoraQuerier: ZuoraQuerier)(accountIds: NonEmptyList[AccountId]): ClientFailableOp[Map[ContactId, IdentityAndSFContact]] =
+  def apply(zuoraQuerier: ZuoraQuerier, accountIds: NonEmptyList[AccountId]): ClientFailableOp[Map[ContactId, IdentityAndSFContact]] =
     for {
       or <- OrTraverse(accountIds) { accountId =>
         zoql"""Id = ${accountId.value}"""

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetEmails.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetEmails.scala
@@ -16,7 +16,7 @@ object GetEmails {
   case class WireContact(Id: String, WorkEmail: Option[String])
   implicit val readWireContact = Json.reads[WireContact]
 
-  def apply(zuoraQuerier: ZuoraQuerier)(contactIds: NonEmptyList[ContactId]): ClientFailableOp[Map[ContactId, Option[EmailAddress]]] =
+  def apply(zuoraQuerier: ZuoraQuerier, contactIds: NonEmptyList[ContactId]): ClientFailableOp[Map[ContactId, Option[EmailAddress]]] =
     for {
       or <- OrTraverse(contactIds) { accountId =>
         zoql"""Id = ${accountId.value}"""

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetIdentityAndZuoraEmailsForAccountsSteps.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetIdentityAndZuoraEmailsForAccountsSteps.scala
@@ -15,10 +15,10 @@ object GetIdentityAndZuoraEmailsForAccountsSteps {
     emailAddress: Option[EmailAddress]
   )
 
-  def apply(zuoraQuerier: ZuoraQuerier)(accountIds: NonEmptyList[AccountId]): ClientFailableOp[List[IdentityAndSFContactAndEmail]] = {
+  def apply(zuoraQuerier: ZuoraQuerier, accountIds: NonEmptyList[AccountId]): ClientFailableOp[List[IdentityAndSFContactAndEmail]] = {
 
-    val getEmails = GetEmails(zuoraQuerier)_
-    val getContacts = GetContacts(zuoraQuerier)_
+    val getEmails: NonEmptyList[GetEmails.ContactId] => ClientFailableOp[Map[GetEmails.ContactId, Option[EmailAddress]]] = GetEmails(zuoraQuerier, _)
+    val getContacts: NonEmptyList[AccountId] => ClientFailableOp[Map[GetEmails.ContactId, GetContacts.IdentityAndSFContact]] = GetContacts(zuoraQuerier, _)
 
     for {
       identityForBillingContact <- getContacts(accountIds)

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetIdentityAndZuoraEmailsForAccountsSteps.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/getaccounts/GetIdentityAndZuoraEmailsForAccountsSteps.scala
@@ -17,8 +17,10 @@ object GetIdentityAndZuoraEmailsForAccountsSteps {
 
   def apply(zuoraQuerier: ZuoraQuerier, accountIds: NonEmptyList[AccountId]): ClientFailableOp[List[IdentityAndSFContactAndEmail]] = {
 
-    val getEmails: NonEmptyList[GetEmails.ContactId] => ClientFailableOp[Map[GetEmails.ContactId, Option[EmailAddress]]] = GetEmails(zuoraQuerier, _)
-    val getContacts: NonEmptyList[AccountId] => ClientFailableOp[Map[GetEmails.ContactId, GetContacts.IdentityAndSFContact]] = GetContacts(zuoraQuerier, _)
+    val getEmails: NonEmptyList[GetEmails.ContactId] => ClientFailableOp[Map[GetEmails.ContactId, Option[EmailAddress]]] =
+      GetEmails(zuoraQuerier, _)
+    val getContacts: NonEmptyList[AccountId] => ClientFailableOp[Map[GetEmails.ContactId, GetContacts.IdentityAndSFContact]] =
+      GetContacts(zuoraQuerier, _)
 
     for {
       identityForBillingContact <- getContacts(accountIds)

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSteps.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSteps.scala
@@ -10,8 +10,7 @@ object UpdateSteps {
 
   def apply(
     setOrClearIdentityId: ((SFContactId, Option[IdentityId])) => ClientFailableOp[Unit],
-    updateAccountSFLinks: LinksFromZuora => AccountId => ClientFailableOp[Unit]
-  )(
+    updateAccountSFLinks: LinksFromZuora => AccountId => ClientFailableOp[Unit],
     sfPointer: LinksFromZuora,
     maybeOldContactId: Option[SFContactId],
     accountIds: NonEmptyList[AccountId]

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -109,7 +109,13 @@ object EndToEndTest {
       |    "done": true
       |}""".stripMargin.replaceAll("""\n""", "")
 
-  val sfAuthReq = """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""
+  val sfAuthReq =
+    "client_id=clientsfclient&" +
+      "client_secret=clientsecretsfsecret&" +
+      "username=usernamesf&" +
+      "password=passSFpasswordtokentokenSFtoken&" +
+      "grant_type=password"
+
   val sfAuthResponse = """{"access_token":"aaaccess", "instance_url":"https://iinstance"}"""
 
   val updateAccountRequestBody = """{"crmId":"sfacc","sfContactId__c":"newSFCont","IdentityId__c":"identest"}"""

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -109,6 +109,9 @@ object EndToEndTest {
       |    "done": true
       |}""".stripMargin.replaceAll("""\n""", "")
 
+  val sfAuthReq = """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""
+  val sfAuthResponse = """{"access_token":"aaaccess", "instance_url":"https://iinstance"}"""
+
   val updateAccountRequestBody = """{"crmId":"sfacc","sfContactId__c":"newSFCont","IdentityId__c":"identest"}"""
   val removeIdentityBody = """{"IdentityID__c":""}"""
   val addIdentityBody = """{"IdentityID__c":"identest"}"""
@@ -116,12 +119,13 @@ object EndToEndTest {
   val updateAccountResponse = HTTPResponse(200, """{"Success": true}""")
 
   val mock = new TestingRawEffects(postResponses = Map(
+    POSTRequest("/services/oauth2/token", sfAuthReq) -> HTTPResponse(200, sfAuthResponse),
     POSTRequest("/action/query", accountQueryRequest) -> HTTPResponse(200, accountQueryResponse),
     POSTRequest("/action/query", contactQueryRequest) -> HTTPResponse(200, contactQueryResponse),
     POSTRequest("/accounts/2c92c0f9624bbc5f016253e573970b16", updateAccountRequestBody, "PUT") -> updateAccountResponse,
     POSTRequest("/accounts/2c92c0f8644618e30164652a558c6e20", updateAccountRequestBody, "PUT") -> updateAccountResponse,
-    POSTRequest("/services/data/v20.0/sobjects/Contact/oldSFCont", removeIdentityBody, "PATCH") -> updateAccountResponse,
-    POSTRequest("/services/data/v20.0/sobjects/Contact/newSFCont", addIdentityBody, "PATCH") -> updateAccountResponse
+    POSTRequest("/data/v20.0/sobjects/Contact/oldSFCont", removeIdentityBody, "PATCH") -> updateAccountResponse,
+    POSTRequest("/data/v20.0/sobjects/Contact/newSFCont", addIdentityBody, "PATCH") -> updateAccountResponse
   ))
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetContactsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetContactsTest.scala
@@ -14,8 +14,8 @@ class GetContactsTest extends FlatSpec with Matchers {
   it should "work" in {
 
     val zuoraQuerier = FakeZuoraQuerier(accountQueryRequest, accountQueryResponse)
-    val getContacts = GetContacts(zuoraQuerier)_
-    val actual = getContacts(NonEmptyList(
+
+    val actual = GetContacts(zuoraQuerier, NonEmptyList(
       AccountId("acid1"),
       AccountId("acid2")
     ))

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetEmailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetEmailsTest.scala
@@ -15,8 +15,8 @@ class GetEmailsTest extends FlatSpec with Matchers {
     val expectedQuery = """SELECT Id, WorkEmail FROM Contact WHERE Id = 'cid1' or Id = 'cid2'"""
 
     val querier = FakeZuoraQuerier(expectedQuery, contactQueryResponse)
-    val getContacts = GetEmails(querier)_
-    val actual = getContacts(NonEmptyList(
+
+    val actual = GetEmails(querier, NonEmptyList(
       ContactId("cid1"),
       ContactId("cid2")
     ))

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetZuoraEmailsForAccountsEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetZuoraEmailsForAccountsEffectsTest.scala
@@ -22,7 +22,7 @@ class GetZuoraEmailsForAccountsEffectsTest extends FlatSpec with Matchers {
     val actual = for {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig].toApiGatewayOp("parse config")
       zuoraQuerier = ZuoraQuery(ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig))
-      getZuoraEmailsForAccounts = GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier) _
+      getZuoraEmailsForAccounts = GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier, _: NonEmptyList[AccountId])
       maybeEmailAddresses <- getZuoraEmailsForAccounts(testData).toApiGatewayOp("get zuora emails for accounts")
     } yield maybeEmailAddresses
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/UpdateStepsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/UpdateStepsTest.scala
@@ -29,8 +29,6 @@ class UpdateStepsTest extends FlatSpec with Matchers {
       ClientSuccess(())
     }
 
-    val wired = UpdateSteps((setOrClearIdentityId _).tupled, updateAccountSFLinks) _
-
     val accountIds: NonEmptyList[GetContacts.AccountId] =
       NonEmptyList(AccountId("account1"))
 
@@ -38,7 +36,7 @@ class UpdateStepsTest extends FlatSpec with Matchers {
     val sfPointer = LinksFromZuora(SFContactId("contnew"), CRMAccountId("crmcrm"), maybeIdentityId)
     val maybeContactId = Some(SFContactId("contold"))
 
-    val actual = wired(sfPointer, maybeContactId, accountIds)
+    val actual = UpdateSteps((setOrClearIdentityId _).tupled, updateAccountSFLinks, sfPointer, maybeContactId, accountIds)
 
     order.reverse should be(List("doLink", "clear contold"))
     actual should be(ClientSuccess(()))
@@ -68,14 +66,12 @@ class UpdateStepsTest extends FlatSpec with Matchers {
       ClientSuccess(())
     }
 
-    val wired = UpdateSteps((setOrClearIdentityId _).tupled, updateAccountSFLinks) _
-
     val accountIds: NonEmptyList[GetContacts.AccountId] =
       NonEmptyList(AccountId("account1"))
 
     val maybeContactId = Some(SFContactId("contold"))
 
-    val actual = wired(sfPointer, maybeContactId, accountIds)
+    val actual = UpdateSteps((setOrClearIdentityId _).tupled, updateAccountSFLinks, sfPointer, maybeContactId, accountIds)
 
     order.reverse should be(List("doLink", "clear", "addidentity contnew"))
     actual should be(ClientSuccess(()))


### PR DESCRIPTION
@pvighi 
I accidentally used the zuoraRequests object rather than the sf one for the PATCH request.  The type checker didn't really save me from that error.  Perhaps the SFAuthenticate or the ZuoraRestRequestMaker should return a suitable type parameter so we can't do this!

I have also tweaked it all to use the non curried functions in all the wiring, see what you think.
