### PR TITLE
capture the gaData in the SF cancellation case so we can see if the A/B test variants affected the users actions

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -68,7 +68,8 @@ object Handler extends Logging {
     case class RaiseCaseDetail(
       product: ProductName,
       reason: Reason,
-      subscriptionName: SubscriptionName
+      subscriptionName: SubscriptionName,
+      gaData: String
     )
     implicit val readsRaiseCaseDetail = Json.reads[RaiseCaseDetail]
     implicit val writesCaseWithId = Json.writes[CaseWithId]
@@ -86,6 +87,7 @@ object Handler extends Logging {
         SF_Subscription__c = SubscriptionId(sfSubscriptionIdContainer.Id),
         Journey__c = "SV - At Risk - MB",
         Enquiry_Type__c = raiseCaseDetail.reason.value,
+        Case_Closure_Reason__c = raiseCaseDetail.gaData,
         Status = "Closed",
         Subject = CaseSubject(STARTING_CASE_SUBJECT)
       )

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -60,6 +60,9 @@ object Handler extends Logging {
     final case class SubscriptionName(value: String) extends AnyVal
     implicit val formatSubscriptionName = Jsonx.formatInline[SubscriptionName]
 
+    final case class GaDataJsonString(value: String) extends AnyVal
+    implicit val formatGaDataJsonString = Jsonx.formatInline[GaDataJsonString]
+
     final case class ContactIdContainer(Id: String)
     implicit val readsContactIdContainer = Json.reads[ContactIdContainer]
     final case class SubscriptionIdContainer(Id: String)
@@ -69,7 +72,7 @@ object Handler extends Logging {
       product: ProductName,
       reason: Reason,
       subscriptionName: SubscriptionName,
-      gaData: String
+      gaData: GaDataJsonString
     )
     implicit val readsRaiseCaseDetail = Json.reads[RaiseCaseDetail]
     implicit val writesCaseWithId = Json.writes[CaseWithId]
@@ -87,7 +90,7 @@ object Handler extends Logging {
         SF_Subscription__c = SubscriptionId(sfSubscriptionIdContainer.Id),
         Journey__c = "SV - At Risk - MB",
         Enquiry_Type__c = raiseCaseDetail.reason.value,
-        Case_Closure_Reason__c = raiseCaseDetail.gaData,
+        Case_Closure_Reason__c = raiseCaseDetail.gaData.value,
         Status = "Closed",
         Subject = CaseSubject(STARTING_CASE_SUBJECT)
       )

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/cases/SalesforceCase.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/cases/SalesforceCase.scala
@@ -38,6 +38,7 @@ object SalesforceCase extends Logging {
       Product__c: String,
       Journey__c: String,
       Enquiry_Type__c: String,
+      Case_Closure_Reason__c: String,
       Status: String,
       Subject: CaseSubject,
       Origin: String = CASE_ORIGIN

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -152,7 +152,9 @@ object EndToEndData {
     bodyString = "{" +
       s"""\\\"reason\\\":\\\"${Random.alphanumeric.take(10).mkString}\\\",""" +
       "\\\"product\\\":\\\"Membership\\\"," +
-      "\\\"subscriptionName\\\":\\\"A-S00045062\\\"" +
+      "\\\"subscriptionName\\\":\\\"A-S00045062\\\"," +
+      "\\\"gaData\\\":\\\"{\\\\\\\"UA-51507017-5\\\\\\\":{\\\\\\\"experiments\\\\\\\":" +
+      "{\\\\\\\"9ycLuqmFRBGBDGV5bnFlCA\\\\\\\":\\\\\\\"1\\\\\\\"},\\\\\\\"hitcount\\\\\\\":3}\\\"" +
       "}"
   )
 

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/HandlerTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/HandlerTest.scala
@@ -1,0 +1,48 @@
+package com.gu.cancellation.sf_cases
+
+import com.gu.cancellation.sf_cases.Handler.RaiseCase
+import com.gu.cancellation.sf_cases.Handler.RaiseCase._
+import com.gu.salesforce.cases.SalesforceCase.Create.WireNewCase
+import com.gu.salesforce.cases.SalesforceCase.{CaseSubject, ContactId, SubscriptionId}
+import org.scalatest.{FlatSpec, Matchers}
+
+class HandlerTest extends FlatSpec with Matchers {
+
+  it should "convert the raise case post body, sub id and contact id to a WireNewCase" in {
+
+    val subId = SubscriptionIdContainer("subID")
+    val contactId = ContactIdContainer("contactID")
+    val product = ProductName("Membership")
+    val reason = Reason("mma_editorial")
+    val subName = SubscriptionName("A-S12345678")
+    val gaData = GaDataJsonString(
+      "{\"UA-51507017-5\":{\"experiments\":{\"9ycLuqmFRBGBDGV5bnFlCA\":\"1\"},\"hitcount\":3}}"
+    )
+
+    val actual = RaiseCase.buildWireNewCaseForSalesforce(
+      RaiseCaseDetail(
+        product,
+        reason,
+        subName,
+        gaData
+      ),
+      subId,
+      contactId
+    )
+
+    val expected = WireNewCase(
+      ContactId = ContactId(contactId.Id),
+      Product__c = product.value,
+      SF_Subscription__c = SubscriptionId(subId.Id),
+      Journey__c = "SV - At Risk - MB",
+      Enquiry_Type__c = reason.value,
+      Case_Closure_Reason__c = gaData.value,
+      Status = "Closed",
+      Subject = CaseSubject(STARTING_CASE_SUBJECT)
+    )
+
+    actual shouldEqual expected
+
+  }
+
+}


### PR DESCRIPTION
minor change to forward on some extra GA data into the salesforce case for better reporting down the line