### PR TITLE
Hard coded catalog values

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -7,8 +7,17 @@ import com.gu.newproduct.api.productcatalog.PlanId._
 
 case class Catalog(
   voucherWeekend: Plan,
+  voucherSaturday: Plan,
+  voucherSunday:Plan,
   voucherEveryDay: Plan,
-  monthlyContribution: Plan
+  voucherSixDay: Plan,
+  voucherWeekendPlus: Plan,
+  voucherSaturdayPlus: Plan,
+  voucherSundayPlus:Plan,
+  voucherEveryDayPlus: Plan,
+  voucherSixDayPlus: Plan,
+  monthlyContribution: Plan,
+
 )
 
 object NewProductApi {
@@ -26,29 +35,25 @@ object NewProductApi {
     val voucherSundayDateRules = voucherDateRules(List(SUNDAY))
     val voucherSaturdayDateRules = voucherDateRules(List(SATURDAY))
 
-    val voucherWeekend = Plan(VoucherWeekend, voucherSaturdayDateRules, monthlyPayment("20.76"))
-    val voucherEveryDay = Plan(VoucherEveryDay, voucherMondayRules, monthlyPayment("47.62"))
-    val voucherSixDay = Plan(VoucherSixDay, voucherMondayRules, monthlyPayment("41.12"))
-    val voucherSaturday = Plan(VoucherSaturday, voucherSaturdayDateRules, monthlyPayment("10.36"))
-    val voucherSunday = Plan(VoucherSunday, voucherSundayDateRules, monthlyPayment("10.79"))
-
-    val voucherWeekendPlus = Plan(VoucherWeekendPlus, voucherSaturdayDateRules, monthlyPayment("29.42"))
-    val voucherEveryDayPlus = Plan(VoucherEveryDayPlus, voucherMondayRules, monthlyPayment("51.96"))
-    val voucherSixDayPlus = Plan(VoucherSixDayPlus, voucherMondayRules, monthlyPayment("47.62"))
-    val voucherSaturdayPlus = Plan(VoucherSaturdayPlus, voucherSaturdayDateRules, monthlyPayment("21.62"))
-    val voucherSundayPlus = Plan(VoucherSundayPlus, voucherSundayDateRules, monthlyPayment("22.06"))
-
     val monthlyContributionWindow = WindowRule(
       maybeSize = Some(WindowSizeDays(1)),
       maybeCutOffDay = None,
       maybeStartDelay = None
     )
     val monthlyContributionRules = StartDateRules(windowRule = Some(monthlyContributionWindow))
-    val monthlyContribution = Plan(MonthlyContribution, monthlyContributionRules)
+
     Catalog(
-      voucherWeekend = voucherWeekend,
-      voucherEveryDay = voucherEveryDay,
-      monthlyContribution = monthlyContribution
+      voucherWeekendPlus = Plan(VoucherWeekendPlus, voucherSaturdayDateRules, monthlyPayment("29.42")),
+      voucherWeekend = Plan(VoucherWeekend, voucherSaturdayDateRules, monthlyPayment("20.76")),
+      voucherSixDay = Plan(VoucherSixDay, voucherMondayRules, monthlyPayment("41.12")),
+      voucherSixDayPlus = Plan(VoucherSixDayPlus, voucherMondayRules, monthlyPayment("47.62")),
+      voucherEveryDay = Plan(VoucherEveryDay, voucherMondayRules, monthlyPayment("47.62")),
+      voucherEveryDayPlus = Plan(VoucherEveryDayPlus, voucherMondayRules, monthlyPayment("51.96")),
+      voucherSaturday = Plan(VoucherSaturday, voucherSaturdayDateRules, monthlyPayment("10.36")),
+      voucherSaturdayPlus = Plan(VoucherSaturdayPlus, voucherSaturdayDateRules, monthlyPayment("21.62")),
+      voucherSunday = Plan(VoucherSunday, voucherSundayDateRules, monthlyPayment("10.79")),
+      voucherSundayPlus = Plan(VoucherSundayPlus, voucherSundayDateRules, monthlyPayment("22.06")),
+      monthlyContribution = Plan(MonthlyContribution, monthlyContributionRules)
     )
   }
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -3,7 +3,7 @@ package com.gu.newproduct.api.productcatalog
 import java.time.DayOfWeek
 import java.time.DayOfWeek._
 
-import com.gu.newproduct.api.productcatalog.PlanId.{MonthlyContribution, VoucherEveryDay, VoucherWeekend}
+import com.gu.newproduct.api.productcatalog.PlanId._
 
 case class Catalog(
   voucherWeekend: Plan,
@@ -13,17 +13,31 @@ case class Catalog(
 
 object NewProductApi {
   val catalog: Catalog = {
+    def monthlyPayment(priceInPounds: String) = Some(PaymentPlan(s"£$priceInPounds every month"))
     val voucherWindowRule = WindowRule(
       maybeCutOffDay = Some(DayOfWeek.TUESDAY),
       maybeStartDelay = Some(DelayDays(20)),
       maybeSize = Some(WindowSizeDays(28))
     )
-    val weekendRule = DaysOfWeekRule(List(SATURDAY, SUNDAY))
-    val mondayRule = DaysOfWeekRule(List(MONDAY))
-    val voucherWeekendDateRules = StartDateRules(Some(weekendRule), Some(voucherWindowRule))
-    val voucherWeekend = Plan(VoucherWeekend, voucherWeekendDateRules)
-    val voucherEveryDayDateRules = StartDateRules(Some(mondayRule), Some(voucherWindowRule))
-    val voucherEveryDay = Plan(VoucherEveryDay, voucherEveryDayDateRules)
+
+    def voucherDateRules(allowedDays: List[DayOfWeek]) = StartDateRules(Some(DaysOfWeekRule(allowedDays)), Some(voucherWindowRule))
+
+    val voucherMondayRules = voucherDateRules(List(MONDAY))
+    val voucherSundayDateRules = voucherDateRules(List(SUNDAY))
+    val voucherSaturdayDateRules = voucherDateRules(List(SATURDAY))
+
+    val voucherWeekend = Plan(VoucherWeekend, voucherSaturdayDateRules, monthlyPayment("20.76"))
+    val voucherEveryDay = Plan(VoucherEveryDay, voucherMondayRules, monthlyPayment("47.62"))
+    val voucherSixDay = Plan(VoucherSixDay, voucherMondayRules, monthlyPayment("41.12"))
+    val voucherSaturday = Plan(VoucherSaturday, voucherSaturdayDateRules, monthlyPayment("10.36"))
+    val voucherSunday = Plan(VoucherSunday, voucherSundayDateRules, monthlyPayment("10.79"))
+
+    val voucherWeekendPlus = Plan(VoucherWeekendPlus, voucherSaturdayDateRules, monthlyPayment("29.42"))
+    val voucherEveryDayPlus = Plan(VoucherEveryDayPlus, voucherMondayRules, monthlyPayment("51.96"))
+    val voucherSixDayPlus = Plan(VoucherSixDayPlus, voucherMondayRules, monthlyPayment("47.62"))
+    val voucherSaturdayPlus = Plan(VoucherSaturdayPlus, voucherSaturdayDateRules, monthlyPayment("21.62"))
+    val voucherSundayPlus = Plan(VoucherSundayPlus, voucherSundayDateRules, monthlyPayment("22.06"))
+
     val monthlyContributionWindow = WindowRule(
       maybeSize = Some(WindowSizeDays(1)),
       maybeCutOffDay = None,
@@ -38,18 +52,36 @@ object NewProductApi {
     )
   }
 }
+
 sealed abstract class PlanId(val name: String)
+
 object PlanId {
+
   case object MonthlyContribution extends PlanId("monthly_contribution")
+
   case object VoucherWeekend extends PlanId("voucher_weekend")
   case object VoucherEveryDay extends PlanId("voucher_everyday")
+  case object VoucherSixDay extends PlanId("voucher_sixday")
+  case object VoucherSaturday extends PlanId("voucher_saturday")
+  case object VoucherSunday extends PlanId("voucher_sunday")
+
+  case object VoucherWeekendPlus extends PlanId("voucher_weekend_plus")
+  case object VoucherEveryDayPlus extends PlanId("voucher_everyday_plus")
+  case object VoucherSixDayPlus extends PlanId("voucher_sixday_plus")
+  case object VoucherSaturdayPlus extends PlanId("voucher_saturday_plus")
+  case object VoucherSundayPlus extends PlanId("voucher_sunday_plus")
+
   val supported = List(MonthlyContribution)
+
   def fromName(name: String): Option[PlanId] = supported.find(_.name == name)
 }
 
-case class Plan(id: PlanId, startDateRules: StartDateRules = StartDateRules())
+case class Plan(id: PlanId, startDateRules: StartDateRules = StartDateRules(), paymentPlan: Option[PaymentPlan] = None)
+
+case class PaymentPlan(description: String)
 
 case class DelayDays(value: Int) extends AnyVal
+
 case class WindowSizeDays(value: Int) extends AnyVal
 
 sealed trait DateRule

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -24,7 +24,8 @@ object WireModel {
   case class WirePlanInfo(
     id: String,
     label: String,
-    startDateRules: Option[WireStartDateRules] = None
+    startDateRules: Option[WireStartDateRules] = None,
+    paymentPlan: Option[String] = None
   )
 
   case class WireSelectableWindow(
@@ -84,7 +85,8 @@ object WireModel {
       WirePlanInfo(
         id = plan.id.name,
         label = label,
-        startDateRules = toOptionalWireRules(plan.startDateRules)
+        startDateRules = toOptionalWireRules(plan.startDateRules),
+        paymentPlan = plan.paymentPlan.map(_.description)
       )
     }
   }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -103,15 +103,15 @@ object WireModel {
         label = "Voucher",
         plans = List(
           WirePlanInfo.fromPlan(catalog.voucherWeekend, "Weekend"),
-          WirePlanInfo.fromPlan(catalog.voucherEveryDay, "Every day"),
-          WirePlanInfo.fromPlan(catalog.voucherSixDay, "Six day"),
-          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Saturday"),
-          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Sunday"),
           WirePlanInfo.fromPlan(catalog.voucherWeekendPlus, "Weekend+"),
-          WirePlanInfo.fromPlan(catalog.voucherEveryDayPlus, "Every day+"),
-          WirePlanInfo.fromPlan(catalog.voucherSixDayPlus, "Six day+"),
+          WirePlanInfo.fromPlan(catalog.voucherSunday, "Sunday"),
+          WirePlanInfo.fromPlan(catalog.voucherSundayPlus, "Sunday+"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Saturday"),
           WirePlanInfo.fromPlan(catalog.voucherSaturdayPlus, "Saturday+"),
-          WirePlanInfo.fromPlan(catalog.voucherSaturdayPlus, "Sunday+")
+          WirePlanInfo.fromPlan(catalog.voucherEveryDay, "Every day"),
+          WirePlanInfo.fromPlan(catalog.voucherEveryDayPlus, "Every day+"),
+          WirePlanInfo.fromPlan(catalog.voucherSixDay, "Six day"),
+          WirePlanInfo.fromPlan(catalog.voucherSixDayPlus, "Six day+")
         )
       )
       val contributionProduct = WireProduct(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -103,7 +103,15 @@ object WireModel {
         label = "Voucher",
         plans = List(
           WirePlanInfo.fromPlan(catalog.voucherWeekend, "Weekend"),
-          WirePlanInfo.fromPlan(catalog.voucherEveryDay, "Every day")
+          WirePlanInfo.fromPlan(catalog.voucherEveryDay, "Every day"),
+          WirePlanInfo.fromPlan(catalog.voucherSixDay, "Six day"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Saturday"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Sunday"),
+          WirePlanInfo.fromPlan(catalog.voucherWeekendPlus, "Weekend+"),
+          WirePlanInfo.fromPlan(catalog.voucherEveryDayPlus, "Every day+"),
+          WirePlanInfo.fromPlan(catalog.voucherSixDayPlus, "Six day+"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturdayPlus, "Saturday+"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturdayPlus, "Sunday+")
         )
       )
       val contributionProduct = WireProduct(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -102,16 +102,16 @@ object WireModel {
       val voucherProduct = WireProduct(
         label = "Voucher",
         plans = List(
-          WirePlanInfo.fromPlan(catalog.voucherWeekend, "Weekend"),
-          WirePlanInfo.fromPlan(catalog.voucherWeekendPlus, "Weekend+"),
-          WirePlanInfo.fromPlan(catalog.voucherSunday, "Sunday"),
-          WirePlanInfo.fromPlan(catalog.voucherSundayPlus, "Sunday+"),
-          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Saturday"),
-          WirePlanInfo.fromPlan(catalog.voucherSaturdayPlus, "Saturday+"),
           WirePlanInfo.fromPlan(catalog.voucherEveryDay, "Every day"),
           WirePlanInfo.fromPlan(catalog.voucherEveryDayPlus, "Every day+"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturday, "Saturday"),
+          WirePlanInfo.fromPlan(catalog.voucherSaturdayPlus, "Saturday+"),
           WirePlanInfo.fromPlan(catalog.voucherSixDay, "Six day"),
-          WirePlanInfo.fromPlan(catalog.voucherSixDayPlus, "Six day+")
+          WirePlanInfo.fromPlan(catalog.voucherSixDayPlus, "Six day+"),
+          WirePlanInfo.fromPlan(catalog.voucherSunday, "Sunday"),
+          WirePlanInfo.fromPlan(catalog.voucherSundayPlus, "Sunday+"),
+          WirePlanInfo.fromPlan(catalog.voucherWeekend, "Weekend"),
+          WirePlanInfo.fromPlan(catalog.voucherWeekendPlus, "Weekend+")
         )
       )
       val contributionProduct = WireProduct(
@@ -120,7 +120,7 @@ object WireModel {
           WirePlanInfo.fromPlan(catalog.monthlyContribution, "Monthly")
         )
       )
-      WireCatalog(List(voucherProduct, contributionProduct))
+      WireCatalog(List(contributionProduct, voucherProduct))
     }
   }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -19,6 +19,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |    "plans": [{
         |            "id": "voucher_weekend",
         |            "label": "Weekend",
+        |            "paymentPlan": "£10.50 every month",
         |            "startDateRules" : {
         |            "selectableWindow" : {
         |              "cutOffDayInclusive": "Tuesday",
@@ -31,6 +32,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |        {
         |            "id": "voucher_everyday",
         |            "label": "Every day",
+        |            "paymentPlan" : "£37 every month",
         |             "startDateRules" : {
         |             "selectableWindow" : {
         |                "cutOffDayInclusive": "Tuesday",
@@ -77,7 +79,8 @@ object TestData {
     val voucherEveryday = WirePlanInfo(
       id = "voucher_everyday",
       label = "Every day",
-      startDateRules = Some(everyDayRules)
+      startDateRules = Some(everyDayRules),
+      paymentPlan = Some("£37 every month")
     )
 
     val weekendsRule = everyDayRules.copy(
@@ -86,7 +89,9 @@ object TestData {
     val voucherWeekend = WirePlanInfo(
       id = "voucher_weekend",
       label = "Weekend",
-      startDateRules = Some(weekendsRule)
+      startDateRules = Some(weekendsRule),
+      paymentPlan = Some("£10.50 every month")
+
     )
 
     val monthlyContribution = WirePlanInfo(
@@ -108,9 +113,9 @@ object TestData {
     val weekendRule = DaysOfWeekRule(List(SATURDAY, SUNDAY))
     val tuesdayRule = DaysOfWeekRule(List(MONDAY))
     val voucherWeekendRule = StartDateRules(Some(weekendRule), Some(voucherWindowRule))
-    val voucherWeekend = Plan(VoucherWeekend, voucherWeekendRule)
+    val voucherWeekend = Plan(VoucherWeekend, voucherWeekendRule, Some(PaymentPlan("£10.50 every month")))
     val voucherEveryDayRule = StartDateRules(Some(tuesdayRule), Some(voucherWindowRule))
-    val voucherEveryDay = Plan(VoucherEveryDay, voucherEveryDayRule)
+    val voucherEveryDay = Plan(VoucherEveryDay, voucherEveryDayRule, Some(PaymentPlan("£37 every month")))
 
     val monthlyContribution = Plan(MonthlyContribution)
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -10,14 +10,28 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |{
         |  "products": [
         |    {
+        |      "label": "Contribution",
+        |      "plans": [
+        |        {
+        |          "id": "monthly_contribution",
+        |          "label": "Monthly",
+        |          "startDateRules": {
+        |            "selectableWindow": {
+        |              "sizeInDays": 1
+        |            }
+        |          }
+        |        }
+        |      ]
+        |    },
+        |    {
         |      "label": "Voucher",
         |      "plans": [
         |        {
-        |          "id": "voucher_weekend",
-        |          "label": "Weekend",
+        |          "id": "voucher_everyday",
+        |          "label": "Every day",
         |          "startDateRules": {
         |            "daysOfWeek": [
-        |              "Saturday"
+        |              "Monday"
         |            ],
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
@@ -25,14 +39,14 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "sizeInDays": 28
         |            }
         |          },
-        |          "paymentPlan": "£20.76 every month"
+        |          "paymentPlan": "£47.62 every month"
         |        },
         |        {
-        |          "id": "voucher_weekend_plus",
-        |          "label": "Weekend+",
+        |          "id": "voucher_everyday_plus",
+        |          "label": "Every day+",
         |          "startDateRules": {
         |            "daysOfWeek": [
-        |              "Saturday"
+        |              "Monday"
         |            ],
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
@@ -40,37 +54,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |              "sizeInDays": 28
         |            }
         |          },
-        |          "paymentPlan": "£29.42 every month"
-        |        },
-        |        {
-        |          "id": "voucher_sunday",
-        |          "label": "Sunday",
-        |          "startDateRules": {
-        |            "daysOfWeek": [
-        |              "Sunday"
-        |            ],
-        |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
-        |            }
-        |          },
-        |          "paymentPlan": "£10.79 every month"
-        |        },
-        |        {
-        |          "id": "voucher_sunday_plus",
-        |          "label": "Sunday+",
-        |          "startDateRules": {
-        |            "daysOfWeek": [
-        |              "Sunday"
-        |            ],
-        |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
-        |            }
-        |          },
-        |          "paymentPlan": "£22.06 every month"
+        |          "paymentPlan": "£51.96 every month"
         |        },
         |        {
         |          "id": "voucher_saturday",
@@ -103,36 +87,6 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |          "paymentPlan": "£21.62 every month"
         |        },
         |        {
-        |          "id": "voucher_everyday",
-        |          "label": "Every day",
-        |          "startDateRules": {
-        |            "daysOfWeek": [
-        |              "Monday"
-        |            ],
-        |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
-        |            }
-        |          },
-        |          "paymentPlan": "£47.62 every month"
-        |        },
-        |        {
-        |          "id": "voucher_everyday_plus",
-        |          "label": "Every day+",
-        |          "startDateRules": {
-        |            "daysOfWeek": [
-        |              "Monday"
-        |            ],
-        |            "selectableWindow": {
-        |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
-        |            }
-        |          },
-        |          "paymentPlan": "£51.96 every month"
-        |        },
-        |        {
         |          "id": "voucher_sixday",
         |          "label": "Six day",
         |          "startDateRules": {
@@ -161,20 +115,66 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            }
         |          },
         |          "paymentPlan": "£47.62 every month"
-        |        }
-        |      ]
-        |    },
-        |    {
-        |      "label": "Contribution",
-        |      "plans": [
+        |        },
         |        {
-        |          "id": "monthly_contribution",
-        |          "label": "Monthly",
+        |          "id": "voucher_sunday",
+        |          "label": "Sunday",
         |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Sunday"
+        |            ],
         |            "selectableWindow": {
-        |              "sizeInDays": 1
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
         |            }
-        |          }
+        |          },
+        |          "paymentPlan": "£10.79 every month"
+        |        },
+        |        {
+        |          "id": "voucher_sunday_plus",
+        |          "label": "Sunday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£22.06 every month"
+        |        },
+        |        {
+        |          "id": "voucher_weekend",
+        |          "label": "Weekend",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£20.76 every month"
+        |        },
+        |        {
+        |          "id": "voucher_weekend_plus",
+        |          "label": "Weekend+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£29.42 every month"
         |        }
         |      ]
         |    }
@@ -185,5 +185,4 @@ class CatalogWireTest extends FlatSpec with Matchers {
     Json.toJson(wireCatalog) shouldBe Json.parse(expected)
   }
 }
-
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -1,128 +1,189 @@
 package com.gu.newproduct.api.productcatalog
-
-import java.time.DayOfWeek
-import java.time.DayOfWeek._
-
-import com.gu.newproduct.api.productcatalog.PlanId.{MonthlyContribution, VoucherEveryDay, VoucherWeekend}
 import com.gu.newproduct.api.productcatalog.WireModel._
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.Json
 
 class CatalogWireTest extends FlatSpec with Matchers {
-  it should "serialise wire catalog" in {
-    val testWireCatalog = TestData.testWireCatalog
+  it should "serialise catalog" in {
     val expected =
       """
         |{
-        |"products": [{
-        |    "label": "Voucher",
-        |    "plans": [{
-        |            "id": "voucher_weekend",
-        |            "label": "Weekend",
-        |            "paymentPlan": "£10.50 every month",
-        |            "startDateRules" : {
-        |            "selectableWindow" : {
+        |  "products": [
+        |    {
+        |      "label": "Voucher",
+        |      "plans": [
+        |        {
+        |          "id": "voucher_weekend",
+        |          "label": "Weekend",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
-        |              "startDaysAfterCutOff" : 20,
-        |              "sizeInDays" : 28
-        |              },
-        |            "daysOfWeek": ["Saturday", "Sunday"]
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
         |            }
+        |          },
+        |          "paymentPlan": "£20.76 every month"
         |        },
         |        {
-        |            "id": "voucher_everyday",
-        |            "label": "Every day",
-        |            "paymentPlan" : "£37 every month",
-        |             "startDateRules" : {
-        |             "selectableWindow" : {
-        |                "cutOffDayInclusive": "Tuesday",
-        |                "startDaysAfterCutOff" : 20,
-        |                "sizeInDays" : 28
-        |                },
-        |             "daysOfWeek": ["Monday"]
+        |          "id": "voucher_weekend_plus",
+        |          "label": "Weekend+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
         |            }
+        |          },
+        |          "paymentPlan": "£29.42 every month"
+        |        },
+        |        {
+        |          "id": "voucher_sunday",
+        |          "label": "Sunday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£10.79 every month"
+        |        },
+        |        {
+        |          "id": "voucher_sunday_plus",
+        |          "label": "Sunday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Sunday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£22.06 every month"
+        |        },
+        |        {
+        |          "id": "voucher_saturday",
+        |          "label": "Saturday",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£10.36 every month"
+        |        },
+        |        {
+        |          "id": "voucher_saturday_plus",
+        |          "label": "Saturday+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Saturday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£21.62 every month"
+        |        },
+        |        {
+        |          "id": "voucher_everyday",
+        |          "label": "Every day",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£47.62 every month"
+        |        },
+        |        {
+        |          "id": "voucher_everyday_plus",
+        |          "label": "Every day+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£51.96 every month"
+        |        },
+        |        {
+        |          "id": "voucher_sixday",
+        |          "label": "Six day",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£41.12 every month"
+        |        },
+        |        {
+        |          "id": "voucher_sixday_plus",
+        |          "label": "Six day+",
+        |          "startDateRules": {
+        |            "daysOfWeek": [
+        |              "Monday"
+        |            ],
+        |            "selectableWindow": {
+        |              "cutOffDayInclusive": "Tuesday",
+        |              "startDaysAfterCutOff": 20,
+        |              "sizeInDays": 28
+        |            }
+        |          },
+        |          "paymentPlan": "£47.62 every month"
         |        }
-        |    ]
-        |}, {
-        |    "label": "Contribution",
-        |    "plans": [{
-        |        "id": "monthly_contribution",
-        |        "label": "Monthly"
-        |    }]
-        |}]
+        |      ]
+        |    },
+        |    {
+        |      "label": "Contribution",
+        |      "plans": [
+        |        {
+        |          "id": "monthly_contribution",
+        |          "label": "Monthly",
+        |          "startDateRules": {
+        |            "selectableWindow": {
+        |              "sizeInDays": 1
+        |            }
+        |          }
+        |        }
+        |      ]
+        |    }
+        |  ]
         |}
       """.stripMargin
-    Json.toJson(testWireCatalog) shouldBe Json.parse(expected)
-
-  }
-
-  it should "convert catalog to wire catalog" in {
-    val testCatalog = TestData.testCatalog
-    WireCatalog.fromCatalog(testCatalog) shouldBe TestData.testWireCatalog
+    val wireCatalog = WireCatalog.fromCatalog(NewProductApi.catalog)
+    Json.toJson(wireCatalog) shouldBe Json.parse(expected)
   }
 }
 
-object TestData {
 
-  val testWireCatalog = {
-
-    val everyDayWindowRules = WireSelectableWindow(
-      cutOffDayInclusive = Some(Tuesday),
-      startDaysAfterCutOff = Some(20),
-      sizeInDays = Some(28)
-    )
-    val everyDayRules = WireStartDateRules(
-      daysOfWeek = Some(List(Monday)),
-      selectableWindow = Some(everyDayWindowRules)
-    )
-
-    val voucherEveryday = WirePlanInfo(
-      id = "voucher_everyday",
-      label = "Every day",
-      startDateRules = Some(everyDayRules),
-      paymentPlan = Some("£37 every month")
-    )
-
-    val weekendsRule = everyDayRules.copy(
-      daysOfWeek = Some(List(Saturday, Sunday))
-    )
-    val voucherWeekend = WirePlanInfo(
-      id = "voucher_weekend",
-      label = "Weekend",
-      startDateRules = Some(weekendsRule),
-      paymentPlan = Some("£10.50 every month")
-
-    )
-
-    val monthlyContribution = WirePlanInfo(
-      id = "monthly_contribution",
-      label = "Monthly"
-    )
-
-    val voucherGroup = WireProduct("Voucher", List(voucherWeekend, voucherEveryday))
-    val contributionGroup = WireProduct("Contribution", List(monthlyContribution))
-    WireCatalog(List(voucherGroup, contributionGroup))
-  }
-
-  val testCatalog = {
-    val voucherWindowRule = WindowRule(
-      maybeCutOffDay = Some(DayOfWeek.TUESDAY),
-      maybeStartDelay = Some(DelayDays(20)),
-      maybeSize = Some(WindowSizeDays(28))
-    )
-    val weekendRule = DaysOfWeekRule(List(SATURDAY, SUNDAY))
-    val tuesdayRule = DaysOfWeekRule(List(MONDAY))
-    val voucherWeekendRule = StartDateRules(Some(weekendRule), Some(voucherWindowRule))
-    val voucherWeekend = Plan(VoucherWeekend, voucherWeekendRule, Some(PaymentPlan("£10.50 every month")))
-    val voucherEveryDayRule = StartDateRules(Some(tuesdayRule), Some(voucherWindowRule))
-    val voucherEveryDay = Plan(VoucherEveryDay, voucherEveryDayRule, Some(PaymentPlan("£37 every month")))
-
-    val monthlyContribution = Plan(MonthlyContribution)
-
-    Catalog(
-      voucherWeekend = voucherWeekend,
-      voucherEveryDay = voucherEveryDay,
-      monthlyContribution = monthlyContribution
-    )
-  }
-}


### PR DESCRIPTION
Added all voucher plans and payment descriptions to the catalog response. The payment information is hardcoded for now to allow @david-pepper to make progress on the salesforce side. 
In the future we should probably use the catalog service (or zuora directly) to get at least the updated prices