### PR TITLE
create voucher subscriptions from new product API

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -56,7 +56,8 @@ object Steps {
     request: AddSubscriptionRequest,
     acceptanceDate: LocalDate,
     chargeOverride: Option[ChargeOverride],
-    productRatePlanId: ProductRatePlanId) = ZuoraCreateSubRequest(
+    productRatePlanId: ProductRatePlanId
+  ) = ZuoraCreateSubRequest(
     productRatePlanId,
     request.zuoraAccountId,
     chargeOverride,
@@ -127,8 +128,7 @@ object Steps {
     getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
     getCustomerData: ZuoraAccountId => ApiGatewayOp[VoucherCustomerData],
     validateStartDate: (PlanId, LocalDate) => ValidationResult[Unit],
-    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
-
+    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName]
   )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = for {
     _ <- validateStartDate(request.planId, request.startDate).toApiGatewayOp.toAsync
     customerData <- getCustomerData(request.zuoraAccountId).toAsync

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -51,9 +51,9 @@ object Handler extends Logging {
 }
 
 object Steps {
-  def createZuoraSubRequest(request: AddSubscriptionRequest, acceptanceDate: LocalDate, amountMinorUnits: AmountMinorUnits) = ZuoraCreateSubRequest(
+  def createZuoraSubRequest(request: AddSubscriptionRequest, acceptanceDate: LocalDate) = ZuoraCreateSubRequest(
     request.zuoraAccountId,
-    amountMinorUnits,
+    request.amountMinorUnits,
     request.startDate,
     acceptanceDate,
     request.acquisitionCase,
@@ -108,7 +108,7 @@ object Steps {
       validatableFields = ValidatableFields(request.amountMinorUnits, request.startDate)
       amountMinorUnits <- contributionValidations(validatableFields, account.currency).toApiGatewayOp.toAsync
       acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
-      zuoraCreateSubRequest = createZuoraSubRequest(request, acceptanceDate, amountMinorUnits)
+      zuoraCreateSubRequest = createZuoraSubRequest(request, acceptanceDate)
       subscriptionName <- createMonthlyContribution(zuoraCreateSubRequest).toAsyncApiGatewayOp("create monthly contribution")
       contributionEmailData = toContributionEmailData(request, account.currency, paymentMethod, acceptanceDate, contacts.billTo, amountMinorUnits)
       _ <- sendConfirmationEmail(contributionEmailData)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/ZuoraIds.scala
@@ -1,5 +1,7 @@
 package com.gu.newproduct.api.addsubscription
 
+import com.gu.newproduct.api.productcatalog.PlanId
+import com.gu.newproduct.api.productcatalog.PlanId._
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.config.Stage
 import com.gu.util.reader.Types.{ApiGatewayOp, _}
@@ -7,41 +9,116 @@ import com.gu.util.reader.Types.{ApiGatewayOp, _}
 object ZuoraIds {
 
   case class ProductRatePlanId(value: String) extends AnyVal
+
   case class ProductRatePlanChargeId(value: String) extends AnyVal
+
   case class PlanAndCharge(productRatePlanId: ProductRatePlanId, productRatePlanChargeId: ProductRatePlanChargeId)
+
   case class ContributionsZuoraIds(monthly: PlanAndCharge, annual: PlanAndCharge)
 
-  def zuoraIdsForStage(stage: Stage): ApiGatewayOp[ContributionsZuoraIds] = {
+  case class VoucherZuoraIds(
+    everyday: ProductRatePlanId,
+    saturday: ProductRatePlanId,
+    sunday: ProductRatePlanId,
+    weekend: ProductRatePlanId,
+    sixDay: ProductRatePlanId,
+    everydayPlus: ProductRatePlanId,
+    saturdayPlus: ProductRatePlanId,
+    sundayPlus: ProductRatePlanId,
+    weekendPlus: ProductRatePlanId,
+    sixDayPlus: ProductRatePlanId
+  ) {
+    val byApiPlanId: Map[PlanId, ProductRatePlanId] = Map(
+      VoucherEveryDay -> everyday,
+      VoucherWeekend -> weekend,
+      VoucherSixDay -> sixDay,
+      VoucherSunday -> sunday,
+      VoucherSaturday -> saturday,
+      VoucherEveryDayPlus -> everydayPlus,
+      VoucherWeekendPlus -> weekendPlus,
+      VoucherSixDayPlus -> sixDayPlus,
+      VoucherSundayPlus -> sundayPlus,
+      VoucherSaturdayPlus -> saturdayPlus
+    )
+
+  }
+
+  case class ZuoraIds(contributionsZuoraIds: ContributionsZuoraIds, voucherZuoraIds: VoucherZuoraIds)
+
+  def zuoraIdsForStage(stage: Stage): ApiGatewayOp[ZuoraIds] = {
     val mappings = Map(
       // todo ideally we should add an id to the fields in zuora so we don't have to hard code
-      Stage("PROD") -> ContributionsZuoraIds(
-        monthly = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92a0fc5aacfadd015ad24db4ff5e97"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92a0fc5aacfadd015ad250bf2c6d38")
+      Stage("PROD") -> ZuoraIds(
+        ContributionsZuoraIds(
+          monthly = PlanAndCharge(
+            ProductRatePlanId("2c92a0fc5aacfadd015ad24db4ff5e97"),
+            ProductRatePlanChargeId("2c92a0fc5aacfadd015ad250bf2c6d38")
+          ),
+          annual = PlanAndCharge(
+            ProductRatePlanId("2c92a0fc5e1dc084015e37f58c200eea"),
+            ProductRatePlanChargeId("2c92a0fc5e1dc084015e37f58c7b0f34")
+          )
         ),
-        annual = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92a0fc5e1dc084015e37f58c200eea"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92a0fc5e1dc084015e37f58c7b0f34")
+        VoucherZuoraIds(
+          everyday = ProductRatePlanId("2c92a0fd56fe270b0157040dd79b35da"),
+          sunday = ProductRatePlanId("2c92a0fe5af9a6b9015b0fe1ecc0116c"),
+          saturday = ProductRatePlanId("2c92a0fd6205707201621f9f6d7e0116"),
+          weekend = ProductRatePlanId("2c92a0ff56fe33f00157040f9a537f4b"),
+          sixDay = ProductRatePlanId("2c92a0fd56fe270b0157040e42e536ef"),
+          everydayPlus = ProductRatePlanId("2c92a0ff56fe33f50157040bbdcf3ae4"),
+          sundayPlus = ProductRatePlanId("2c92a0fe56fe33ff0157040d4b824168"),
+          saturdayPlus = ProductRatePlanId("2c92a0fd6205707201621fa1350710e3"),
+          weekendPlus = ProductRatePlanId("2c92a0fd56fe26b60157040cdd323f76"),
+          sixDayPlus = ProductRatePlanId("2c92a0fc56fe26ba0157040c5ea17f6a")
         )
       ),
-      Stage("CODE") -> ContributionsZuoraIds(
-        monthly = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92c0f85ab269be015acd9d014549b7"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85ab2696b015acd9eeb6150ab")
+      Stage("CODE") -> ZuoraIds(
+        ContributionsZuoraIds(
+          monthly = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("2c92c0f85ab269be015acd9d014549b7"),
+            productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85ab2696b015acd9eeb6150ab")
+          ),
+          annual = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("2c92c0f95e1d5c9c015e38f8c87d19a1"),
+            productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f95e1d5c9c015e38f8c8ac19a3")
+          )
         ),
-        annual = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92c0f95e1d5c9c015e38f8c87d19a1"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f95e1d5c9c015e38f8c8ac19a3")
+        VoucherZuoraIds(
+          everyday = ProductRatePlanId("2c92c0f855c9f4b20155d9f1d3d4512a"),
+          sunday = ProductRatePlanId("2c92c0f95aff3b54015b0ee0eb500b2e"),
+          saturday = ProductRatePlanId("2c92c0f961f9cf300161fc02a7d805c9"),
+          weekend = ProductRatePlanId("2c92c0f855c9f4b20155d9f1db9b5199"),
+          sixDay = ProductRatePlanId("2c92c0f955ca02910155da254a641fb3"),
+          everydayPlus = ProductRatePlanId("2c92c0f955ca02920155da240cdb4399"),
+          sundayPlus = ProductRatePlanId("2c92c0f858aa38af0158b9dae19110a3"),
+          saturdayPlus = ProductRatePlanId("2c92c0f961f9cf350161fc0454283f3e"),
+          weekendPlus = ProductRatePlanId("2c92c0f855c9f4b20155d9f1dd0651ab"),
+          sixDayPlus = ProductRatePlanId("2c92c0f855c9f4540155da2607db6402")
         )
       ),
-      Stage("DEV") -> ContributionsZuoraIds(
-        monthly = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92c0f85a6b134e015a7fcd9f0c7855"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85a6b1352015a7fcf35ab397c")
+      Stage("DEV") -> ZuoraIds(
+        ContributionsZuoraIds(
+          monthly = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("2c92c0f85a6b134e015a7fcd9f0c7855"),
+            productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85a6b1352015a7fcf35ab397c")
+          ),
+          annual = PlanAndCharge(
+            productRatePlanId = ProductRatePlanId("2c92c0f85e2d19af015e3896e824092c"),
+            productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85e2d19af015e3896e84d092e")
+          )
         ),
-        annual = PlanAndCharge(
-          productRatePlanId = ProductRatePlanId("2c92c0f85e2d19af015e3896e824092c"),
-          productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85e2d19af015e3896e84d092e")
+        VoucherZuoraIds(
+          everyday = ProductRatePlanId("2c92c0f9555cf10501556e84a70440e2"),
+          sunday = ProductRatePlanId("2c92c0f95aff3b56015b1045fb9332d2"),
+          saturday = ProductRatePlanId("2c92c0f861f9c26d0161fc434bfe004c"),
+          weekend = ProductRatePlanId("2c92c0f8555ce5cf01556e7f01b81b94"),
+          sixDay = ProductRatePlanId("2c92c0f8555ce5cf01556e7f01771b8a"),
+          everydayPlus = ProductRatePlanId("2c92c0f95aff3b53015b10469bbf5f5f"),
+          sundayPlus = ProductRatePlanId("2c92c0f955a0b5bf0155b62623846fc8"),
+          saturdayPlus = ProductRatePlanId("2c92c0f961f9cf300161fc44f2661258"), //for some reason this is effective in the future in the dev catalog
+          weekendPlus = ProductRatePlanId("2c92c0f95aff3b54015b1047efaa2ac3"),
+          sixDayPlus = ProductRatePlanId("2c92c0f855c3b8190155c585a95e6f5a") //TODO for some reason at least in dev this sets all the charges for the days to quantity = 0 !
+
         )
       )
     )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/ZuoraIds.scala
@@ -115,9 +115,9 @@ object ZuoraIds {
           sixDay = ProductRatePlanId("2c92c0f8555ce5cf01556e7f01771b8a"),
           everydayPlus = ProductRatePlanId("2c92c0f95aff3b53015b10469bbf5f5f"),
           sundayPlus = ProductRatePlanId("2c92c0f955a0b5bf0155b62623846fc8"),
-          saturdayPlus = ProductRatePlanId("2c92c0f961f9cf300161fc44f2661258"), //for some reason this is effective in the future in the dev catalog
+          saturdayPlus = ProductRatePlanId("2c92c0f961f9cf300161fc44f2661258"),
           weekendPlus = ProductRatePlanId("2c92c0f95aff3b54015b1047efaa2ac3"),
-          sixDayPlus = ProductRatePlanId("2c92c0f855c3b8190155c585a95e6f5a") //TODO for some reason at least in dev this sets all the charges for the days to quantity = 0 !
+          sixDayPlus = ProductRatePlanId("2c92c0f855c3b8190155c585a95e6f5a")
 
         )
       )

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
@@ -20,7 +20,7 @@ object ContributionValidations {
     currency: Currency
   ): ValidationResult[AmountMinorUnits] =
     for {
-      amount <- validatableFields.amountMinorUnits getOrFailWith s"amount is missing"
+      amount <- validatableFields.amountMinorUnits getOrFailWith s"amountMinorUnits is missing"
       _ <- isValidStartDate(validatableFields.startDate)
       limits = limitsFor(currency)
       _ <- (amount.value <= limits.max) orFailWith s"amount must not be more than ${limits.max}"

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
@@ -9,7 +9,7 @@ object ContributionValidations {
 
   case class ValidatableFields(
     amountMinorUnits: Option[AmountMinorUnits],
-    startDate: LocalDate,
+    startDate: LocalDate
   )
 
   def apply(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -15,18 +15,23 @@ object CreateSubscription {
   object WireModel {
 
     case class WireSubscription(subscriptionNumber: String)
+
     implicit val readsResponse: Reads[WireSubscription] = Json.reads[WireSubscription]
 
     case class ChargeOverrides(
       price: Double,
       productRatePlanChargeId: String
     )
+
     implicit val writesCharge = Json.writes[ChargeOverrides]
+
     case class SubscribeToRatePlans(
       productRatePlanId: String,
       chargeOverrides: List[ChargeOverrides]
     )
+
     implicit val writesSubscribe = Json.writes[SubscribeToRatePlans]
+
     case class WireCreateRequest(
       accountKey: String,
       autoRenew: Boolean = true,
@@ -40,6 +45,7 @@ object CreateSubscription {
       AcquisitionSource__c: String,
       CreatedByCSR__c: String
     )
+
     implicit val writesRequest = Json.writes[WireCreateRequest]
   }
 
@@ -57,12 +63,11 @@ object CreateSubscription {
       subscribeToRatePlans = List(
         SubscribeToRatePlans(
           productRatePlanId = planAndCharge.productRatePlanId.value,
-          chargeOverrides = List(
+          chargeOverrides = maybeAmountMinorUnits.map(amountMinorUnits =>
             ChargeOverrides(
               price = amountMinorUnits.value.toDouble / 100,
               productRatePlanChargeId = planAndCharge.productRatePlanChargeId.value
-            )
-          )
+            )).toList
         )
       )
     )
@@ -70,7 +75,7 @@ object CreateSubscription {
 
   case class ZuoraCreateSubRequest(
     accountId: ZuoraAccountId,
-    amountMinorUnits: AmountMinorUnits,
+    maybeAmountMinorUnits: Option[AmountMinorUnits],
     effectiveDate: LocalDate,
     acceptanceDate: LocalDate,
     acquisitionCase: CaseId,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -51,7 +51,7 @@ object CreateSubscription {
 
   import WireModel._
 
-  def createRequest(createSubscription: ZuoraCreateSubRequest, planAndCharge: PlanAndCharge): WireCreateRequest = {
+  def createRequest(createSubscription: ZuoraCreateSubRequest): WireCreateRequest = {
     import createSubscription._
     WireCreateRequest(
       accountKey = accountId.value,
@@ -74,6 +74,7 @@ object CreateSubscription {
   }
 
   case class ZuoraCreateSubRequest(
+    planAndCharge: PlanAndCharge,
     accountId: ZuoraAccountId,
     maybeAmountMinorUnits: Option[AmountMinorUnits],
     effectiveDate: LocalDate,
@@ -86,10 +87,9 @@ object CreateSubscription {
   case class SubscriptionName(value: String) extends AnyVal
 
   def apply(
-    planAndCharge: PlanAndCharge,
     post: RequestsPost[WireCreateRequest, WireSubscription]
   )(createSubscription: ZuoraCreateSubRequest): ClientFailableOp[SubscriptionName] = {
-    val maybeWireSubscription = post(createRequest(createSubscription, planAndCharge), s"subscriptions", WithCheck)
+    val maybeWireSubscription = post(createRequest(createSubscription), s"subscriptions", WithCheck)
     maybeWireSubscription.map { wireSubscription =>
       SubscriptionName(wireSubscription.subscriptionNumber)
     }.withLogging("created subscription")

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -3,7 +3,7 @@ package com.gu.newproduct.api.addsubscription.zuora
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-import com.gu.newproduct.api.addsubscription.ZuoraIds.PlanAndCharge
+import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription._
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.ClientFailableOp
@@ -62,21 +62,25 @@ object CreateSubscription {
       CreatedByCSR__c = createdByCSR.value,
       subscribeToRatePlans = List(
         SubscribeToRatePlans(
-          productRatePlanId = planAndCharge.productRatePlanId.value,
-          chargeOverrides = maybeAmountMinorUnits.map(amountMinorUnits =>
+          productRatePlanId = productRatePlanId.value,
+          chargeOverrides = maybeChargeOverride.map(chargeOverride =>
             ChargeOverrides(
-              price = amountMinorUnits.value.toDouble / 100,
-              productRatePlanChargeId = planAndCharge.productRatePlanChargeId.value
+              price = chargeOverride.amountMinorUnits.value.toDouble / 100,
+              productRatePlanChargeId = chargeOverride.productRatePlanChargeId.value
             )).toList
         )
       )
     )
   }
 
+  case class ChargeOverride(
+    amountMinorUnits: AmountMinorUnits,
+    productRatePlanChargeId: ProductRatePlanChargeId
+  )
   case class ZuoraCreateSubRequest(
-    planAndCharge: PlanAndCharge,
+    productRatePlanId: ProductRatePlanId,
     accountId: ZuoraAccountId,
-    maybeAmountMinorUnits: Option[AmountMinorUnits],
+    maybeChargeOverride: Option[ChargeOverride],
     effectiveDate: LocalDate,
     acceptanceDate: LocalDate,
     acquisitionCase: CaseId,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -3,12 +3,12 @@ package com.gu.newproduct.api.addsubscription.zuora
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
+import com.gu.newproduct.api.addsubscription.ZuoraIds.{ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription._
+import com.gu.util.resthttp.ClientFailableOpLogging.LogImplicit2
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.ClientFailableOp
 import play.api.libs.json.{Json, Reads}
-import com.gu.util.resthttp.ClientFailableOpLogging.LogImplicit2
 
 object CreateSubscription {
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -30,7 +30,7 @@ class ContributionStepsTest extends FlatSpec with Matchers {
 
     val expectedIn = ZuoraCreateSubRequest(
       ZuoraAccountId("acccc"),
-      AmountMinorUnits(123),
+      Some(AmountMinorUnits(123)),
       LocalDate.of(2018, 7, 18),
       LocalDate.of(2018, 7, 28),
       CaseId("case"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -9,7 +9,7 @@ import com.gu.newproduct.api.addsubscription.email.SendConfirmationEmail.Contrib
 import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionValidations.ValidatableFields
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{SubscriptionName, ZuoraCreateSubRequest}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest}
 import com.gu.test.JsonMatchers.JsonMatcher
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.AsyncTypes._
@@ -28,11 +28,19 @@ class ContributionStepsTest extends FlatSpec with Matchers {
   case class ExpectedOut(subscriptionNumber: String)
 
   it should "run end to end with fakes" in {
-    val planAndCharge = PlanAndCharge(ProductRatePlanId("ratePlanId"), ProductRatePlanChargeId("ratePlanChargeId"))
+
+    val planAndCharge = PlanAndCharge(
+      ProductRatePlanId("ratePlanId"),
+      ProductRatePlanChargeId("ratePlanChargeId")
+    )
+
     val expectedIn = ZuoraCreateSubRequest(
-      planAndCharge,
+      planAndCharge.productRatePlanId,
       ZuoraAccountId("acccc"),
-      Some(AmountMinorUnits(123)),
+      Some(ChargeOverride(
+        AmountMinorUnits(123),
+        planAndCharge.productRatePlanChargeId
+      )),
       LocalDate.of(2018, 7, 18),
       LocalDate.of(2018, 7, 28),
       CaseId("case"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.gu.i18n.Currency
 import com.gu.newproduct.TestData
+import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription.email.SendConfirmationEmail.ContributionsEmailData
 import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionValidations.ValidatableFields
@@ -27,8 +28,9 @@ class ContributionStepsTest extends FlatSpec with Matchers {
   case class ExpectedOut(subscriptionNumber: String)
 
   it should "run end to end with fakes" in {
-
+    val planAndCharge = PlanAndCharge(ProductRatePlanId("ratePlanId"), ProductRatePlanChargeId("ratePlanChargeId"))
     val expectedIn = ZuoraCreateSubRequest(
+      planAndCharge,
       ZuoraAccountId("acccc"),
       Some(AmountMinorUnits(123)),
       LocalDate.of(2018, 7, 18),
@@ -68,6 +70,7 @@ class ContributionStepsTest extends FlatSpec with Matchers {
     val expectedOutput = ExpectedOut("well done")
 
     val fakeAddContributionSteps = Steps.addContributionSteps(
+      planAndCharge,
       fakeGetCustomerData,
       fakeValidateRequest,
       fakeCreate,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -4,7 +4,6 @@ import java.time.LocalDate
 
 import com.gu.newproduct.TestData
 import com.gu.newproduct.api.addsubscription.validation._
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.ZuoraCreateSubRequest
 import com.gu.newproduct.api.productcatalog.PlanId
 import com.gu.test.JsonMatchers.JsonMatcher
 import com.gu.util.apigateway.ApiGatewayRequest

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -22,16 +22,6 @@ class VoucherStepsTest extends FlatSpec with Matchers {
 
   it should "run end to end with fakes" in {
 
-    val expectedIn = ZuoraCreateSubRequest(
-      ZuoraAccountId("acccc"),
-      AmountMinorUnits(123),
-      LocalDate.of(2018, 7, 18),
-      LocalDate.of(2018, 7, 28),
-      CaseId("case"),
-      AcquisitionSource("CSR"),
-      CreatedByCSR("bob")
-    )
-
     def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
 
     val requestInput = JsObject(Map(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -3,11 +3,16 @@ package com.gu.newproduct.api.addsubscription
 import java.time.LocalDate
 
 import com.gu.newproduct.TestData
+import com.gu.newproduct.api.addsubscription.ZuoraIds.ProductRatePlanId
 import com.gu.newproduct.api.addsubscription.validation._
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{SubscriptionName, ZuoraCreateSubRequest}
 import com.gu.newproduct.api.productcatalog.PlanId
 import com.gu.test.JsonMatchers.JsonMatcher
 import com.gu.util.apigateway.ApiGatewayRequest
 import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
+import com.gu.util.resthttp.Types
+import com.gu.util.resthttp.Types.ClientSuccess
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json._
 
@@ -20,6 +25,7 @@ class VoucherStepsTest extends FlatSpec with Matchers {
   case class ExpectedOut(subscriptionNumber: String)
 
   it should "run end to end with fakes" in {
+    val ratePlanId = ProductRatePlanId("ratePlanId")
 
     def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
 
@@ -35,17 +41,37 @@ class VoucherStepsTest extends FlatSpec with Matchers {
     ))
 
     implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
-    val expectedOutput = ExpectedOut("fakeSubId")
+    val expectedOutput = ExpectedOut("well done")
 
     val dummyContributionSteps = (req: AddSubscriptionRequest) => {
       fail("unexpected execution of contribution steps while processing voucher request!")
     }
 
+    val expectedIn = ZuoraCreateSubRequest(
+      ratePlanId,
+      ZuoraAccountId("acccc"),
+      None,
+      LocalDate.of(2018, 7, 18),
+      LocalDate.of(2018, 7, 18),
+      CaseId("case"),
+      AcquisitionSource("CSR"),
+      CreatedByCSR("bob")
+    )
+
+    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
+      in shouldBe expectedIn
+      ClientSuccess(SubscriptionName("well done"))
+    }
+
+    val fakeGetZuoraId = (planId: PlanId) => Some(ratePlanId)
+
     def fakeValidateVoucherStartDate(id: PlanId, d: LocalDate) = Passed(())
 
     val fakeAddVoucherSteps = Steps.addVoucherSteps(
+      fakeGetZuoraId,
       fakeGetVoucherCustomerData,
-      fakeValidateVoucherStartDate
+      fakeValidateVoucherStartDate,
+      fakeCreate
     ) _
 
     val futureActual = Steps.handleRequest(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
@@ -44,7 +44,7 @@ class ContributionValidationsTest extends FlatSpec with Matchers {
   }
 
   it should "return error if amount is missing" in {
-    wiredValidator(testRequest.copy(amountMinorUnits = None), GBP) shouldBe Failed("amount is missing")
+    wiredValidator(testRequest.copy(amountMinorUnits = None), GBP) shouldBe Failed("amountMinorUnits is missing")
   }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/VoucherAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/VoucherAccountValidationTest.scala
@@ -2,7 +2,7 @@ package com.gu.newproduct.api.addsubscription.validation.voucher
 
 import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed, ValidatedAccount}
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, IdentityId, PaymentMethodId}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, PaymentMethodId}
 import org.scalatest.{FlatSpec, Matchers}
 
 class VoucherAccountValidationTest extends FlatSpec with Matchers {

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -21,7 +21,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
     val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
     val request = CreateSubscription.ZuoraCreateSubRequest(
       ZuoraAccountId("2c92c0f864a214c30164a8b5accb650b"),
-      AmountMinorUnits(100),
+      Some(AmountMinorUnits(100)),
       LocalDate.now,
       LocalDate.now.plusDays(2),
       validCaseIdToAvoidCausingSFErrors,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -20,6 +20,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
   it should "create subscription in account" taggedAs EffectsTest in {
     val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
     val request = CreateSubscription.ZuoraCreateSubRequest(
+      monthlyIds,
       ZuoraAccountId("2c92c0f864a214c30164a8b5accb650b"),
       Some(AmountMinorUnits(100)),
       LocalDate.now,
@@ -32,7 +33,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
-      res <- CreateSubscription(monthlyIds, post)(request).toDisjunction
+      res <- CreateSubscription(post)(request).toDisjunction
     } yield res
     withClue(actual) {
       actual.map(_.value.substring(0, 3)) shouldBe \/-("A-S")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -6,6 +6,7 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel._
 import com.gu.newproduct.api.addsubscription._
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.ChargeOverride
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.resthttp.RestRequestMaker.RequestsPost
@@ -20,9 +21,12 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
   it should "create subscription in account" taggedAs EffectsTest in {
     val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
     val request = CreateSubscription.ZuoraCreateSubRequest(
-      monthlyIds,
+      monthlyContribution.productRatePlanId,
       ZuoraAccountId("2c92c0f864a214c30164a8b5accb650b"),
-      Some(AmountMinorUnits(100)),
+      Some(ChargeOverride(
+        AmountMinorUnits(100),
+        monthlyContribution.productRatePlanChargeId
+      )),
       LocalDate.now,
       LocalDate.now.plusDays(2),
       validCaseIdToAvoidCausingSFErrors,
@@ -44,7 +48,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
 
 object ZuoraDevContributions {
 
-  val monthlyIds = PlanAndCharge(
+  val monthlyContribution = PlanAndCharge(
     productRatePlanId = ProductRatePlanId("2c92c0f85a6b134e015a7fcd9f0c7855"),
     productRatePlanChargeId = ProductRatePlanChargeId("2c92c0f85a6b1352015a7fcf35ab397c")
   )

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -43,7 +43,7 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
     }
     val createReq = ZuoraCreateSubRequest(
       accountId = ZuoraAccountId("zac"),
-      amountMinorUnits = AmountMinorUnits(125),
+      maybeAmountMinorUnits = Some(AmountMinorUnits(125)),
       effectiveDate = LocalDate.of(2018, 7, 17),
       acceptanceDate = LocalDate.of(2018, 7, 27),
       acquisitionCase = CaseId("casecase"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -42,6 +42,7 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       case in => GenericError(s"bad request: $in")
     }
     val createReq = ZuoraCreateSubRequest(
+      planAndCharge = ids,
       accountId = ZuoraAccountId("zac"),
       maybeAmountMinorUnits = Some(AmountMinorUnits(125)),
       effectiveDate = LocalDate.of(2018, 7, 17),
@@ -50,7 +51,7 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       acquisitionSource = AcquisitionSource("sourcesource"),
       createdByCSR = CreatedByCSR("csrcsr")
     )
-    val actual = CreateSubscription(ids, accF)(createReq)
+    val actual = CreateSubscription(accF)(createReq)
     actual shouldBe ClientSuccess(SubscriptionName("a-s123"))
   }
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import com.gu.newproduct.api.addsubscription.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{ChargeOverrides, SubscribeToRatePlans, WireCreateRequest, WireSubscription}
-import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ZuoraCreateSubRequest, SubscriptionName}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest}
 import com.gu.newproduct.api.addsubscription._
 import com.gu.util.resthttp.RestRequestMaker.{RequestsPost, WithCheck}
 import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
@@ -42,9 +42,13 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
       case in => GenericError(s"bad request: $in")
     }
     val createReq = ZuoraCreateSubRequest(
-      planAndCharge = ids,
+      productRatePlanId = ids.productRatePlanId,
       accountId = ZuoraAccountId("zac"),
-      maybeAmountMinorUnits = Some(AmountMinorUnits(125)),
+      maybeChargeOverride = Some(ChargeOverride(
+        AmountMinorUnits(125),
+        ids.productRatePlanChargeId
+      )),
+
       effectiveDate = LocalDate.of(2018, 7, 17),
       acceptanceDate = LocalDate.of(2018, 7, 27),
       acquisitionCase = CaseId("casecase"),


### PR DESCRIPTION
Added the code to actually create voucher subscriptions from the /add-subscription endpoint.
There's probably some refactoring to do to extract the contribution and voucher specific code from the handler into their own files but I'm trying not to refactor too much in the same PR I add new functionality