### PR TITLE
quick manual batch runner for sf contact merge

### DIFF
--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -1,0 +1,101 @@
+package manualTest
+
+import java.io.FileInputStream
+
+import com.gu.effects.Http
+import com.gu.util.resthttp.RestRequestMaker.{BodyAsString, createBodyFromString}
+import com.gu.util.resthttp.Types.{ClientFailure, ClientSuccess}
+import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
+import manualTest.GetArgs.{ApiKey, FileName}
+import manualTest.ReadFile.JsonString
+import okhttp3.Request
+import play.api.libs.json.{JsSuccess, Json}
+import scalaz.std.list.listInstance
+import scalaz.syntax.std.either._
+import scalaz.syntax.traverse.ToTraverseOps
+import scalaz.{-\/, \/, \/-}
+
+import scala.util.Try
+
+object RunBatch {
+
+  /*
+  this is run to process a batch manually that's been extracted from postman
+
+  run this first in postman for some suitable date range:
+  {{instance_url}}/services/data/v43.0/query?q=SELECT+Scenario_Type__c,+Recent_Contact_Creation_Date__c,+Json_For_Zuora__c+from+Duplicate_Contact__c+WHERE+Recent_Contact_Creation_Date__c+<+2016-06-16T00:00:00.000Z+AND+Scenario_Type__c+!=+null+AND+No_Of_Billing_Accounts__c+>=+2+ORDER+BY+Recent_Contact_Creation_Date__c
+
+  Then run this script with args <sf-contact-merge-apikey> <queryResultFileName>
+  If you're using intellij it's easier to just run it once using the green arrow, then use the drop down at the top saying RunBatch to
+  edit the config and add to the Program Arguments.
+   */
+
+  def main(rawArgs: Array[String]): Unit = {
+
+    val result = for {
+      args <- GetArgs(rawArgs)
+      postIt = HttpOp(Http.response).setupRequest(post(args.apiKey))
+      jsons <- ReadFile(args.fileName)
+      updateIt = postIt.setupRequest[JsonString](a => BodyAsString(a.value))
+      requestWithResultAsTry = (updateIt.runRequest _) andThen {
+        case ClientSuccess(unit) => \/-(())
+        case f: ClientFailure => -\/(s"failed to call sf contact merge: $f")
+      }
+      err <- jsons.traverseU(requestWithResultAsTry)
+    } yield err
+
+    println(s"result: $result")
+  }
+
+  def post(apiKey: ApiKey)(postBody: BodyAsString): Request = {
+    val headers = Map(
+      "x-api-key" -> apiKey.value,
+      "content-type" -> "application/json"
+    )
+    val prodContactMergeUrl = "https://sf-contact-merge-PROD.membership.guardianapis.com/sf-contact-merge"
+    RestRequestMaker.buildRequest(headers, prodContactMergeUrl, _.post(createBodyFromString(postBody)))
+  }
+
+}
+
+object GetArgs {
+
+  def apply(rawArgs: Array[String]): String \/ Args = {
+    rawArgs.toList match {
+      case apiKey :: fileName :: Nil => \/-(Args(ApiKey(apiKey), FileName(fileName)))
+      case _ => -\/("syntax: $0 <sf-contact-merge-apikey> <queryResultFileName>")
+    }
+  }
+
+  case class Args(apiKey: ApiKey, fileName: FileName)
+
+  case class ApiKey(value: String) extends AnyVal
+
+  case class FileName(value: String) extends AnyVal
+
+}
+
+object ReadFile {
+
+  case class JsonString(value: String) extends AnyVal
+
+  case class Record(Json_For_Zuora__c: String)
+
+  implicit val readsRecord = Json.reads[Record]
+
+  case class SFQueryResponse(records: List[Record])
+
+  implicit val readsSFQueryResponse = Json.reads[SFQueryResponse]
+
+  def apply(name: FileName): String \/ List[JsonString] = {
+    Try {
+      val json = Json.parse(new FileInputStream(name.value))
+      val resp = json.validate[SFQueryResponse]
+      resp match {
+        case JsSuccess(value, _) => \/-(value.records.map(a => JsonString(a.Json_For_Zuora__c)))
+        case fail => -\/(s"FAIL to parse: $fail")
+      }
+    }.toEither.disjunction.leftMap(_.toString).flatMap(identity)
+  }
+
+}

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/HttpOp.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/HttpOp.scala
@@ -13,6 +13,8 @@ case class HttpOp[PARAM](
   def runRequest(in: PARAM): ClientFailableOp[Unit] =
     responseToOutput(effect(inputToRequest(in)))
 
+  // this is effectively "contramap" so it is actually setting it up to run the given function before any previously setup functions
+  // you can learn more about contravariant functors https://www.google.co.uk/search?q=contravariant+functor
   def setupRequest[UPDATEDPARAM](function: UPDATEDPARAM => PARAM): HttpOp[UPDATEDPARAM] =
     HttpOp(function.andThen(inputToRequest), effect, responseToOutput)
 

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
@@ -155,8 +155,14 @@ object RestRequestMaker extends Logging {
     createBodyFromJs(Json.toJson(req))
   }
 
+  case class BodyAsString(value: String) extends AnyVal
+
   def createBodyFromJs(req: JsValue) = {
-    RequestBody.create(MediaType.parse("application/json"), Json.stringify(req))
+    val bodyAsString = BodyAsString(Json.stringify(req))
+    createBodyFromString(bodyAsString)
   }
 
+  def createBodyFromString(bodyAsString: BodyAsString): RequestBody = {
+    RequestBody.create(MediaType.parse("application/json"), bodyAsString.value)
+  }
 }


### PR DESCRIPTION
This is just a quick way to run a batch of contacts into the merger without having to use post man for each one.

I considered using an SQS queue rather than api gateway, and generating the batches off a different lambda, but due to lack of experience in this I decided it would be too time consuming.

@paulbrown1982 @pvighi @jacobwinch 