### PR TITLE
Small PR: ignore the case of the lastname when merging contacts

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -54,8 +54,8 @@ object Handler {
       WireRequestToDomainObject {
         DomainSteps(
           GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier, _),
-          AssertSame[Option[EmailAddress]]("emails"),
-          AssertSame[LastName]("last names"),
+          AssertSame.emailAddress,
+          AssertSame.lastName,
           EnsureNoAccountWithWrongIdentityId.apply,
           MoveIdentityId(
             UpdateSalesforceIdentityId(sfPatch).runRequestMultiArg

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/AssertSame.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/AssertSame.scala
@@ -1,14 +1,22 @@
 package com.gu.sf_contact_merge.validate
 
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, LastName}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 
 object AssertSame {
 
-  def apply[Element](message: String): AssertSame[Element] = (elements: List[Element]) =>
-    if (elements.distinct.size == 1) ContinueProcessing(())
-    else ReturnWithResponse(ApiGatewayResponse.notFound(s"those zuora accounts had differing $message"))
+  def apply[Element](message: String, transform: Element => Any = identity[Element] _): AssertSame[Element] = (elements: List[Element]) =>
+    if (elements.map(transform).distinct.size == 1) ContinueProcessing(())
+    else ReturnWithResponse(ApiGatewayResponse.notFound(s"those zuora accounts had differing $message: $elements"))
+
+  val lastName: AssertSame[LastName] = apply[LastName](
+    "last names",
+    _.value.toLowerCase // some seem to be entered entirely lower case, but this isn't a significant difference, so ignore
+  )
+
+  val emailAddress: AssertSame[Option[EmailAddress]] = AssertSame[Option[EmailAddress]]("emails")
 
 }
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/validate/AssertSameEmailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/validate/AssertSameEmailsTest.scala
@@ -1,6 +1,6 @@
 package com.gu.sf_contact_merge.validate
 
-import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, LastName}
 import org.scalatest.{FlatSpec, Matchers}
 
 class AssertSameEmailsTest extends FlatSpec with Matchers {
@@ -23,6 +23,20 @@ class AssertSameEmailsTest extends FlatSpec with Matchers {
     val testData = List(Some("hi"), None).map(_.map(EmailAddress.apply))
 
     AssertSame("").apply(testData).toDisjunction.isRight should be(false)
+
+  }
+
+  it should "be happy that superficially different items are the same if they are transformed" in {
+    val testData = List("JOHN", "john").map(LastName.apply)
+
+    AssertSame.lastName.apply(testData).toDisjunction.isRight should be(true)
+
+  }
+
+  it should "be happy that actually different items are the still different if they are transformed" in {
+    val testData = List("JOHN", "JOHNHI").map(LastName.apply)
+
+    AssertSame.lastName.apply(testData).toDisjunction.isRight should be(false)
 
   }
 


### PR DESCRIPTION
When I am doing the name checking before merging contacts, I noticed that many of them have completely lower case surname on one of the contacts.
I don't think that's something to block merging, so I have added the code to ignore that.

@pvighi  @abhichawla