### PR TITLE
added one week to voucher start date validation rules

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -15,7 +15,7 @@ object NewProductApi {
     val voucherWindowRule = WindowRule(
       maybeCutOffDay = Some(DayOfWeek.TUESDAY),
       maybeStartDelay = Some(DelayDays(20)),
-      maybeSize = Some(WindowSizeDays(28))
+      maybeSize = Some(WindowSizeDays(35))
     )
 
     def voucherDateRules(allowedDays: List[DayOfWeek]) = StartDateRules(Some(DaysOfWeekRule(allowedDays)), Some(voucherWindowRule))

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -38,7 +38,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 47.62 every month"
@@ -53,7 +53,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 51.96 every month"
@@ -68,7 +68,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 10.36 every month"
@@ -83,7 +83,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 21.62 every month"
@@ -98,7 +98,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 41.12 every month"
@@ -113,7 +113,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 47.62 every month"
@@ -128,7 +128,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 10.79 every month"
@@ -143,7 +143,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 22.06 every month"
@@ -158,7 +158,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 20.76 every month"
@@ -173,7 +173,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
         |            "selectableWindow": {
         |              "cutOffDayInclusive": "Tuesday",
         |              "startDaysAfterCutOff": 20,
-        |              "sizeInDays": 28
+        |              "sizeInDays": 35
         |            }
         |          },
         |          "paymentPlan": "GBP 29.42 every month"


### PR DESCRIPTION
[the date validation in subs frontend](https://github.com/guardian/subscriptions-frontend/blob/e057a5b8dfd8ec94c48ebae4455f0e1fcb6aed5c/assets/javascripts/modules/checkout/voucherFields.jsx#L37) calculates voucher selectable dates adding 4 weeks to the first selectable date (or 3 weeks if it before wednesday 6 am). 

The validation here is simpler, the selectable window is 4 weeks long and starts on the next cut off day. The problem is when the cut off day is not a selectable day of the week for the selected plan. In these cases the window will be effectively smaller after applying day of the week rules.

The fix was to add an extra week to the voucher validation rules. 
I'm not sure if there's a corner case that would make this not match the frontend results. In any case, I don't think it would be a problem if CSRs can add vouchers that start a week later that the latest selectable date in the frontend