### PR TITLE
Ignore provided identity id when merging contacts

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/TypeConvert.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/TypeConvert.scala
@@ -5,8 +5,8 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 
 object TypeConvert {
 
-  implicit class TypeConvertClientOp[A](theEither: ClientFailableOp[A]) {
-    def toApiGatewayOp = theEither.toDisjunction.toApiGatewayOp(_)
+  implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
   }
 
 }

--- a/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/TypeConvert.scala
+++ b/handlers/digital-subscription-expiry/src/main/scala/com/gu/digitalSubscriptionExpiry/TypeConvert.scala
@@ -5,8 +5,8 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 
 object TypeConvert {
 
-  implicit class TypeConvertClientOp[A](theEither: ClientFailableOp[A]) {
-    def toApiGatewayOp = theEither.toDisjunction.toApiGatewayOp(_)
+  implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
   }
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/TypeConvert.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/TypeConvert.scala
@@ -5,8 +5,8 @@ import com.gu.util.reader.Types._
 
 object TypeConvert {
 
-  implicit class TypeConvertClientOp[A](theEither: ClientFailableOp[A]) {
-    def toApiGatewayOp = theEither.toDisjunction.toApiGatewayOp(_)
+  implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
   }
 
 }

--- a/handlers/identity-retention/src/main/scala/com/gu/identityRetention/TypeConvert.scala
+++ b/handlers/identity-retention/src/main/scala/com/gu/identityRetention/TypeConvert.scala
@@ -5,8 +5,8 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 
 object TypeConvert {
 
-  implicit class TypeConvertClientOp[A](theEither: ClientFailableOp[A]) {
-    def toApiGatewayOp = theEither.toDisjunction.toApiGatewayOp(_)
+  implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
   }
 
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/TypeConvert.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/TypeConvert.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
 object TypeConvert {
 
   implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
-    def toApiGatewayOp = clientOp.toDisjunction.toApiGatewayOp(_)
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
   }
 
   implicit class TypeConvertClientOpAsync[A](clientOp: ClientFailableOp[A]) {

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/TypeConvert.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/TypeConvert.scala
@@ -6,7 +6,7 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 object TypeConvert {
 
   implicit class TypeConvertClientOp[A](theEither: ClientFailableOp[A]) {
-    def toApiGatewayOp = theEither.toDisjunction.toApiGatewayOp(_)
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = theEither.toDisjunction.toApiGatewayOp(action)
   }
 
 }

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/EnsureNoAccountWithWrongIdentityId.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/EnsureNoAccountWithWrongIdentityId.scala
@@ -1,38 +1,22 @@
 package com.gu.sf_contact_merge.validate
 
 import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.IdentityId
+import scalaz.{-\/, \/, \/-}
 
-object EnsureNoAccountWithWrongIdentityId { // make sure all accounts are either this identity id or none
+object EnsureNoAccountWithWrongIdentityId {
 
-  val apply: EnsureNoAccountWithWrongIdentityId = //FIXME use the validation from new-product-api
-    (
-      accounts: List[Option[IdentityId]],
-      maybeCorrectIdentityId: Option[IdentityId]
-    ) =>
-      maybeCorrectIdentityId match {
-        case Some(correctIdentityId) =>
-          val wrongIdentityIdIsThere = accounts.filter(_.exists(_ != correctIdentityId))
-          if (wrongIdentityIdIsThere.nonEmpty)
-            Some(
-              s"one of the accounts had an unexpected identity id other than: $correctIdentityId - can't merge yet: $wrongIdentityIdIsThere"
-            )
-          else
-            None
-        case None =>
-          val hasIdentityButWillLoseIt = accounts.filter(_.isDefined)
-          if (hasIdentityButWillLoseIt.nonEmpty)
-            Some(s"one of the accounts had an identity id but will lose it: $hasIdentityButWillLoseIt")
-          else
-            None
+  val apply: EnsureNoAccountWithWrongIdentityId =
+    (accounts: List[Option[IdentityId]]) =>
+      accounts.flatten.distinct match {
+        case Nil => \/-(None)
+        case id :: Nil => \/-(Some(id))
+        case multi => -\/(s"there are multiple identity ids: $multi")
       }
 
 }
 
 trait EnsureNoAccountWithWrongIdentityId {
 
-  def apply(
-    accounts: List[Option[IdentityId]],
-    maybeCorrectIdentityId: Option[IdentityId]
-  ): Option[String]
+  def apply(accounts: List[Option[IdentityId]]): String \/ Option[IdentityId]
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -30,8 +30,7 @@ class EndToEndTest extends FlatSpec with Matchers {
         |      "2c92c0f9624bbc5f016253e573970b16",
         |      "2c92c0f8644618e30164652a558c6e20"
         |   ],
-        |   "accountId":"sfacc",
-        |   "identityId":"identest"
+        |   "accountId":"sfacc"
         |}
       """.stripMargin
     val input = ApiGatewayRequest(None, Some(body), None, None)

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/validate/EnsureNoAccountWithWrongIdentityIdTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/validate/EnsureNoAccountWithWrongIdentityIdTest.scala
@@ -2,57 +2,49 @@ package com.gu.sf_contact_merge.validate
 
 import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.IdentityId
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.{-\/, \/-}
 
 class EnsureNoAccountWithWrongIdentityIdTest extends FlatSpec with Matchers {
 
-  it should "pass when we update to an identity id which is already" in {
+  it should "get a single identity id correctly" in {
 
-    val existingAccounts = List(Some(IdentityId("newidid")))
-    val newIdentityId = Some(IdentityId("newidid"))
+    val maybeIdentityId = Some(IdentityId("newidid"))
+    val existingAccounts = List(maybeIdentityId)
 
-    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts, newIdentityId)
+    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts)
 
-    actual should be(None)
+    actual should be(\/-(maybeIdentityId))
   }
 
-  it should "pass when we update to an identity id which is not present at all" in {
+  it should "return none when there's no identity" in {
 
-    val existingAccounts = List(None)
-    val newIdentityId = Some(IdentityId("newidid"))
+    val maybeIdentityId = None
+    val existingAccounts = List(maybeIdentityId)
 
-    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts, newIdentityId)
+    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts)
 
-    actual should be(None)
-  }
-
-  it should "pass when we ask to remove to a blank identity id and one is not present anyway" in {
-
-    val existingAccounts = List(None)
-    val newIdentityId = None
-
-    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts, newIdentityId)
-
-    actual should be(None)
+    actual should be(\/-(maybeIdentityId))
   }
 
   it should "FAIL when we update to an identity id which is contradicted" in {
 
-    val existingAccounts = List(Some(IdentityId("existingidid")))
-    val newIdentityId = Some(IdentityId("newidid"))
+    val maybeIdentityId1 = Some(IdentityId("newidid1"))
+    val maybeIdentityId2 = Some(IdentityId("newidid2"))
+    val existingAccounts = List(maybeIdentityId1, maybeIdentityId2)
 
-    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts, newIdentityId)
+    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts)
 
-    actual.map(_.split(":")(0)) should be(Some("one of the accounts had an unexpected identity id other than"))
+    actual.leftMap(_.split(":")(0)) should be(-\/("there are multiple identity ids"))
   }
 
-  it should "FAIL when we ask to remove to an identity id where one is already present" in {
+  it should "get a single identity id correctly when duplicated and with Nones" in {
 
-    val existingAccounts = List(Some(IdentityId("existingidid")))
-    val newIdentityId = None
+    val maybeIdentityId = Some(IdentityId("newidid"))
+    val existingAccounts = List(None, maybeIdentityId, None, maybeIdentityId)
 
-    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts, newIdentityId)
+    val actual = EnsureNoAccountWithWrongIdentityId.apply(existingAccounts)
 
-    actual.map(_.split(":")(0)) should be(Some("one of the accounts had an identity id but will lose it"))
+    actual should be(\/-(maybeIdentityId))
   }
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -80,7 +80,7 @@ object ReadFile {
 
   case class JsonString(value: String) extends AnyVal
 
-  case class Record(Json_For_Zuora__c: String)
+  case class Record(Json_For_Zuora__c: Option[String])
 
   implicit val readsRecord = Json.reads[Record]
 
@@ -93,7 +93,7 @@ object ReadFile {
       val json = Json.parse(new FileInputStream(name.value))
       val resp = json.validate[SFQueryResponse]
       resp match {
-        case JsSuccess(value, _) => \/-(value.records.map(a => JsonString(a.Json_For_Zuora__c)))
+        case JsSuccess(value, _) => \/-(value.records.flatMap(_.Json_For_Zuora__c.map(JsonString.apply)))
         case fail => -\/(s"FAIL to parse: $fail")
       }
     }.toEither.disjunction.leftMap(_.toString).flatMap(identity)

--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -157,6 +157,12 @@ object Types extends Logging {
           ReturnWithResponse(internalServerError(s"Failed to execute lambda - unable to $action"))
       }
 
+    def toApiGatewayOp(toApiResponse: L => ApiResponse): ApiGatewayOp[A] =
+      theEither match {
+        case scalaz.\/-(success) => ContinueProcessing(success)
+        case scalaz.-\/(error) => ReturnWithResponse(toApiResponse(error))
+      }
+
   }
 
   implicit class LogImplicit[A](op: A) {

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/TypeConvert.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/TypeConvert.scala
@@ -5,8 +5,8 @@ import com.gu.util.resthttp.Types.ClientFailableOp
 
 object TypeConvert {
 
-  implicit class TypeConvertClientOp[A](theEither: ClientFailableOp[A]) {
-    def toApiGatewayOp = theEither.toDisjunction.toApiGatewayOp(_)
+  implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
   }
 
 }


### PR DESCRIPTION
So I am linking zuora subs together with the winning SF contact, and also updating the identity id at the same time.
In the JSON provided by SF there was an identity id which I was checking to make sure it wasn't suggesting to delete an existing one.
However it turns out based on discussion this is not the right approach, the identity id provided by salesforce is not relevant and should be ignored, as it is the existing one on the winning contact.
This means that ones where the identity contact wasn't the winning one were being rejected by the pre checks.

This PR updates it to work out the correct identity id from zuora, and then write that to the winning contact and the zuora accounts.

Abhishek will remove the field from the provided JSON at some point if it's not too much trouble, as it's redundant and it will prevent the possibility of future confusion.

@pvighi @paulbrown1982 @abhichawla