### PR TITLE
Publish sfContactId on sendConfirmationEmail

### DIFF
--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/DigitalSubscriptionExpiryStepsTest.scala
@@ -232,7 +232,6 @@ class DeserialiserTest extends FlatSpec with Matchers {
 
   "deserialise url params" should "manage without the noActivation param" in {
     val json = """{"apiToken": "a", "apiClientId": "b"}"""
-    val actualRequest = Json.parse(json).validate[UrlParams]
 
     Json.parse(json).validate[UrlParams] should be(JsSuccess(UrlParams(false)))
 
@@ -240,14 +239,12 @@ class DeserialiserTest extends FlatSpec with Matchers {
 
   it should "manage with the noActivation param being false" in {
     val json = """{"apiToken": "a", "apiClientId": "b", "noActivation": "false"}"""
-    val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     Json.parse(json).validate[UrlParams] should be(JsSuccess(UrlParams(false)))
   }
 
   it should "manage with the noActivation param being true" in {
     val json = """{"apiToken": "a", "apiClientId": "b", "noActivation": "true"}"""
-    val actualRequest = Json.parse(json).validate[ApiGatewayRequest]
 
     Json.parse(json).validate[UrlParams] should be(JsSuccess(UrlParams(true)))
   }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/ETPayload.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/ETPayload.scala
@@ -6,7 +6,7 @@ case class CContactAttributes[A](SubscriberAttributes: A)
 
 case class CTo[A](Address: String, SubscriberKey: String, ContactAttributes: CContactAttributes[A])
 
-case class ETPayload[A](To: CTo[A], DataExtensionName: String)
+case class ETPayload[A](To: CTo[A], DataExtensionName: String, SfContactId: Option[String])
 
 object CContactAttributes {
   implicit def writes[A: Writes] = Json.writes[CContactAttributes[A]]
@@ -20,10 +20,11 @@ object ETPayload {
 
   implicit def writes[A: Writes] = Json.writes[ETPayload[A]]
 
-  def apply[A](email: String, fields: A, name: DataExtensionName): ETPayload[A] =
+  def apply[A](email: String, fields: A, name: DataExtensionName, sfContactId: Option[String]): ETPayload[A] =
     ETPayload(
       To = CTo(email, email, CContactAttributes(fields)),
-      DataExtensionName = name.value
+      DataExtensionName = name.value,
+      SfContactId = sfContactId
     )
 }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/EtSqsSend.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/EtSqsSend.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 
 object EtSqsSend extends Logging {
 
-  def apply[FIELDS: Writes](sqsSend: Payload => Future[Unit]) = { etPayload: ETPayload[FIELDS] =>
+  def apply[FIELDS: Writes](sqsSend: Payload => Future[Unit])(etPayload: ETPayload[FIELDS]) = {
     val payloadString = Json.prettyPrint(Json.toJson(etPayload))
     sqsSend(Payload(payloadString))
   }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/contributions/SendConfirmationEmailContributions.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/contributions/SendConfirmationEmailContributions.scala
@@ -44,7 +44,10 @@ object SendConfirmationEmailContributions extends Logging {
 
   }
 
-  def toPayload(sfContactId: Option[SfContactId], maybeContributionFields: Option[ContributionFields]): AsyncApiGatewayOp[ETPayload[ContributionFields]] =
+  def toPayload(
+    sfContactId: Option[SfContactId],
+    maybeContributionFields: Option[ContributionFields]
+  ): AsyncApiGatewayOp[ETPayload[ContributionFields]] =
     maybeContributionFields.map { fields =>
       val payload = ETPayload(fields.EmailAddress, fields, DataExtensionName("regular-contribution-thank-you"), sfContactId.map(_.value))
       ContinueProcessing(payload).toAsync

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
@@ -3,6 +3,7 @@ package com.gu.newproduct.api.addsubscription.email.voucher
 import java.time.LocalDate
 
 import com.gu.newproduct.api.addsubscription.email.{DataExtensionName, ETPayload}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
@@ -16,15 +17,17 @@ object SendConfirmationEmailVoucher extends Logging {
   def apply(
     etSqsSend: ETPayload[VoucherEmailData] => Future[Unit],
     getCurrentDate: () => LocalDate
-  )(data: VoucherEmailData): AsyncApiGatewayOp[Unit] = for {
-    etPayload <- toPayload(data).toAsync
+  )(sfContactId: Option[SfContactId],
+    data: VoucherEmailData
+  ): AsyncApiGatewayOp[Unit] = for {
+    etPayload <- toPayload(sfContactId, data).toAsync
     sendMessageResult <- etSqsSend(etPayload).toAsyncApiGatewayOp("sending voucher email sqs message")
   } yield sendMessageResult
 
-  def toPayload(voucherEmailData: VoucherEmailData): ApiGatewayOp[ETPayload[VoucherEmailData]] =
+  def toPayload(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData): ApiGatewayOp[ETPayload[VoucherEmailData]] =
     voucherEmailData.contacts.soldTo.email match {
       case Some(email) =>
-        val payload = ETPayload(email = email.value, fields = voucherEmailData, DataExtensionName("paper-voucher"))
+        val payload = ETPayload(email = email.value, fields = voucherEmailData, DataExtensionName("paper-voucher"), sfContactId.map(_.value))
         ContinueProcessing(payload)
       case None =>
         val errorLogMessage = "No email address in zuora sold to contact, skipping voucher thank you email"

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
@@ -27,7 +27,12 @@ object SendConfirmationEmailVoucher extends Logging {
   def toPayload(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData): ApiGatewayOp[ETPayload[VoucherEmailData]] =
     voucherEmailData.contacts.soldTo.email match {
       case Some(email) =>
-        val payload = ETPayload(email = email.value, fields = voucherEmailData, DataExtensionName("paper-voucher"), sfContactId.map(_.value))
+        val payload = ETPayload(
+          email = email.value,
+          fields = voucherEmailData,
+          DataExtensionName("paper-voucher"),
+          sfContactId.map(_.value)
+        )
         ContinueProcessing(payload)
       case None =>
         val errorLogMessage = "No email address in zuora sold to contact, skipping voucher thank you email"

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccount.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccount.scala
@@ -6,6 +6,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount._
 
 case class ValidatedAccount(
   identityId: Option[IdentityId],
+  sfContactId: Option[SfContactId],
   paymentMethodId: PaymentMethodId,
   autoPay: AutoPay,
   accountBalanceMinorUnits: AccountBalanceMinorUnits,
@@ -20,6 +21,7 @@ object ValidateAccount {
       paymentMethodId <- account.paymentMethodId getOrFailWith "Zuora account has no default payment method"
     } yield ValidatedAccount(
       account.identityId,
+      account.sfContactId,
       paymentMethodId,
       account.autoPay,
       account.accountBalanceMinorUnits,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccount.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccount.scala
@@ -12,6 +12,7 @@ object GetAccount {
 
     case class ZuoraAccount(
       IdentityId__c: Option[String],
+      sfContactId__c: Option[String],
       DefaultPaymentMethodId: Option[String],
       AutoPay: Boolean,
       Balance: Double,
@@ -24,6 +25,7 @@ object GetAccount {
       case Some(currency) => ClientSuccess(
         Account(
           zuoraAccount.IdentityId__c.map(IdentityId),
+          zuoraAccount.sfContactId__c.map(SfContactId.apply),
           zuoraAccount.DefaultPaymentMethodId.map(PaymentMethodId),
           AutoPay(zuoraAccount.AutoPay),
           AccountBalanceMinorUnits((zuoraAccount.Balance * 100).toInt),
@@ -40,6 +42,8 @@ object GetAccount {
 
   case class IdentityId(value: String) extends AnyVal
 
+  case class SfContactId(value: String) extends AnyVal
+
   case class PaymentMethodId(value: String) extends AnyVal
 
   case class AutoPay(value: Boolean) extends AnyVal
@@ -48,6 +52,7 @@ object GetAccount {
 
   case class Account(
     identityId: Option[IdentityId],
+    sfContactId: Option[SfContactId],
     paymentMethodId: Option[PaymentMethodId],
     autoPay: AutoPay,
     accountBalanceMinorUnits: AccountBalanceMinorUnits,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/TestData.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/TestData.scala
@@ -5,7 +5,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.validation.ValidatedAccount
 import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionCustomerData
 import com.gu.newproduct.api.addsubscription.validation.voucher.VoucherCustomerData
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, IdentityId, PaymentMethodId}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, IdentityId, PaymentMethodId, SfContactId}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.{Active, Subscription}
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{BankAccountName, BankAccountNumberMask, DirectDebit, MandateId, SortCode}
@@ -18,7 +18,8 @@ object TestData {
     paymentMethodId = PaymentMethodId("paymentMethodId"),
     autoPay = AutoPay(true),
     accountBalanceMinorUnits = AccountBalanceMinorUnits(1234),
-    currency = GBP
+    currency = GBP,
+    sfContactId = Some(SfContactId("sfContactId"))
   )
   val contacts = Contacts(
     billTo = BillToContact(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -9,6 +9,7 @@ import com.gu.newproduct.api.addsubscription.validation.contribution.Contributio
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.test.JsonMatchers.JsonMatcher
@@ -54,7 +55,7 @@ class ContributionStepsTest extends FlatSpec with Matchers {
       ClientSuccess(SubscriptionName("well done"))
     }
 
-    def fakeSendEmails(contributionsEmailData: ContributionsEmailData) = {
+    def fakeSendEmails(sfContactId: Option[SfContactId], contributionsEmailData: ContributionsEmailData) = {
       ContinueProcessing(()).toAsync
     }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckTest.scala
@@ -2,7 +2,7 @@ package com.gu.newproduct.api.addsubscription
 
 import com.gu.i18n.Currency
 import com.gu.newproduct.api.addsubscription.AccountIdentitys.HealthCheckTestAccountData
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{Account, AccountBalanceMinorUnits, AutoPay, IdentityId}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount._
 import com.gu.util.resthttp.Types
 import com.gu.util.resthttp.Types.ClientSuccess
 import org.scalatest.{FlatSpec, Matchers}
@@ -12,7 +12,7 @@ class HealthCheckTest extends FlatSpec with Matchers {
   it should "pass" in {
     def getAccount(requestedAccountId: ZuoraAccountId): Types.ClientFailableOp[Account] = {
       requestedAccountId should be(ZuoraAccountId("accacc"))
-      ClientSuccess(Account(Some(IdentityId("1313")), None, AutoPay(false), AccountBalanceMinorUnits(0), Currency.GBP))
+      ClientSuccess(Account(Some(IdentityId("1313")), Some(SfContactId("1414")), None, AutoPay(false), AccountBalanceMinorUnits(0), Currency.GBP))
     }
 
     val fakeTestData = HealthCheckTestAccountData(ZuoraAccountId("accacc"), IdentityId("1313"))
@@ -21,7 +21,7 @@ class HealthCheckTest extends FlatSpec with Matchers {
 
   it should "fail" in {
     def getAccount(dontcare: ZuoraAccountId): Types.ClientFailableOp[Account] = {
-      ClientSuccess(Account(Some(IdentityId("asdf")), None, AutoPay(false), AccountBalanceMinorUnits(0), Currency.GBP))
+      ClientSuccess(Account(Some(IdentityId("asdf")), Some(SfContactId("1414")), None, AutoPay(false), AccountBalanceMinorUnits(0), Currency.GBP))
     }
 
     val fakeTestData = HealthCheckTestAccountData(ZuoraAccountId("accacc"), IdentityId("1313"))

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/HealthCheckTest.scala
@@ -12,7 +12,15 @@ class HealthCheckTest extends FlatSpec with Matchers {
   it should "pass" in {
     def getAccount(requestedAccountId: ZuoraAccountId): Types.ClientFailableOp[Account] = {
       requestedAccountId should be(ZuoraAccountId("accacc"))
-      ClientSuccess(Account(Some(IdentityId("1313")), Some(SfContactId("1414")), None, AutoPay(false), AccountBalanceMinorUnits(0), Currency.GBP))
+      ClientSuccess(
+        Account(
+          Some(IdentityId("1313")),
+          Some(SfContactId("1414")),
+          None, AutoPay(false),
+          AccountBalanceMinorUnits(0),
+          Currency.GBP
+        )
+      )
     }
 
     val fakeTestData = HealthCheckTestAccountData(ZuoraAccountId("accacc"), IdentityId("1313"))
@@ -21,7 +29,16 @@ class HealthCheckTest extends FlatSpec with Matchers {
 
   it should "fail" in {
     def getAccount(dontcare: ZuoraAccountId): Types.ClientFailableOp[Account] = {
-      ClientSuccess(Account(Some(IdentityId("asdf")), Some(SfContactId("1414")), None, AutoPay(false), AccountBalanceMinorUnits(0), Currency.GBP))
+      ClientSuccess(
+        Account(
+          Some(IdentityId("asdf")),
+          Some(SfContactId("1414")),
+          None,
+          AutoPay(false),
+          AccountBalanceMinorUnits(0),
+          Currency.GBP
+        )
+      )
     }
 
     val fakeTestData = HealthCheckTestAccountData(ZuoraAccountId("accacc"), IdentityId("1313"))

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -7,6 +7,7 @@ import com.gu.newproduct.api.addsubscription.email.voucher.VoucherEmailData
 import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{SubscriptionName, ZuoraCreateSubRequest}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.PlanId.VoucherEveryDay
 import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription, PlanId}
 import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
@@ -73,7 +74,7 @@ class VoucherStepsTest extends FlatSpec with Matchers {
     //todo maybe add assertions on the input params for these two
     def fakeValidateVoucherStartDate(id: PlanId, d: LocalDate) = Passed(())
 
-    def fakeSendEmail(voucherEmailData: VoucherEmailData) = ContinueProcessing(()).toAsync
+    def fakeSendEmail(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData) = ContinueProcessing(()).toAsync
 
     def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"))
     val fakeAddVoucherSteps = Steps.addVoucherSteps(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/ETPayloadTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/ETPayloadTest.scala
@@ -22,7 +22,8 @@ class ETPayloadTest extends FlatSpec with Matchers {
         )
 
       ),
-      DataExtensionName = "someDataExtension"
+      DataExtensionName = "someDataExtension",
+      SfContactId = Some("sfContactId")
     )
 
     val expected =
@@ -37,7 +38,8 @@ class ETPayloadTest extends FlatSpec with Matchers {
         |            }
         |        }
         |    },
-        |    "DataExtensionName": "someDataExtension"
+        |    "DataExtensionName": "someDataExtension",
+        |    "SfContactId" : "sfContactId"
         |}
       """.stripMargin
     Json.toJson(testPayload) shouldBe Json.parse(expected)

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/contributions/SendConfirmationEmailContributionsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/contributions/SendConfirmationEmailContributionsTest.scala
@@ -7,6 +7,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
 import com.gu.newproduct.api.addsubscription.email.contributions.SendConfirmationEmailContributions.ContributionsEmailData
 import com.gu.newproduct.api.addsubscription.email.{CContactAttributes, CTo, ETPayload}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{BankAccountName, BankAccountNumberMask, DirectDebit, MandateId, NonDirectDebitMethod, SortCode}
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodStatus.ActivePaymentMethod
@@ -15,9 +16,7 @@ import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import org.scalatest.{AsyncFlatSpec, Matchers}
-
 import scala.concurrent.Future
-import scala.language.postfixOps
 
 class SendConfirmationEmailContributionsTest extends AsyncFlatSpec with Matchers {
 
@@ -55,6 +54,8 @@ class SendConfirmationEmailContributionsTest extends AsyncFlatSpec with Matchers
     billTo = testContact
   )
 
+  val sfContactId = Some(SfContactId("sfContactId"))
+
   it should "send confirmation email" in {
 
     def sqsSend(payload: ETPayload[ContributionFields]): Future[Unit] = {
@@ -82,7 +83,8 @@ class SendConfirmationEmailContributionsTest extends AsyncFlatSpec with Matchers
           SubscriberKey = "email@email.com",
           ContactAttributes = expectedContactAttributes
         ),
-        DataExtensionName = "regular-contribution-thank-you"
+        DataExtensionName = "regular-contribution-thank-you",
+        SfContactId = Some("sfContactId")
       )
 
       payload shouldBe expectedPayload
@@ -91,7 +93,7 @@ class SendConfirmationEmailContributionsTest extends AsyncFlatSpec with Matchers
 
     val send = SendConfirmationEmailContributions(sqsSend, today) _
 
-    send(testData).underlying map {
+    send(sfContactId, testData).underlying map {
       res => res shouldBe ContinueProcessing(())
     }
 
@@ -103,7 +105,7 @@ class SendConfirmationEmailContributionsTest extends AsyncFlatSpec with Matchers
 
     val send = SendConfirmationEmailContributions(sqsSend, today) _
 
-    send(testData).underlying map {
+    send(sfContactId, testData).underlying map {
       res => res shouldBe ReturnWithResponse(ApiGatewayResponse.internalServerError("some log message"))
     }
   }
@@ -114,7 +116,7 @@ class SendConfirmationEmailContributionsTest extends AsyncFlatSpec with Matchers
 
     val send = SendConfirmationEmailContributions(sqsSend, today) _
 
-    send(testData).underlying map {
+    send(sfContactId, testData).underlying map {
       res => res shouldBe ReturnWithResponse(ApiGatewayResponse.internalServerError("some log message"))
     }
   }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucherTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucherTest.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 import com.gu.newproduct.TestData
 import com.gu.newproduct.api.addsubscription.email.{DataExtensionName, ETPayload}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.PlanId.VoucherSunday
 import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription}
 import com.gu.util.apigateway.ApiGatewayResponse
@@ -14,11 +15,12 @@ import scala.concurrent.Future
 class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
   it should "send voucher confirmation email" in {
     def sqsSend(payload: ETPayload[VoucherEmailData]): Future[Unit] = Future {
-      payload shouldBe ETPayload("soldToEmail@mail.com", testVoucherData, DataExtensionName("paper-voucher"))
+      payload shouldBe ETPayload("soldToEmail@mail.com", testVoucherData, DataExtensionName("paper-voucher"), Some("sfContactId"))
+      ()
     }
 
     val send = SendConfirmationEmailVoucher(sqsSend, today) _
-    send(testVoucherData).underlying map {
+    send(Some(SfContactId("sfContactId")), testVoucherData).underlying map {
       result => result shouldBe ContinueProcessing(())
     }
   }
@@ -32,7 +34,7 @@ class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
     def sqsSend(payload: ETPayload[VoucherEmailData]): Future[Unit] = Future.successful(())
 
     val send = SendConfirmationEmailVoucher(sqsSend, today) _
-    send(noSoldToEmailVoucherData).underlying map {
+    send(Some(SfContactId("sfContactId")), noSoldToEmailVoucherData).underlying map {
       result => result shouldBe ReturnWithResponse(ApiGatewayResponse.internalServerError("some error"))
     }
   }
@@ -43,7 +45,7 @@ class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
 
     val send = SendConfirmationEmailVoucher(sqsSend, today) _
 
-    send(testVoucherData).underlying map {
+    send(Some(SfContactId("sfContactId")), testVoucherData).underlying map {
       result => result shouldBe ReturnWithResponse(ApiGatewayResponse.internalServerError("some error"))
     }
   }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccountTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccountTest.scala
@@ -8,6 +8,7 @@ class ValidateAccountTest extends FlatSpec with Matchers {
 
   val validAccount = Account(
     identityId = Some(IdentityId("idAccount1")),
+    sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = Some(PaymentMethodId("activePaymentMethod")),
     autoPay = AutoPay(true),
     accountBalanceMinorUnits = AccountBalanceMinorUnits(0),
@@ -16,6 +17,7 @@ class ValidateAccountTest extends FlatSpec with Matchers {
 
   val validatedAccount = ValidatedAccount(
     identityId = Some(IdentityId("idAccount1")),
+    sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("activePaymentMethod"),
     autoPay = AutoPay(true),
     accountBalanceMinorUnits = AccountBalanceMinorUnits(0),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionAccountValidationTest.scala
@@ -2,12 +2,13 @@ package com.gu.newproduct.api.addsubscription.validation.contribution
 
 import com.gu.i18n.Currency.GBP
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed, ValidatedAccount}
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, IdentityId, PaymentMethodId}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount._
 import org.scalatest.{FlatSpec, Matchers}
 
 class ContributionAccountValidationTest extends FlatSpec with Matchers {
   val account = ValidatedAccount(
     identityId = Some(IdentityId("identityId")),
+    sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("id"),
     autoPay = AutoPay(true),
     accountBalanceMinorUnits = AccountBalanceMinorUnits(1233),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/VoucherAccountValidationTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/voucher/VoucherAccountValidationTest.scala
@@ -2,12 +2,13 @@ package com.gu.newproduct.api.addsubscription.validation.voucher
 
 import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.newproduct.api.addsubscription.validation.{Failed, Passed, ValidatedAccount}
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, PaymentMethodId}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.{AccountBalanceMinorUnits, AutoPay, PaymentMethodId, SfContactId}
 import org.scalatest.{FlatSpec, Matchers}
 
 class VoucherAccountValidationTest extends FlatSpec with Matchers {
   val account = ValidatedAccount(
     identityId = None,
+    sfContactId = Some(SfContactId("sfContactId")),
     paymentMethodId = PaymentMethodId("id"),
     autoPay = AutoPay(true),
     accountBalanceMinorUnits = AccountBalanceMinorUnits(1233),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountEffectsTest.scala
@@ -21,6 +21,7 @@ class GetAccountEffectsTest extends FlatSpec with Matchers {
     } yield res
     val expected = Account(
       identityId = Some(IdentityId("30000549")),
+      sfContactId = Some(SfContactId("sfContactId")),
       paymentMethodId = Some(PaymentMethodId("2c92c0f860017cd501600893132117ae")),
       autoPay = AutoPay(true),
       accountBalanceMinorUnits = AccountBalanceMinorUnits(0),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetAccountTest.scala
@@ -15,7 +15,8 @@ class GetAccountTest extends FlatSpec with Matchers {
     DefaultPaymentMethodId = Some("2c92c0f8649cc8a60164a2bfd475000c"),
     AutoPay = false,
     Balance = 24.55,
-    Currency = "GBP"
+    Currency = "GBP",
+    sfContactId__c = Some("sfContactId")
   )
   it should "get account as object" in {
 
@@ -26,6 +27,7 @@ class GetAccountTest extends FlatSpec with Matchers {
     val actual = GetAccount(accF)(ZuoraAccountId("2c92c0f9624bbc5f016253e573970b16"))
     actual shouldBe ClientSuccess(Account(
       Some(IdentityId("6002")),
+      Some(SfContactId("sfContactId")),
       Some(PaymentMethodId("2c92c0f8649cc8a60164a2bfd475000c")),
       AutoPay(false),
       AccountBalanceMinorUnits(2455),
@@ -34,13 +36,14 @@ class GetAccountTest extends FlatSpec with Matchers {
   }
 
   it should "deserialise accounts with missing identity id or default payment method" in {
-    val missingFieldsAccount = acc.copy(IdentityId__c = None, DefaultPaymentMethodId = None)
+    val missingFieldsAccount = acc.copy(IdentityId__c = None, DefaultPaymentMethodId = None, sfContactId__c = None)
     val accF: RequestsGet[ZuoraAccount] = {
       case ("object/account/missingFieldsAccount", WithoutCheck) => ClientSuccess(missingFieldsAccount)
       case in => GenericError(s"bad request: $in")
     }
     val actual = GetAccount(accF)(ZuoraAccountId("missingFieldsAccount"))
     actual shouldBe ClientSuccess(Account(
+      None,
       None,
       None,
       AutoPay(false),

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -10,7 +10,7 @@ object AddSubscriptionManualTest extends App {
   val requestBody =
     """{
       |   "zuoraAccountId":"2c92c0f865244687016538e563b85fac",
-      |   "startDate":"2018-08-15",
+      |   "startDate":"2018-10-15",
       |   "acquisitionSource":"CSR",
       |   "createdByCSR":"CSRName",
       |   "amountMinorUnits": 500,

--- a/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
@@ -12,6 +12,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.NonDirectDebitMethod
 import com.gu.newproduct.api.addsubscription.zuora.{PaymentMethodStatus, PaymentMethodType}
 import com.gu.newproduct.api.addsubscription.ZuoraAccountId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.util.config.Stage
 
@@ -53,7 +54,7 @@ object SendConfirmationEmailsManualTest {
       sqsSend = AwsSQSSend(queueName) _
       contributionsSqsSend = EtSqsSend[ContributionFields](sqsSend) _
       sendConfirmationEmail = SendConfirmationEmailContributions(contributionsSqsSend, () => fakeDate) _
-      sendResult = sendConfirmationEmail(contributionsEmailData(fakeContact(email)))
+      sendResult = sendConfirmationEmail(Some(SfContactId("sfContactId")), contributionsEmailData(fakeContact(email)))
     } yield sendResult
     result match {
       case None =>

--- a/handlers/new-product-api/src/test/scala/manualTest/SendVoucherEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendVoucherEmailsManualTest.scala
@@ -8,6 +8,7 @@ import com.gu.newproduct.api.addsubscription.Steps.emailQueuesFor
 import com.gu.newproduct.api.addsubscription.email.EtSqsSend
 import com.gu.newproduct.api.addsubscription.email.voucher.{SendConfirmationEmailVoucher, VoucherEmailData}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetContacts._
 import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{BankAccountName, BankAccountNumberMask, DirectDebit, MandateId, SortCode}
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodStatus.ActivePaymentMethod
@@ -82,7 +83,7 @@ object SendVoucherEmailsManualTest {
       voucherSqsSend = EtSqsSend[VoucherEmailData](sqsSend) _
       sendConfirmationEmail = SendConfirmationEmailVoucher(voucherSqsSend, () => fakeDate) _
       data = fakeVoucherEmailData(email)
-      sendResult = sendConfirmationEmail(fakeVoucherEmailData(email))
+      sendResult = sendConfirmationEmail(Some(SfContactId("sfContactId")), fakeVoucherEmailData(email))
     } yield sendResult
     result match {
       case None =>


### PR DESCRIPTION
Part of ET to Braze CMT migration.
We are going to store sfContactIds in Braze.
Required by membship-workflow. 
see https://github.com/guardian/membership-workflow/pull/143