### PR TITLE
add the address fields to the zuora query

### DIFF
--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/EndToEndTest.scala
@@ -89,7 +89,7 @@ object EndToEndTest {
 
   val contactQueryRequest =
     """{"queryString":"
-      |SELECT Id, WorkEmail, FirstName, LastName
+      |SELECT Id, WorkEmail, FirstName, LastName, Address1, City, State, PostalCode, Country
       | FROM Contact
       | WHERE Id = '2c92c0f8644618e30164652a55986e21' or Id = '2c92c0f9624bbc5f016253e5739b0b17'
       |"}""".stripMargin.replaceAll("""\n""", "")
@@ -101,13 +101,23 @@ object EndToEndTest {
       |            "WorkEmail": "peppa.pig@guardian.co.uk",
       |            "Id": "2c92c0f8644618e30164652a55986e21",
       |            "FirstName": "peppa",
-      |            "LastName": "pig"
+      |            "LastName": "pig",
+      |            "State": "Farmland",
+      |            "PostalCode": "N1 9GU",
+      |            "Country": "United Kingdom",
+      |            "City": "Grassy Hills",
+      |            "Address1": "Windy Castle"
       |        },
       |        {
       |            "WorkEmail": "peppa.pig@guardian.co.uk",
       |            "Id": "2c92c0f9624bbc5f016253e5739b0b17",
       |            "FirstName": "peppa",
-      |            "LastName": "pig"
+      |            "LastName": "pig",
+      |            "State": "Farmland",
+      |            "PostalCode": "N1 9GU",
+      |            "Country": "United Kingdom",
+      |            "City": "Grassy Hills",
+      |            "Address1": "Windy Castle"
       |        }
       |    ],
       |    "size": 2,

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetZuoraContactDetailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getaccounts/GetZuoraContactDetailsTest.scala
@@ -1,6 +1,6 @@
 package com.gu.sf_contact_merge.getaccounts
 
-import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{ContactId, EmailAddress, FirstName, LastName, ZuoraContactDetails}
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails._
 import com.gu.util.resthttp.Types.ClientSuccess
 import com.gu.zuora.fake.FakeZuoraQuerier
 import org.scalatest.{FlatSpec, Matchers}
@@ -12,7 +12,9 @@ class GetZuoraContactDetailsTest extends FlatSpec with Matchers {
 
   it should "handle an email and a missing email with a fake querier" in {
 
-    val expectedQuery = """SELECT Id, WorkEmail, FirstName, LastName FROM Contact WHERE Id = 'cid1' or Id = 'cid2'"""
+    val expectedQuery =
+      """SELECT Id, WorkEmail, FirstName, LastName, Address1, City, State, PostalCode, Country""" +
+        """ FROM Contact WHERE Id = 'cid1' or Id = 'cid2'"""
 
     val querier = FakeZuoraQuerier(expectedQuery, contactQueryResponse)
 
@@ -22,8 +24,30 @@ class GetZuoraContactDetailsTest extends FlatSpec with Matchers {
     ))
 
     val expected = Map(
-      ContactId("cid1") -> ZuoraContactDetails(Some(EmailAddress("peppa.pig@guardian.co.uk")), Some(FirstName("peppa")), LastName("pig")),
-      ContactId("cid2") -> ZuoraContactDetails(None, None, LastName("pig"))
+      ContactId("cid1") -> ZuoraContactDetails(
+        Some(EmailAddress("peppa.pig@guardian.co.uk")),
+        Some(FirstName("peppa")),
+        LastName("pig"),
+        Address(
+          Some(Address1("Windy Castle")),
+          Some(City("Grassy Hills")),
+          Some(State("Farmland")),
+          Some(PostalCode("N1 9GU")),
+          Country("United Kingdom")
+        )
+      ),
+      ContactId("cid2") -> ZuoraContactDetails(
+        None,
+        None,
+        LastName("pig"),
+        Address(
+          None,
+          None,
+          None,
+          Some(PostalCode("n1 9gu")),
+          Country("United Kingdom")
+        )
+      )
     )
     actual should be(ClientSuccess(expected))
 
@@ -40,12 +64,20 @@ object GetZuoraContactDetailsTest {
       |            "WorkEmail": "peppa.pig@guardian.co.uk",
       |            "Id": "cid1",
       |            "FirstName": "peppa",
-      |            "LastName": "pig"
+      |            "LastName": "pig",
+      |            "State": "Farmland",
+      |            "PostalCode": "N1 9GU",
+      |            "Country": "United Kingdom",
+      |            "City": "Grassy Hills",
+      |            "Address1": "Windy Castle"
       |        },
       |        {
+      |            "Country": "United Kingdom",
       |            "Id": "cid2",
       |            "FirstName": ".",
-      |            "LastName": "pig"
+      |            "Address1": ",",
+      |            "LastName": "pig",
+      |            "PostalCode": "n1 9gu"
       |        }
       |    ],
       |    "size": 2,


### PR DESCRIPTION
We are merging together salesforce contacts where the contacts have the same email address.  This is good for GDPR because we have a coherent view of our connection with an individual and it's also good for self service as more of them will have an identity id afetrwards.

We always prefer an active subscription to be the winner when we are merging, but in some cases the cancelled one would be a recently cancelled paper sub, and the active could be a Friend.  The friend may not even have a billing address, so although the active should probably win, we should probably treat the adress we already have on the old contact to be the winner.

This PR is the first stage, just to read the billing addresses from zuora.  The next PRs will actually detect if the winner has no address by checking Address1, and if not, copy it over from one of the losing zuora billing contacts arbitrarily.

I need to find out that editing the address in zuora will actually reflect in salesforce to confirm that this technique is valid.  I didn't do this in salesforce because at present we don't look at the salesforce contacts at all. and we don't even have the losing contact ids without getting them from zuora.

@pvighi @paulbrown1982