### PR TITLE
ignore the case of email addresses when checking for discrepancies

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/AssertSame.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/AssertSame.scala
@@ -16,7 +16,10 @@ object AssertSame {
     _.value.toLowerCase // some seem to be entered entirely lower case, but this isn't a significant difference, so ignore
   )
 
-  val emailAddress: AssertSame[Option[EmailAddress]] = AssertSame[Option[EmailAddress]]("emails")
+  val emailAddress: AssertSame[Option[EmailAddress]] = AssertSame[Option[EmailAddress]](
+    "emails",
+    _.map(_.value.toLowerCase) // although emails are technically case sensitive on the first part, it's usually just a typing in difference
+  )
 
 }
 

--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -34,12 +34,12 @@ object RunBatch {
 
     val result = for {
       args <- GetArgs(rawArgs)
-      postString = HttpOp(Http.response).setupRequest(post(args.apiKey))
+      postString = HttpOp(Http.response).setupRequest(post(args.apiKey)).flatMap(RestRequestMaker.toClientFailableOp)
       jsons <- ReadFile(args.fileName)
       postJsonString = postString.setupRequest[JsonString](jsonString => BodyAsString(jsonString.value))
       requestWithResultAsTry = (jsonString: JsonString) =>
         postJsonString.runRequest(jsonString) match {
-          case ClientSuccess(unit) => \/-(())
+          case ClientSuccess(_) => \/-(())
           case f: ClientFailure => -\/(s"failed to call sf contact merge: $f")
         }
       err <- jsons.traverseU(requestWithResultAsTry)


### PR DESCRIPTION
This is part of the work to merge salesforce contacts together.  We want to get all info about a single customer under a single contact and all connected to the same identity id.

I have noticed when doing the merge that a lot of the email failures, although a small percentage overall, are just due to case being incorrect.  Although the first part is technically case sensitive, I don't think anyone would legitimately use it that way.

This pr just ignores the case when validating that the merge looks sensible, before actually doing the merge.

@pvighi @paulbrown1982 