### PR TITLE
convert cancellation lambda to use httpop for SF operations

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/salesforce/SalesforceGenericIdLookup.scala
@@ -1,9 +1,12 @@
 package com.gu.salesforce
 
 import ai.x.play.json.Jsonx
-import com.gu.util.resthttp.RestRequestMaker.Requests
+import com.gu.util.resthttp.HttpOp._
+import com.gu.util.resthttp.RestOp._
+import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
 import com.gu.util.resthttp.Types.ClientFailableOp
-import play.api.libs.json.Json
+import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
+import play.api.libs.json.{JsValue, Json}
 
 object SalesforceGenericIdLookup {
 
@@ -21,11 +24,13 @@ object SalesforceGenericIdLookup {
   case class ResponseWithId(Id: String)
   implicit val reads = Json.reads[ResponseWithId]
 
-  def apply(sfRequests: Requests)(
+  def apply(get: HttpOp[RestRequestMaker.GetRequest, JsValue]): (SfObjectType, FieldName, LookupValue) => ClientFailableOp[ResponseWithId] =
+    get.setupRequestMultiArg(toRequest _).parse[ResponseWithId].runRequestMultiArg
+
+  def toRequest(
     sfObjectType: SfObjectType,
     fieldName: FieldName,
     lookupValue: LookupValue
-  ): ClientFailableOp[ResponseWithId] =
-    sfRequests.get[ResponseWithId](s"/services/data/v29.0/sobjects/${sfObjectType.value}/${fieldName.value}/${lookupValue.value}")
+  ): GetRequest = RestRequestMaker.GetRequest(RelativePath(s"/services/data/v29.0/sobjects/${sfObjectType.value}/${fieldName.value}/${lookupValue.value}"))
 
 }

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -28,7 +28,7 @@ class EndToEndHandlerEffectsTest extends FlatSpec with Matchers {
     (for {
       identityAndSfRequests <- sfBackendForIdentityCookieHeader(apiGatewayRequest.headers)
       pathParams <- apiGatewayRequest.pathParamsAsCaseClass[CasePathParams]()
-      sfGet = SalesforceCase.GetById[JsValue](identityAndSfRequests.sfRequests)_
+      sfGet = SalesforceCase.GetById[JsValue](identityAndSfRequests.sfRequests.get)_
       getCaseResponse <- sfGet(pathParams.caseId).toApiGatewayOp("get case detail")
     } yield ApiGatewayResponse("200", getCaseResponse)).apiResponse
 

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSalesforceIdentityId.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSalesforceIdentityId.scala
@@ -32,7 +32,7 @@ object UpdateSalesforceIdentityId {
   case class SFContactUpdate(identityId: Option[IdentityId], firstName: UpdateFirstName, maybeNewAddress: SFAddressOverride)
 
   def apply(patchOp: HttpOp[PatchRequest, Unit]): SetOrClearIdentityId =
-    SetOrClearIdentityId(patchOp.setupRequestMultiArg(toRequest).runRequestMultiArg)
+    SetOrClearIdentityId(patchOp.setupRequestMultiArg(toRequest _).runRequestMultiArg)
 
   def toRequest(sFContactId: SFContactId, contactUpdate: SFContactUpdate): PatchRequest = {
 

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/HttpOp.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/HttpOp.scala
@@ -43,6 +43,13 @@ object HttpOp {
   implicit class HttpOpOps[IN, RESPONSE](httpOp: HttpOp[IN, RESPONSE]) {
     def setupRequestMultiArg[A1, A2](function2Arg: (A1, A2) => IN): HttpOp[(A1, A2), RESPONSE] =
       httpOp.setupRequest(function2Arg.tupled)
+    def setupRequestMultiArg[A1, A2, A3](function2Arg: (A1, A2, A3) => IN): HttpOp[(A1, A2, A3), RESPONSE] =
+      httpOp.setupRequest(function2Arg.tupled)
+  }
+
+  // convenience, untuples for you
+  implicit class HttpOpTuple3Ops[A1, A2, A3, RESPONSE](httpOp3Arg: HttpOp[(A1, A2, A3), RESPONSE]) {
+    def runRequestMultiArg: (A1, A2, A3) => ClientFailableOp[RESPONSE] = Function.untupled(httpOp3Arg.runRequest)
   }
 
 }


### PR DESCRIPTION
As per the previous work
https://github.com/guardian/zuora-auto-cancel/pull/198
https://github.com/guardian/zuora-auto-cancel/pull/174
We have found a nice way to split out the preprocessing and postprocessing of HTTP operations in order to make the tests simpler and get rid of the monolithic http Requests object.  This Requests object is used by the zuora, sf and identity operations, however we don't call salesforce that much so it's reasonable to convert everything and delete the old way.

This PR is to convert most of the cancellation-sf-cases lambda to use this HttpOp.  There is still work to add a post operation so we can convert the Create salesforce case operation, but that can be a further PR.

This all passes the effectstest but there are no tests that run without credentials yet.

@pvighi @paulbrown1982 @twrichards have a look and see what you think!