### PR TITLE
Skip contact merge process if already done/no work to do

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/AnyContactsToChange.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/AnyContactsToChange.scala
@@ -1,0 +1,14 @@
+package com.gu.sf_contact_merge
+
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.ApiGatewayOp
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+
+object AnyContactsToChange {
+  def apply[SFContactId](targetId: SFContactId, existingIds: List[SFContactId]): ApiGatewayOp[Unit] = {
+    existingIds.distinct match {
+      case existingId :: Nil if existingId == targetId => ReturnWithResponse(ApiGatewayResponse.noActionRequired("already merged"))
+      case _ => ContinueProcessing(())
+    }
+  }
+}

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -4,9 +4,9 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
-import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
+import com.gu.salesforce.TypesForSFEffectsData.SFContactId
+import com.gu.salesforce.{JsonHttp, SalesforceClient}
 import com.gu.sf_contact_merge.TypeConvert._
 import com.gu.sf_contact_merge.WireRequestToDomainObject.MergeRequest
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
@@ -86,6 +86,7 @@ object DomainSteps {
     (for {
       accountAndEmails <- getIdentityAndZuoraEmailsForAccounts(mergeRequest.zuoraAccountIds)
         .toApiGatewayOp("getIdentityAndZuoraEmailsForAccounts")
+      _ <- AnyContactsToChange(mergeRequest.sfContactId, accountAndEmails.map(_.sfContactId))
       _ <- validateEmails(accountAndEmails.map(_.emailAddress))
       maybeIdentityId <- validateIdentityIds(accountAndEmails.map(_.identityId))
         .toApiGatewayOp(ApiGatewayResponse.notFound _)

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/AnyContactsToChangeTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/AnyContactsToChangeTest.scala
@@ -1,0 +1,23 @@
+package com.gu.sf_contact_merge
+
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.-\/
+
+class AnyContactsToChangeTest extends FlatSpec with Matchers {
+
+  it should "return no action needed if only one contact with the correct id" in {
+    val actual = AnyContactsToChange(1, List(1))
+    actual.toDisjunction.leftMap(_.statusCode) should be(-\/("200"))
+  }
+
+  it should "return no action needed if several contacts all with the correct id" in {
+    val actual = AnyContactsToChange(1, List(1, 1, 1))
+    actual.toDisjunction.leftMap(_.statusCode) should be(-\/("200"))
+  }
+
+  it should "return continue if there are differing contacts" in {
+    val actual = AnyContactsToChange(1, List(1, 2))
+    actual.toDisjunction.isRight should be(true)
+  }
+
+}

--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -39,7 +39,8 @@ object RunBatch {
       postJsonString = postString.setupRequest[JsonString](jsonString => BodyAsString(jsonString.value))
       requestWithResultAsTry = (jsonString: JsonString) =>
         postJsonString.runRequest(jsonString) match {
-          case ClientSuccess(_) => \/-(())
+          case ClientSuccess(body) if body.value.contains("Success") => \/-(())
+          case ClientSuccess(body) => \/-(body.value)
           case f: ClientFailure => -\/(s"failed to call sf contact merge: $f")
         }
       err <- jsons.traverseU(requestWithResultAsTry)


### PR DESCRIPTION
Since we have run most of the scenarios already, we have a small number to redo.  Unfortunately it does a lot of calls and some preparation and tidyup of the SF contact, even if all the merging has already completed.

This PR adds a pre check that at least one of the zuora accounts will have its link changed.  If not it will skip it with a 200 and the body saying that there's no processing needed.

@pvighi @paulbrown1982 take a look