### PR TITLE
Allow updating the email address in SF

### DIFF
--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -18,7 +18,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
   it should "get auth SF correctly" taggedAs EffectsTest in {
 
     val unique = s"${Random.nextInt(10000)}"
-    val testContact = SFEffectsData.updateIdentityIdAndFirstNameContact
+    val testContact = SFEffectsData.updateIdentityIdEmailAndFirstNameContact
 
     val actual = for {
       sfConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[SFAuthConfig]

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/AnyContactsToChange.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/AnyContactsToChange.scala
@@ -1,0 +1,14 @@
+package com.gu.sf_contact_merge
+
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.ApiGatewayOp
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+
+object AnyContactsToChange {
+  def apply[SFContactId](targetId: SFContactId, existingIds: List[SFContactId]): ApiGatewayOp[Unit] = {
+    existingIds.distinct match {
+      case existingId :: Nil if existingId == targetId => ReturnWithResponse(ApiGatewayResponse.noActionRequired("already merged"))
+      case _ => ContinueProcessing(())
+    }
+  }
+}

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -4,9 +4,9 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
-import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
+import com.gu.salesforce.TypesForSFEffectsData.SFContactId
+import com.gu.salesforce.{JsonHttp, SalesforceClient}
 import com.gu.sf_contact_merge.TypeConvert._
 import com.gu.sf_contact_merge.WireRequestToDomainObject.MergeRequest
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
@@ -86,6 +86,7 @@ object DomainSteps {
     (for {
       accountAndEmails <- getIdentityAndZuoraEmailsForAccounts(mergeRequest.zuoraAccountIds)
         .toApiGatewayOp("getIdentityAndZuoraEmailsForAccounts")
+      _ <- AnyContactsToChange(mergeRequest.sfContactId, accountAndEmails.map(_.sfContactId))
       _ <- validateEmails(accountAndEmails.map(_.emailAddress))
       maybeIdentityId <- validateIdentityIds(accountAndEmails.map(_.identityId))
         .toApiGatewayOp(ApiGatewayResponse.notFound _)

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -101,7 +101,8 @@ object DomainSteps {
       linksFromZuora = LinksFromZuora(mergeRequest.sfContactId, mergeRequest.crmAccountId, maybeIdentityId)
       _ <- mergeRequest.zuoraAccountIds.traverseU(updateAccountSFLinks(linksFromZuora))
         .toApiGatewayOp("update accounts with winning details")
-      _ <- updateSFContacts(mergeRequest.sfContactId, maybeIdentityId, oldContact, firstNameToUse, maybeSFAddressOverride)
+      _ <- updateSFContacts(mergeRequest.sfContactId, maybeIdentityId, oldContact, firstNameToUse, maybeSFAddressOverride, None /*TODO*/ )
+        // TODO next pr will fill in the None above with the non "+gnm" email address, if the winner is a +gnm.
         .toApiGatewayOp("update sf contact(s) to force a sync")
     } yield ApiGatewayResponse.successfulExecution).apiResponse
 }

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSFContacts.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSFContacts.scala
@@ -1,10 +1,10 @@
 package com.gu.sf_contact_merge.update
 
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
-import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.FirstName
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddressOverride.{DontOverrideAddress, SFAddressOverride}
 import com.gu.sf_contact_merge.update.UpdateSFContacts.OldSFContact
-import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.{DontChangeFirstName, DummyFirstName, IdentityId, SFContactUpdate, SetFirstName}
+import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId._
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 
 object UpdateSFContacts {
@@ -16,12 +16,13 @@ object UpdateSFContacts {
     identityId: Option[IdentityId],
     maybeOldContactId: Option[OldSFContact],
     firstName: Option[FirstName],
-    maybeSFAddressOverride: SFAddressOverride
+    maybeSFAddressOverride: SFAddressOverride,
+    maybeOverwriteEmailAddress: Option[EmailAddress]
   ) =>
     for {
       _ <- maybeOldContactId match {
         case Some(oldContactId) => {
-          val sFContactUpdate = SFContactUpdate(None, DontChangeFirstName, DontOverrideAddress)
+          val sFContactUpdate = SFContactUpdate(None, DontChangeFirstName, DontOverrideAddress, None)
           setOrClearIdentityId.apply(oldContactId.sfContactId, sFContactUpdate)
         }
         case None => ClientSuccess(())
@@ -30,7 +31,8 @@ object UpdateSFContacts {
         val sFContactUpdate = SFContactUpdate(
           identityId,
           firstName.map(SetFirstName.apply).getOrElse(DummyFirstName),
-          maybeSFAddressOverride
+          maybeSFAddressOverride,
+          maybeOverwriteEmailAddress
         )
         setOrClearIdentityId.apply(sfContactId, sFContactUpdate) // this causes the sync to identity and zuora
       }
@@ -47,7 +49,8 @@ trait UpdateSFContacts {
     identityId: Option[IdentityId],
     maybeOldContactId: Option[OldSFContact],
     firstNameToUse: Option[FirstName],
-    maybeSFAddressOverride: SFAddressOverride
+    maybeSFAddressOverride: SFAddressOverride,
+    maybeOverwriteEmailAddress: Option[EmailAddress]
   ): ClientFailableOp[Unit]
 
 }

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSalesforceIdentityId.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateSalesforceIdentityId.scala
@@ -1,7 +1,7 @@
 package com.gu.sf_contact_merge.update
 
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
-import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.FirstName
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddressOverride.SFAddressOverride
 import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.SFContactUpdate
 import com.gu.util.resthttp.HttpOp
@@ -19,7 +19,8 @@ object UpdateSalesforceIdentityId {
     OtherState: Option[String],
     OtherPostalCode: Option[String],
     OtherCountry: Option[String],
-    Phone: Option[String]
+    Phone: Option[String],
+    Email: Option[String]
   )
   implicit val writes = Json.writes[WireRequest]
 
@@ -29,7 +30,12 @@ object UpdateSalesforceIdentityId {
   case class SetFirstName(firstName: FirstName) extends UpdateFirstName
   case object DummyFirstName extends UpdateFirstName
   case object DontChangeFirstName extends UpdateFirstName
-  case class SFContactUpdate(identityId: Option[IdentityId], firstName: UpdateFirstName, maybeNewAddress: SFAddressOverride)
+  case class SFContactUpdate(
+    identityId: Option[IdentityId],
+    firstName: UpdateFirstName,
+    maybeNewAddress: SFAddressOverride,
+    maybeOverwriteEmailAddress: Option[EmailAddress]
+  )
 
   def apply(patchOp: HttpOp[PatchRequest, Unit]): SetOrClearIdentityId =
     SetOrClearIdentityId(patchOp.setupRequestMultiArg(toRequest _).runRequestMultiArg)
@@ -50,7 +56,8 @@ object UpdateSalesforceIdentityId {
       contactUpdate.maybeNewAddress.toOption.flatMap(_.OtherState.map(_.value)),
       contactUpdate.maybeNewAddress.toOption.flatMap(_.OtherPostalCode.map(_.value)),
       contactUpdate.maybeNewAddress.toOption.map(_.OtherCountry.value),
-      contactUpdate.maybeNewAddress.toOption.flatMap(_.Phone.map(_.value))
+      contactUpdate.maybeNewAddress.toOption.flatMap(_.Phone.map(_.value)),
+      contactUpdate.maybeOverwriteEmailAddress.map(_.value)
     )
 
     val relativePath = RelativePath(s"/services/data/v43.0/sobjects/Contact/${sFContactId.value}")

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/AnyContactsToChangeTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/AnyContactsToChangeTest.scala
@@ -1,0 +1,23 @@
+package com.gu.sf_contact_merge
+
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.-\/
+
+class AnyContactsToChangeTest extends FlatSpec with Matchers {
+
+  it should "return no action needed if only one contact with the correct id" in {
+    val actual = AnyContactsToChange(1, List(1))
+    actual.toDisjunction.leftMap(_.statusCode) should be(-\/("200"))
+  }
+
+  it should "return no action needed if several contacts all with the correct id" in {
+    val actual = AnyContactsToChange(1, List(1, 1, 1))
+    actual.toDisjunction.leftMap(_.statusCode) should be(-\/("200"))
+  }
+
+  it should "return continue if there are differing contacts" in {
+    val actual = AnyContactsToChange(1, List(1, 2))
+    actual.toDisjunction.isRight should be(true)
+  }
+
+}

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -5,7 +5,7 @@ import com.gu.salesforce.{JsonHttp, SalesforceClient}
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.dev.SFEffectsData
-import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.FirstName
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddress.SFAddress
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddress.SFAddressFields._
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddressOverride.OverrideAddressWith
@@ -29,7 +29,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
   it should "get auth SF correctly" taggedAs EffectsTest in {
 
     val unique = s"${Random.nextInt(10000)}"
-    val testContact = SFEffectsData.updateIdentityIdAndFirstNameContact
+    val testContact = SFEffectsData.updateIdentityIdEmailAndFirstNameContact
 
     val testIdentityId = IdentityId(s"iden$unique")
     val testFirstName = FirstName(s"name$unique")
@@ -41,6 +41,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
       SFCountry(s"country$unique"),
       Some(SFPhone(s"phone$unique"))
     )
+    val testEmail = EmailAddress(s"fulfilment.dev+$unique@guardian.co.uk")
 
     val actual = for {
       sfConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[SFAuthConfig]
@@ -48,7 +49,12 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
       sfClient <- SalesforceClient(response, sfConfig).value.toDisjunction
       patch = sfClient.wrap(JsonHttp.patch)
       updateSalesforceIdentityId = UpdateSalesforceIdentityId(patch)
-      sFContactUpdate = SFContactUpdate(Some(testIdentityId), SetFirstName(testFirstName), OverrideAddressWith(testAddress))
+      sFContactUpdate = SFContactUpdate(
+        Some(testIdentityId),
+        SetFirstName(testFirstName),
+        OverrideAddressWith(testAddress),
+        Some(testEmail)
+      )
       _ <- updateSalesforceIdentityId.apply(testContact, sFContactUpdate).toDisjunction
       getSalesforceIdentityId = GetSalesforceIdentityId(sfClient.wrap(JsonHttp.get)) _
       updatedIdentityId <- getSalesforceIdentityId(testContact).toDisjunction
@@ -62,7 +68,8 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
       s"state$unique",
       s"post$unique",
       s"country$unique",
-      s"phone$unique"
+      s"phone$unique",
+      s"fulfilment.dev+$unique@guardian.co.uk"
     )))
 
   }
@@ -79,7 +86,8 @@ object GetSalesforceIdentityId {
     OtherState: String,
     OtherPostalCode: String,
     OtherCountry: String,
-    Phone: String
+    Phone: String,
+    Email: String
   )
 
   object WireResult {

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdTest.scala
@@ -1,7 +1,7 @@
 package com.gu.sf_contact_merge.update.updateSFIdentityId
 
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
-import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.FirstName
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddress.SFAddress
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddress.SFAddressFields._
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddressOverride.{DontOverrideAddress, OverrideAddressWith}
@@ -27,7 +27,8 @@ class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
           Some(SFPostalCode("post1")),
           SFCountry("country1"),
           Some(SFPhone("phone1"))
-        ))
+        )),
+        Some(EmailAddress("emailemail"))
       )
     )
     val expectedJson = JsObject(Seq(
@@ -38,7 +39,8 @@ class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
       "OtherState" -> JsString("state2"),
       "OtherPostalCode" -> JsString("post1"),
       "OtherCountry" -> JsString("country1"),
-      "Phone" -> JsString("phone1")
+      "Phone" -> JsString("phone1"),
+      "Email" -> JsString("emailemail")
     ))
     val expected = new PatchRequest(expectedJson, RelativePath("/services/data/v43.0/sobjects/Contact/contactsf"))
     actual should be(expected)
@@ -52,7 +54,8 @@ class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
       SFContactUpdate(
         Some(IdentityId("identityid")),
         DummyFirstName,
-        DontOverrideAddress
+        DontOverrideAddress,
+        None
       )
     )
     val expectedJson = JsObject(Seq(
@@ -71,7 +74,8 @@ class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
       SFContactUpdate(
         Some(IdentityId("identityid")),
         DontChangeFirstName,
-        DontOverrideAddress
+        DontOverrideAddress,
+        None
       )
     )
     val expectedJson = JsObject(Seq(
@@ -89,7 +93,8 @@ class UpdateSalesforceIdentityIdTest extends FlatSpec with Matchers {
       SFContactUpdate(
         None,
         DontChangeFirstName,
-        DontOverrideAddress
+        DontOverrideAddress,
+        None
       )
     )
     val expectedJson = JsObject(Seq(

--- a/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
+++ b/handlers/sf-contact-merge/src/test/scala/manualTest/RunBatch.scala
@@ -39,7 +39,8 @@ object RunBatch {
       postJsonString = postString.setupRequest[JsonString](jsonString => BodyAsString(jsonString.value))
       requestWithResultAsTry = (jsonString: JsonString) =>
         postJsonString.runRequest(jsonString) match {
-          case ClientSuccess(_) => \/-(())
+          case ClientSuccess(body) if body.value.contains("Success") => \/-(())
+          case ClientSuccess(body) => \/-(body.value)
           case f: ClientFailure => -\/(s"failed to call sf contact merge: $f")
         }
       err <- jsons.traverseU(requestWithResultAsTry)

--- a/lib/salesforce/src/test/scala/com/gu/salesforce/dev/SFEffectsData.scala
+++ b/lib/salesforce/src/test/scala/com/gu/salesforce/dev/SFEffectsData.scala
@@ -9,6 +9,6 @@ object SFEffectsData {
   val testContactHasNamePhoneOtherAddress = SFContactId("0036E00000NLzPkQAL")
 
   // this contact we can update the identity id freely
-  val updateIdentityIdAndFirstNameContact = SFContactId("0036E00000Ho05i")
+  val updateIdentityIdEmailAndFirstNameContact = SFContactId("0036E00000Ho05i")
 
 }


### PR DESCRIPTION
NOTE this is based off this branch: https://github.com/guardian/zuora-auto-cancel/pull/202 so it also has that commit it.  Please ignore the first commit and review that separately. (second commit link: https://github.com/guardian/zuora-auto-cancel/pull/203/commits/1a4d0c3ee374600db5e9dab8aa3d885953942151 )

This it needed because if the winning contact is a +gnm contact, we need to replace the email address with the correct one.

@paulbrown1982 @pvighi take a look (at the last commit - https://github.com/guardian/zuora-auto-cancel/pull/203/commits/1a4d0c3ee374600db5e9dab8aa3d885953942151 )