### PR TITLE
add update email address facility to zuora

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -98,7 +98,8 @@ object DomainSteps {
         .toApiGatewayOp("get salesforce addresses")
       _ <- ValidateNoLosingDigitalVoucher(winningAndOtherContact.others.map(_.map(_.isDigitalVoucherUser)))
       oldContact = accountAndEmails.find(_.identityId.isDefined).map(_.sfContactId).map(OldSFContact.apply)
-      linksFromZuora = LinksFromZuora(mergeRequest.sfContactId, mergeRequest.crmAccountId, maybeIdentityId)
+      linksFromZuora = LinksFromZuora(mergeRequest.sfContactId, mergeRequest.crmAccountId, maybeIdentityId, None /*TODO*/ )
+      // TODO next pr will fill in the None above with the non "+gnm" email address, there are any +gnm addresses at all.
       _ <- mergeRequest.zuoraAccountIds.traverseU(updateAccountSFLinks(linksFromZuora))
         .toApiGatewayOp("update accounts with winning details")
       _ <- updateSFContacts(mergeRequest.sfContactId, maybeIdentityId, oldContact, firstNameToUse, maybeSFAddressOverride, None /*TODO*/ )

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinks.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinks.scala
@@ -6,7 +6,7 @@ import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
 import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.IdentityId
 import com.gu.util.resthttp.RestRequestMaker.{JsonResponse, PutRequest, RelativePath}
 import com.gu.util.resthttp.Types.ClientFailableOp
-import play.api.libs.json.{JsSuccess, Json, Reads}
+import play.api.libs.json.Json
 
 object UpdateAccountSFLinks {
 
@@ -21,7 +21,6 @@ object UpdateAccountSFLinks {
   )
   implicit val writesC = Json.writes[WireZuoraContact]
   implicit val writesA = Json.writes[WireZuoraAccount]
-  implicit val unitReads: Reads[Unit] = Reads(_ => JsSuccess(()))
 
   case class LinksFromZuora(
     sfContactId: SFContactId,

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinksTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinksTest.scala
@@ -3,6 +3,7 @@ package com.gu.sf_contact_merge.update
 import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.IdentityId
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
 import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, LinksFromZuora}
 import com.gu.util.resthttp.RestRequestMaker.{PutRequest, RelativePath}
 import org.scalatest.{FlatSpec, Matchers}
@@ -27,6 +28,7 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
       LinksFromZuora(
         SFContactId("johnjohn_c"),
         CRMAccountId("crmIdjohn"),
+        None,
         None
       )
     )(
@@ -46,7 +48,8 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
         |{
         |    "sfContactId__c": "johnjohn_c",
         |    "crmId": "crmIdjohn",
-        |    "IdentityId__c": "identity"
+        |    "IdentityId__c": "identity",
+        |    "billToContact": {"workEmail": "email@email.com"}
         |    }
       """.stripMargin
     )
@@ -55,7 +58,8 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
       LinksFromZuora(
         SFContactId("johnjohn_c"),
         CRMAccountId("crmIdjohn"),
-        Some(IdentityId("identity"))
+        Some(IdentityId("identity")),
+        Some(EmailAddress("email@email.com"))
       )
     )(
         AccountId("1234")

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/GetIdentityIdForAccount.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/GetIdentityIdForAccount.scala
@@ -1,7 +1,7 @@
 package com.gu.sf_contact_merge.update.identityid
 
-import com.gu.sf_contact_merge.update.identityid.GetIdentityIdForAccount.WireModel.{BasicInfo, ZuoraAccount}
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
+import com.gu.sf_contact_merge.update.identityid.GetIdentityIdForAccount.WireModel.ZuoraAccount
 import com.gu.util.resthttp.RestRequestMaker.Requests
 import com.gu.util.resthttp.Types.ClientFailableOp
 import play.api.libs.json.Json
@@ -15,15 +15,21 @@ object GetIdentityIdForAccount {
       IdentityId__c: Option[String]
     )
 
-    case class ZuoraAccount(
-      basicInfo: BasicInfo
+    case class ZContact(
+      workEmail: String
     )
+
+    case class ZuoraAccount(
+      basicInfo: BasicInfo,
+      billToContact: ZContact
+    )
+    implicit val zaReadsZContact = Json.reads[ZContact]
     implicit val zaReadsBasicInfo = Json.reads[BasicInfo]
     implicit val zaReadsZuoraAccount = Json.reads[ZuoraAccount]
 
   }
 
-  def apply(requests: Requests)(accountId: AccountId): ClientFailableOp[BasicInfo] =
-    requests.get[ZuoraAccount](s"/accounts/${accountId.value}").map(_.basicInfo)
+  def apply(requests: Requests)(accountId: AccountId): ClientFailableOp[ZuoraAccount] =
+    requests.get[ZuoraAccount](s"/accounts/${accountId.value}")
 
 }

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/UpdateAccountSFLinksEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/UpdateAccountSFLinksEffectsTest.scala
@@ -5,9 +5,10 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.IdentityId
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.sf_contact_merge.TypeConvert._
+import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
 import com.gu.sf_contact_merge.update.UpdateAccountSFLinks
 import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, LinksFromZuora}
-import com.gu.sf_contact_merge.update.identityid.GetIdentityIdForAccount.WireModel.BasicInfo
+import com.gu.sf_contact_merge.update.identityid.GetIdentityIdForAccount.WireModel.{BasicInfo, ZContact, ZuoraAccount}
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types._
@@ -28,11 +29,19 @@ class UpdateAccountSFLinksEffectsTest extends FlatSpec with Matchers {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig].toApiGatewayOp("load config")
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       update = UpdateAccountSFLinks(zuoraDeps.put)
-      updateAccount = update(LinksFromZuora(SFContactId(s"cont$unique"), CRMAccountId(s"acc$unique"), Some(IdentityId(s"ident$unique"))))
+      updateAccount = update(LinksFromZuora(
+        SFContactId(s"cont$unique"),
+        CRMAccountId(s"acc$unique"),
+        Some(IdentityId(s"ident$unique")),
+        Some(EmailAddress(s"fulfilment.dev+$unique@guardian.co.uk"))
+      ))
       _ <- updateAccount(DevZuora.accountWithRandomLinks).toApiGatewayOp("AddIdentityIdToAccount")
       basicInfo <- GetIdentityIdForAccount(zuoraDeps)(DevZuora.accountWithRandomLinks).toApiGatewayOp("GetIdentityIdForAccount")
     } yield basicInfo
-    actual.toDisjunction should be(\/-(BasicInfo(s"cont$unique", s"acc$unique", Some(s"ident$unique"))))
+    actual.toDisjunction should be(\/-(ZuoraAccount(
+      BasicInfo(s"cont$unique", s"acc$unique", Some(s"ident$unique")),
+      ZContact(s"fulfilment.dev+$unique@guardian.co.uk")
+    )))
 
   }
 


### PR DESCRIPTION
This is also part of the merging +gnm email address support.  When we merge a load of accounts, some of which are +gnm, we need the ability to replace the email addresses in zuora.

This PR adds an optional email field to the zuora update which will cause the work email in the billing contact to be corrected.  This will only happen for +gnm addresses.

@paulbrown1982 @pvighi comment please