### PR TITLE
new product api: make effective date today when creating subs

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -52,11 +52,11 @@ object CreateSubscription {
 
   import WireModel._
 
-  def createRequest(createSubscription: ZuoraCreateSubRequest): WireCreateRequest = {
+  def createRequest(currentDate: LocalDate, createSubscription: ZuoraCreateSubRequest): WireCreateRequest = {
     import createSubscription._
     WireCreateRequest(
       accountKey = accountId.value,
-      contractEffectiveDate = effectiveDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
+      contractEffectiveDate = currentDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
       customerAcceptanceDate = acceptanceDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
       AcquisitionCase__c = acquisitionCase.value,
       AcquisitionSource__c = acquisitionSource.value,
@@ -82,7 +82,6 @@ object CreateSubscription {
     productRatePlanId: ProductRatePlanId,
     accountId: ZuoraAccountId,
     maybeChargeOverride: Option[ChargeOverride],
-    effectiveDate: LocalDate,
     acceptanceDate: LocalDate,
     acquisitionCase: CaseId,
     acquisitionSource: AcquisitionSource,
@@ -92,9 +91,10 @@ object CreateSubscription {
   case class SubscriptionName(value: String) extends AnyVal
 
   def apply(
-    post: RequestsPost[WireCreateRequest, WireSubscription]
+    post: RequestsPost[WireCreateRequest, WireSubscription],
+    currentDate: () => LocalDate
   )(createSubscription: ZuoraCreateSubRequest): ClientFailableOp[SubscriptionName] = {
-    val maybeWireSubscription = post(createRequest(createSubscription), s"subscriptions", WithCheck)
+    val maybeWireSubscription = post(createRequest(currentDate(), createSubscription), s"subscriptions", WithCheck)
     maybeWireSubscription.map { wireSubscription =>
       SubscriptionName(wireSubscription.subscriptionNumber)
     }.withLogging("created subscription")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -43,7 +43,6 @@ class ContributionStepsTest extends FlatSpec with Matchers {
         AmountMinorUnits(123),
         planAndCharge.productRatePlanChargeId
       )),
-      LocalDate.of(2018, 7, 18),
       LocalDate.of(2018, 7, 28),
       CaseId("case"),
       AcquisitionSource("CSR"),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -55,7 +55,6 @@ class VoucherStepsTest extends FlatSpec with Matchers {
       ZuoraAccountId("acccc"),
       None,
       LocalDate.of(2018, 7, 18),
-      LocalDate.of(2018, 7, 18),
       CaseId("case"),
       AcquisitionSource("CSR"),
       CreatedByCSR("bob")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -19,6 +19,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
 
   import ZuoraDevContributions._
 
+  def currentDate = () => LocalDate.of(2018, 2, 10)
   it should "create subscription in account" taggedAs EffectsTest in {
     val validCaseIdToAvoidCausingSFErrors = CaseId("5006E000005b5cf")
     val request = CreateSubscription.ZuoraCreateSubRequest(
@@ -28,7 +29,6 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
         AmountMinorUnits(100),
         monthlyContribution.productRatePlanChargeId
       )),
-      LocalDate.now,
       LocalDate.now.plusDays(2),
       validCaseIdToAvoidCausingSFErrors,
       AcquisitionSource("sourcesource"),
@@ -38,7 +38,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
       zuoraRestConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[ZuoraRestConfig]
       zuoraDeps = ZuoraRestRequestMaker(RawEffects.response, zuoraRestConfig)
       post: RequestsPost[WireCreateRequest, WireSubscription] = zuoraDeps.post[WireCreateRequest, WireSubscription]
-      res <- CreateSubscription(post)(request).toDisjunction
+      res <- CreateSubscription(post, currentDate)(request).toDisjunction
     } yield res
     withClue(actual) {
       actual.map(_.value.substring(0, 3)) shouldBe \/-("A-S")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionTest.scala
@@ -13,6 +13,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class CreateSubscriptionTest extends FlatSpec with Matchers {
 
+  def currentDate = () => LocalDate.of(2018, 7, 2)
   it should "get account as object" in {
 
     val ids = PlanAndCharge(
@@ -22,7 +23,7 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
     val expectedReq = WireCreateRequest(
       accountKey = "zac",
       autoRenew = true,
-      contractEffectiveDate = "2018-07-17",
+      contractEffectiveDate = "2018-07-02",
       customerAcceptanceDate = "2018-07-27",
       termType = "TERMED",
       renewalTerm = 12,
@@ -50,13 +51,12 @@ class CreateSubscriptionTest extends FlatSpec with Matchers {
         ids.productRatePlanChargeId
       )),
 
-      effectiveDate = LocalDate.of(2018, 7, 17),
       acceptanceDate = LocalDate.of(2018, 7, 27),
       acquisitionCase = CaseId("casecase"),
       acquisitionSource = AcquisitionSource("sourcesource"),
       createdByCSR = CreatedByCSR("csrcsr")
     )
-    val actual = CreateSubscription(accF)(createReq)
+    val actual = CreateSubscription(accF, currentDate)(createReq)
     actual shouldBe ClientSuccess(SubscriptionName("a-s123"))
   }
 }

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -9,8 +9,8 @@ import play.api.libs.json.{JsString, Json}
 object AddSubscriptionManualTest extends App {
   val requestBody =
     """{
-      |   "zuoraAccountId":"2c92c0f865244687016538e563b85fac",
-      |   "startDate":"2018-10-15",
+      |   "zuoraAccountId":"2c92c0f9661ff980016633b4200228af",
+      |   "startDate":"2018-11-12",
       |   "acquisitionSource":"CSR",
       |   "createdByCSR":"CSRName",
       |   "amountMinorUnits": 500,


### PR DESCRIPTION
Previously the effective date was set to the selected start date, matt mentioned that it should always be set to today.
After this PR a voucher sub created on 03/10/2018 with a selected start date of 19/11/2018 looks like this in zuora :
```
Contract effective date:03/10/2018 
Service activation date:03/10/2018 
Customer acceptance date:19/11/2018 
```
@paulbrown1982  do you agree with this ? I don't remember how we decided on what to use for the dates originally but we did spend some time deciding.