### PR TITLE
contact merge - Clear identity id from zuora if the winner doesn't have identity

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/DomainSteps.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/DomainSteps.scala
@@ -12,7 +12,7 @@ import com.gu.sf_contact_merge.getaccounts.{GetIdentityAndZuoraEmailsForAccounts
 import com.gu.sf_contact_merge.getsfcontacts.DedupSfContacts.SFContactsForMerge
 import com.gu.sf_contact_merge.getsfcontacts.WireContactToSfContact.Types.SFContact
 import com.gu.sf_contact_merge.getsfcontacts.{DedupSfContacts, GetSfAddressOverride}
-import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, ZuoraFieldUpdates}
+import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, ClearZuoraIdentityId, ReplaceZuoraIdentityId, ZuoraFieldUpdates}
 import com.gu.sf_contact_merge.update.{UpdateAccountSFLinks, UpdateSFContacts}
 import com.gu.sf_contact_merge.validate.GetVariations.{Differing, HasAllowableVariations, HasNoVariations, Variations}
 import com.gu.sf_contact_merge.validate.{GetVariations, ValidateNoLosingDigitalVoucher}
@@ -47,7 +47,10 @@ object DomainSteps {
         val linksFromZuora = ZuoraFieldUpdates(
           mergeRequest.winningSFContact,
           mergeRequest.crmAccountId,
-          sfData.sfIdentityIdMoveData.map(_.identityIdUpdate),
+          sfData.sfIdentityIdMoveData.map(_.identityIdUpdate) match {
+            case Some(identityIdToUse) => ReplaceZuoraIdentityId(identityIdToUse.value)
+            case None => ClearZuoraIdentityId
+          },
           sfData.maybeEmailOverride
         )
         mergeRequest.zuoraAccountIds.traverseU(updateAccountSFLinks(linksFromZuora, _))

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinks.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinks.scala
@@ -1,10 +1,9 @@
 package com.gu.sf_contact_merge.update
 
-import com.gu.sf_contact_merge.Types.WinningSFContact
+import com.gu.sf_contact_merge.Types.{IdentityId, WinningSFContact}
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
 import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.ZuoraFieldUpdates
-import com.gu.sf_contact_merge.update.UpdateSFContacts.IdentityIdToUse
 import com.gu.util.resthttp.RestRequestMaker.{JsonResponse, PutRequest, RelativePath}
 import com.gu.util.resthttp.Types.ClientFailableOp
 import play.api.libs.json.Json
@@ -14,7 +13,7 @@ object UpdateAccountSFLinks {
   case class WireZuoraAccount(
     crmId: String,
     sfContactId__c: String,
-    IdentityId__c: Option[String],
+    IdentityId__c: String,
     billToContact: Option[WireZuoraContact]
   )
   case class WireZuoraContact(
@@ -26,9 +25,13 @@ object UpdateAccountSFLinks {
   case class ZuoraFieldUpdates(
     sfContactId: WinningSFContact,
     crmAccountId: CRMAccountId,
-    identityId: Option[IdentityIdToUse],
+    identityIdUpdate: ZuoraIdentityIdUpdate,
     refreshEmailWith: Option[EmailAddress]
   )
+
+  sealed trait ZuoraIdentityIdUpdate
+  case object ClearZuoraIdentityId extends ZuoraIdentityIdUpdate
+  case class ReplaceZuoraIdentityId(identityId: IdentityId) extends ZuoraIdentityIdUpdate
 
   case class CRMAccountId(value: String) extends AnyVal
 
@@ -40,7 +43,10 @@ object UpdateAccountSFLinks {
     val request = WireZuoraAccount(
       sFPointer.crmAccountId.value,
       sFPointer.sfContactId.id.value,
-      sFPointer.identityId.map(_.value.value),
+      sFPointer.identityIdUpdate match {
+        case ReplaceZuoraIdentityId(identityIdToUse) => identityIdToUse.value
+        case ClearZuoraIdentityId => ""
+      },
       sFPointer.refreshEmailWith.map(e => WireZuoraContact(e.value))
     )
     val path = RelativePath(s"accounts/${account.value}") // TODO danger - we shoudn't go building urls with string concatenation!

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinksTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/UpdateAccountSFLinksTest.scala
@@ -4,15 +4,14 @@ import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.sf_contact_merge.Types.{IdentityId, WinningSFContact}
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
-import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, ZuoraFieldUpdates}
-import com.gu.sf_contact_merge.update.UpdateSFContacts.IdentityIdToUse
+import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, ClearZuoraIdentityId, ReplaceZuoraIdentityId, ZuoraFieldUpdates}
 import com.gu.util.resthttp.RestRequestMaker.{PutRequest, RelativePath}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json._
 
 class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
 
-  it should "handle updating an SF account with no identity to add" in {
+  it should "clear the identity id if the winning account didn't have one" in {
 
     val expectedUrl = """accounts/1234"""
 
@@ -20,7 +19,8 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
       """
         |{
         |    "sfContactId__c": "johnjohn_c",
-        |    "crmId": "crmIdjohn"
+        |    "crmId": "crmIdjohn",
+        |    "IdentityId__c": ""
         |    }
       """.stripMargin
     )
@@ -29,7 +29,7 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
       ZuoraFieldUpdates(
         WinningSFContact(SFContactId("johnjohn_c")),
         CRMAccountId("crmIdjohn"),
-        None,
+        ClearZuoraIdentityId,
         None
       ),
       AccountId("1234")
@@ -58,7 +58,7 @@ class UpdateAccountSFLinksTest extends FlatSpec with Matchers {
       ZuoraFieldUpdates(
         WinningSFContact(SFContactId("johnjohn_c")),
         CRMAccountId("crmIdjohn"),
-        Some(IdentityIdToUse(IdentityId("identity"))),
+        ReplaceZuoraIdentityId(IdentityId("identity")),
         Some(EmailAddress("email@email.com"))
       ),
       AccountId("1234")

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/UpdateAccountSFLinksEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/identityid/UpdateAccountSFLinksEffectsTest.scala
@@ -8,8 +8,7 @@ import com.gu.sf_contact_merge.Types.{IdentityId, WinningSFContact}
 import com.gu.sf_contact_merge.getaccounts.GetContacts.AccountId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
 import com.gu.sf_contact_merge.update.UpdateAccountSFLinks
-import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, ZuoraFieldUpdates}
-import com.gu.sf_contact_merge.update.UpdateSFContacts.IdentityIdToUse
+import com.gu.sf_contact_merge.update.UpdateAccountSFLinks.{CRMAccountId, ReplaceZuoraIdentityId, ZuoraFieldUpdates}
 import com.gu.sf_contact_merge.update.identityid.GetZuoraAccount.WireModel.{BasicInfo, ZContact, ZuoraAccount}
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
@@ -34,7 +33,7 @@ class UpdateAccountSFLinksEffectsTest extends FlatSpec with Matchers {
       updateAccount = update(ZuoraFieldUpdates(
         WinningSFContact(SFContactId(s"cont$unique")),
         CRMAccountId(s"acc$unique"),
-        Some(IdentityIdToUse(IdentityId(s"ident$unique"))),
+        ReplaceZuoraIdentityId(IdentityId(s"ident$unique")),
         Some(EmailAddress(s"fulfilment.dev+$unique@guardian.co.uk"))
       ), _: AccountId)
       _ <- updateAccount(DevZuora.accountWithRandomLinks).toApiGatewayOp("AddIdentityIdToAccount")


### PR DESCRIPTION
This is a bug found by Paul and Abhishek.  Previously when we were merging accounts, if any of the accounts had an identity id we would use that one for all of the zuora accounts, so there was never a need to clear an identity id from zuora.  If it was supposed to end up clear, it would have been clear in the first place.

Now that we are merging +gnm accounts, it is possible there is no identity id at all on the original non +gnm. This means that once we merged we should clean them all from zuora.

The bug was caused by the classic issue of "what does `None` mean?"  As such this PR fixes the bug and also uses a proper type with nice names.

@paulbrown1982 @pvighi 