### PR TITLE
stop logging non existent error

### DIFF
--- a/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
+++ b/lib/handler/src/main/scala/com/gu/util/reader/Types.scala
@@ -105,7 +105,7 @@ object Types extends Logging {
 
   implicit class OptionOps[A](theOption: Option[A]) {
 
-    def toApiGatewayContinueProcessing(NoneResponse: ApiResponse): ApiGatewayOp[A] =
+    def toApiGatewayContinueProcessing(NoneResponse: => ApiResponse): ApiGatewayOp[A] =
       theOption match {
         case Some(value) => ContinueProcessing(value)
         case None => ReturnWithResponse(NoneResponse)


### PR DESCRIPTION
We have a convenience method to convert an option into an ApigatewayOp that takes as a parameter the response that should be used in case the option is None. This parameter should not be evaluated unless it's needed.

When you create an instance of an Api error response an an error message is logged regardless of whether the response is sent back to the client of not (this is an issue that should be addressed in a future PR).

These two issues caused that when this is used in [ZuoraIds.scala](https://github.com/guardian/zuora-auto-cancel/blob/master/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala#L125) it causes the lambda to log "Processing failed due to missing zuora ids for stage Stage(CODE)" even if the error response is not actually used
