### PR TITLE
when linking existing subs, create guest accounts if no identity

### DIFF
--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -160,11 +160,11 @@ object Handler extends Logging {
       (for {
         identityAndSfRequests <- sfBackendForIdentityCookieHeader(apiGatewayRequest.headers)
         raiseCaseDetail <- apiGatewayRequest.bodyAsCaseClass[RaiseCaseDetail]()
-        lookupByIdOp = SalesforceGenericIdLookup(identityAndSfRequests.sfClient.wrap(JsonHttp.get))
-        mostRecentCaseOp = SalesforceCase.GetMostRecentCaseByContactId(identityAndSfRequests.sfClient.wrap(JsonHttp.get))
-        createCaseOp = SalesforceCase.Create(identityAndSfRequests.sfClient.wrap(JsonHttp.post))
+        lookupByIdOp = SalesforceGenericIdLookup(identityAndSfRequests.sfClient.wrapWith(JsonHttp.get))
+        mostRecentCaseOp = SalesforceCase.GetMostRecentCaseByContactId(identityAndSfRequests.sfClient.wrapWith(JsonHttp.get))
+        createCaseOp = SalesforceCase.Create(identityAndSfRequests.sfClient.wrapWith(JsonHttp.post))
         wiredCreateCaseOp = buildWireNewCaseForSalesforce.tupled andThen createCaseOp
-        sfUpdateOp = SalesforceCase.Update(identityAndSfRequests.sfClient.wrap(JsonHttp.patch))
+        sfUpdateOp = SalesforceCase.Update(identityAndSfRequests.sfClient.wrapWith(JsonHttp.patch))
         updateReasonOnRecentCaseOp = updateCaseReason(sfUpdateOp)_
         newOrResumeCaseOp = newOrResumeCase(wiredCreateCaseOp, updateReasonOnRecentCaseOp, raiseCaseDetail)_
         wiredRaiseCase = raiseCase(lookupByIdOp, mostRecentCaseOp, newOrResumeCaseOp)_
@@ -214,11 +214,11 @@ object Handler extends Logging {
       (for {
         identityAndSfRequests <- sfBackendForIdentityCookieHeader(apiGatewayRequest.headers)
         pathParams <- apiGatewayRequest.pathParamsAsCaseClass[CasePathParams]()
-        lookupByIdOp = SalesforceGenericIdLookup(identityAndSfRequests.sfClient.wrap(JsonHttp.get))
-        getCaseByIdOp = SalesforceCase.GetById[CaseWithContactId](identityAndSfRequests.sfClient.wrap(JsonHttp.get))_
+        lookupByIdOp = SalesforceGenericIdLookup(identityAndSfRequests.sfClient.wrapWith(JsonHttp.get))
+        getCaseByIdOp = SalesforceCase.GetById[CaseWithContactId](identityAndSfRequests.sfClient.wrapWith(JsonHttp.get))_
         _ <- verifyCaseBelongsToUser(lookupByIdOp, getCaseByIdOp)(identityAndSfRequests.identityUser.id, pathParams.caseId)
         requestBody <- apiGatewayRequest.bodyAsCaseClass[JsValue]()
-        sfUpdateOp = SalesforceCase.Update(identityAndSfRequests.sfClient.wrap(JsonHttp.patch))
+        sfUpdateOp = SalesforceCase.Update(identityAndSfRequests.sfClient.wrapWith(JsonHttp.patch))
         _ <- sfUpdateOp(pathParams.caseId, requestBody).toApiGatewayOp("update case")
       } yield ApiGatewayResponse.successfulExecution).apiResponse
 

--- a/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
+++ b/handlers/cancellation-sf-cases/src/main/scala/com/gu/cancellation/sf_cases/Handler.scala
@@ -9,13 +9,12 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identity.IdentityCookieToIdentityUser.{CookieValuesToIdentityUser, IdentityId, IdentityUser}
 import com.gu.identity.{IdentityCookieToIdentityUser, IdentityTestUserConfig, IsIdentityTestUser}
 import com.gu.salesforce.SalesforceAuthenticate.{SFAuthConfig, SFAuthTestConfig}
-import com.gu.salesforce.SalesforceClient.StringHttpRequest
 import com.gu.salesforce.SalesforceGenericIdLookup.{FieldName, LookupValue, SfObjectType, TSalesforceGenericIdLookup}
 import com.gu.salesforce.cases.SalesforceCase
 import com.gu.salesforce.cases.SalesforceCase.Create.WireNewCase
 import com.gu.salesforce.cases.SalesforceCase.GetMostRecentCaseByContactId.TGetMostRecentCaseByContactId
 import com.gu.salesforce.cases.SalesforceCase.{CaseId, CaseSubject, CaseWithId, ContactId, SubscriptionId}
-import com.gu.salesforce.{JsonHttp, SalesforceClient, SalesforceGenericIdLookup}
+import com.gu.salesforce.{SalesforceClient, SalesforceGenericIdLookup}
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
@@ -23,9 +22,10 @@ import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayR
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config._
 import com.gu.util.reader.Types._
+import com.gu.util.resthttp.JsonHttp.StringHttpRequest
 import com.gu.util.resthttp.RestRequestMaker.BodyAsString
 import com.gu.util.resthttp.Types.ClientFailableOp
-import com.gu.util.resthttp.{HttpOp, Types}
+import com.gu.util.resthttp.{HttpOp, JsonHttp, Types}
 import okhttp3.{Request, Response}
 import play.api.libs.json._
 

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -6,12 +6,12 @@ import com.gu.cancellation.sf_cases.Handler.{CasePathParams, SfBackendForIdentit
 import com.gu.cancellation.sf_cases.TypeConvert._
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identity.IdentityCookieToIdentityUser.{IdentityId, IdentityUser}
-import com.gu.salesforce.JsonHttp
 import com.gu.salesforce.cases.SalesforceCase
 import com.gu.salesforce.cases.SalesforceCase.CaseWithId
 import com.gu.test.EffectsTest
 import com.gu.util.apigateway.ApiGatewayHandler.LambdaIO
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.resthttp.JsonHttp
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json._
 

--- a/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
+++ b/handlers/cancellation-sf-cases/src/test/scala/com/gu/cancellation/sf_cases/EndToEndHandlerEffectsTest.scala
@@ -29,7 +29,7 @@ class EndToEndHandlerEffectsTest extends FlatSpec with Matchers {
     (for {
       identityAndSfRequests <- sfBackendForIdentityCookieHeader(apiGatewayRequest.headers)
       pathParams <- apiGatewayRequest.pathParamsAsCaseClass[CasePathParams]()
-      sfGet = SalesforceCase.GetById[JsValue](identityAndSfRequests.sfClient.wrap(JsonHttp.get))_
+      sfGet = SalesforceCase.GetById[JsValue](identityAndSfRequests.sfClient.wrapWith(JsonHttp.get))_
       getCaseResponse <- sfGet(pathParams.caseId).toApiGatewayOp("get case detail")
     } yield ApiGatewayResponse("200", getCaseResponse)).apiResponse
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/CreateGuestAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/CreateGuestAccount.scala
@@ -2,25 +2,17 @@ package com.gu.identity
 
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
-import com.gu.salesforce.SalesforceClient.StringHttpRequest
 import com.gu.util.resthttp.HttpOp.HttpOpWrapper
+import com.gu.util.resthttp.RestRequestMaker
 import com.gu.util.resthttp.RestRequestMaker._
-import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
-import okhttp3.{HttpUrl, Request, Response}
 import play.api.libs.json.{JsValue, Json, Reads}
 
 object CreateGuestAccount {
 
-  case class WireGuestRegistrationResponse(
-    userId: String
-  )
+  case class WireGuestRegistrationResponse(userId: String)
   implicit val reads = Json.reads[WireGuestRegistrationResponse]
 
-  case class WireGuestRegistrationRequest(
-    primaryEmailAddress: String //,
-  //    privateFields: ,all optional
-  //    publicFields: req-displayName only
-  )
+  case class WireGuestRegistrationRequest(primaryEmailAddress: String)
   implicit val writes = Json.writes[WireGuestRegistrationRequest]
 
   case class WireIdentityResponse(status: String, guestRegistrationRequest: WireGuestRegistrationResponse)
@@ -37,25 +29,3 @@ object CreateGuestAccount {
 
 }
 
-object IdentityClient {
-
-  def apply(
-    response: Request => Response,
-    config: IdentityConfig
-  ): HttpOp[StringHttpRequest, BodyAsString] =
-    HttpOp(response).flatMap {
-      toClientFailableOp
-    }.setupRequest[StringHttpRequest] {
-      withAuth(config)
-    }
-
-  def withAuth(identityConfig: IdentityConfig)(requestInfo: StringHttpRequest): Request = {
-    val builder = requestInfo.requestMethod.builder
-    val authedBuilder = builder.addHeader("X-GU-ID-Client-Access-Token", s"Bearer ${identityConfig.apiToken}")
-    val url = requestInfo.urlParams.value.foldLeft(HttpUrl.parse(identityConfig.baseUrl + requestInfo.relativePath.value).newBuilder()) {
-      case (nextBuilder, (key, value)) => nextBuilder.addQueryParameter(key, value)
-    }.build()
-    authedBuilder.url(url).build()
-  }
-
-}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/CreateGuestAccount.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/CreateGuestAccount.scala
@@ -1,0 +1,61 @@
+package com.gu.identity
+
+import com.gu.identityBackfill.Types.EmailAddress
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.salesforce.SalesforceClient.StringHttpRequest
+import com.gu.util.resthttp.HttpOp.HttpOpWrapper
+import com.gu.util.resthttp.RestRequestMaker._
+import com.gu.util.resthttp.{HttpOp, RestRequestMaker}
+import okhttp3.{HttpUrl, Request, Response}
+import play.api.libs.json.{JsValue, Json, Reads}
+
+object CreateGuestAccount {
+
+  case class WireGuestRegistrationResponse(
+    userId: String
+  )
+  implicit val reads = Json.reads[WireGuestRegistrationResponse]
+
+  case class WireGuestRegistrationRequest(
+    primaryEmailAddress: String //,
+  //    privateFields: ,all optional
+  //    publicFields: req-displayName only
+  )
+  implicit val writes = Json.writes[WireGuestRegistrationRequest]
+
+  case class WireIdentityResponse(status: String, guestRegistrationRequest: WireGuestRegistrationResponse)
+  implicit val userResponseReads: Reads[WireIdentityResponse] = Json.reads[WireIdentityResponse]
+
+  def toRequest(emailAddress: EmailAddress): PostRequest =
+    PostRequest(WireGuestRegistrationRequest(emailAddress.value), RelativePath("/guest"))
+
+  def toResponse(wireGuestRegistrationResponse: WireIdentityResponse): IdentityId =
+    IdentityId(wireGuestRegistrationResponse.guestRegistrationRequest.userId)
+
+  val wrapper: HttpOpWrapper[EmailAddress, PostRequest, JsValue, IdentityId] =
+    HttpOpWrapper[EmailAddress, PostRequest, JsValue, IdentityId](toRequest, RestRequestMaker.toResult[WireIdentityResponse](_).map(toResponse))
+
+}
+
+object IdentityClient {
+
+  def apply(
+    response: Request => Response,
+    config: IdentityConfig
+  ): HttpOp[StringHttpRequest, BodyAsString] =
+    HttpOp(response).flatMap {
+      toClientFailableOp
+    }.setupRequest[StringHttpRequest] {
+      withAuth(config)
+    }
+
+  def withAuth(identityConfig: IdentityConfig)(requestInfo: StringHttpRequest): Request = {
+    val builder = requestInfo.requestMethod.builder
+    val authedBuilder = builder.addHeader("X-GU-ID-Client-Access-Token", s"Bearer ${identityConfig.apiToken}")
+    val url = requestInfo.urlParams.value.foldLeft(HttpUrl.parse(identityConfig.baseUrl + requestInfo.relativePath.value).newBuilder()) {
+      case (nextBuilder, (key, value)) => nextBuilder.addQueryParameter(key, value)
+    }.build()
+    authedBuilder.url(url).build()
+  }
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
@@ -3,7 +3,6 @@ package com.gu.identity
 import com.gu.identity.GetByEmail.RawWireModel.{User, UserResponse}
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
-import com.gu.util.config.ConfigLocation
 import com.gu.util.resthttp.HttpOp.HttpOpWrapper
 import com.gu.util.resthttp.RestRequestMaker
 import com.gu.util.resthttp.RestRequestMaker.{GetRequestWithParams, RelativePath, UrlParams}
@@ -41,7 +40,7 @@ object GetByEmail {
       case _ => GenericError("not an OK response from api")
     }
 
-  def toResponse(userResponse: UserResponse) = {
+  def toResponse(userResponse: UserResponse): ClientFailableOp[MaybeValidatedEmail] = {
     for {
       user <- userFromResponse(userResponse)
       identityId = if (user.statusFields.userEmailValidated) ValidatedEmail(IdentityId(user.id)) else NotValidated
@@ -49,14 +48,4 @@ object GetByEmail {
 
   }
 
-}
-
-case class IdentityConfig(
-  baseUrl: String,
-  apiToken: String
-)
-
-object IdentityConfig {
-  implicit val reads: Reads[IdentityConfig] = Json.reads[IdentityConfig]
-  implicit val location = ConfigLocation[IdentityConfig](path = "identity", version = 1)
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/IdentityClient.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/IdentityClient.scala
@@ -1,0 +1,41 @@
+package com.gu.identity
+
+import com.gu.salesforce.SalesforceClient.StringHttpRequest
+import com.gu.util.config.ConfigLocation
+import com.gu.util.resthttp.HttpOp
+import com.gu.util.resthttp.RestRequestMaker.{BodyAsString, toClientFailableOp}
+import okhttp3.{HttpUrl, Request, Response}
+import play.api.libs.json.{Json, Reads}
+
+object IdentityClient {
+
+  def apply(
+    response: Request => Response,
+    config: IdentityConfig
+  ): HttpOp[StringHttpRequest, BodyAsString] =
+    HttpOp(response).flatMap {
+      toClientFailableOp
+    }.setupRequest[StringHttpRequest] {
+      withAuth(config)
+    }
+
+  def withAuth(identityConfig: IdentityConfig)(requestInfo: StringHttpRequest): Request = {
+    val builder = requestInfo.requestMethod.builder
+    val authedBuilder = builder.addHeader("X-GU-ID-Client-Access-Token", s"Bearer ${identityConfig.apiToken}")
+    val url = requestInfo.urlParams.value.foldLeft(HttpUrl.parse(identityConfig.baseUrl + requestInfo.relativePath.value).newBuilder()) {
+      case (nextBuilder, (key, value)) => nextBuilder.addQueryParameter(key, value)
+    }.build()
+    authedBuilder.url(url).build()
+  }
+
+}
+
+case class IdentityConfig(
+  baseUrl: String,
+  apiToken: String
+)
+
+object IdentityConfig {
+  implicit val reads: Reads[IdentityConfig] = Json.reads[IdentityConfig]
+  implicit val location = ConfigLocation[IdentityConfig](path = "identity", version = 1)
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/IdentityClient.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/IdentityClient.scala
@@ -1,8 +1,8 @@
 package com.gu.identity
 
-import com.gu.salesforce.SalesforceClient.StringHttpRequest
 import com.gu.util.config.ConfigLocation
 import com.gu.util.resthttp.HttpOp
+import com.gu.util.resthttp.JsonHttp.StringHttpRequest
 import com.gu.util.resthttp.RestRequestMaker.{BodyAsString, toClientFailableOp}
 import okhttp3.{HttpUrl, Request, Response}
 import play.api.libs.json.{Json, Reads}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -134,7 +134,7 @@ object Handler {
 
 object Healthcheck {
   def apply(
-    getByEmail: HttpOp[EmailAddress, GetByEmail.MaybeValidatedEmail],
+    getByEmail: HttpOp[EmailAddress, GetByEmail.IdentityAccount],
     countZuoraAccountsForIdentityId: IdentityId => ClientFailableOp[Int],
     sfAuth: LazyClientFailableOp[Any]
   ): ApiResponse =
@@ -142,7 +142,7 @@ object Healthcheck {
       maybeIdentityId <- getByEmail.runRequest(EmailAddress("john.duffell@guardian.co.uk"))
         .toApiGatewayOp("problem with email").withLogging("healthcheck getByEmail")
       identityId <- maybeIdentityId match {
-        case GetByEmail.ValidatedEmail(identityId) => ContinueProcessing(identityId)
+        case GetByEmail.IdentityAccountWithValidatedEmail(identityId) => ContinueProcessing(identityId)
         case other =>
           logger.error(s"failed healthcheck with $other")
           ReturnWithResponse(ApiGatewayResponse.internalServerError("test identity id was not present"))

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -4,9 +4,11 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.identity.{GetByEmail, IdentityConfig}
+import com.gu.identity.{CreateGuestAccount, GetByEmail, IdentityClient, IdentityConfig}
+import com.gu.identityBackfill.IdentityBackfillSteps.DomainRequest
 import com.gu.identityBackfill.TypeConvert._
 import com.gu.identityBackfill.Types.EmailAddress
+import com.gu.identityBackfill.WireRequestToDomainObject.WireModel.IdentityBackfillRequest
 import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import com.gu.identityBackfill.salesforce._
@@ -17,17 +19,17 @@ import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.salesforce.{JsonHttp, SalesforceClient}
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
-import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayResponse}
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse, ResponseModels}
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, PatchRequest}
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.resthttp.{HttpOp, LazyClientFailableOp, RestRequestMaker}
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
-import play.api.libs.json.JsValue
-import scalaz.\/
+import play.api.libs.json.{JsValue, Json, Reads}
 
 object Handler {
 
@@ -53,25 +55,28 @@ object Handler {
     ) = {
       val zuoraRequests = ZuoraRestRequestMaker(response, zuoraRestConfig)
       val zuoraQuerier = ZuoraQuery(zuoraRequests)
-      val getByEmail: EmailAddress => GetByEmail.ApiError \/ IdentityId = GetByEmail(response, identityConfig)
+      val identityClient = IdentityClient(response, identityConfig)
+      val createGuestAccount = identityClient.wrapWith(JsonHttp.post).wrapWith(CreateGuestAccount.wrapper)
+      val getByEmail = identityClient.wrapWith(JsonHttp.getWithParams).wrapWith(GetByEmail.wrapper)
       val countZuoraAccounts: IdentityId => ClientFailableOp[Int] = CountZuoraAccountsForIdentityId(zuoraQuerier)
 
       lazy val sfAuth: LazyClientFailableOp[HttpOp[StringHttpRequest, RestRequestMaker.BodyAsString]] = SalesforceClient(response, sfConfig)
-      lazy val sfPatch = sfAuth.map(_.wrap(JsonHttp.patch))
-      lazy val sfGet = sfAuth.map(_.wrap(JsonHttp.get))
+      lazy val sfPatch = sfAuth.map(_.wrapWith(JsonHttp.patch))
+      lazy val sfGet = sfAuth.map(_.wrapWith(JsonHttp.get))
 
       Operation(
-        steps = IdentityBackfillSteps(
+        steps = WireRequestToDomainObject(IdentityBackfillSteps(
           PreReqCheck(
-            getByEmail,
+            getByEmail.runRequest,
             GetZuoraAccountsForEmail(zuoraQuerier) _ andThen PreReqCheck.getSingleZuoraAccountForEmail,
             countZuoraAccounts andThen PreReqCheck.noZuoraAccountsForIdentityId,
             GetZuoraSubTypeForAccount(zuoraQuerier) _ andThen PreReqCheck.acceptableReaderType,
             syncableSFToIdentity(sfGet, stage)
           ),
+          createGuestAccount.runRequest,
           AddIdentityIdToAccount(zuoraRequests),
           updateSalesforceIdentityId(sfPatch)
-        ),
+        )),
         healthcheck = () => Healthcheck(
           getByEmail,
           countZuoraAccounts,
@@ -129,15 +134,49 @@ object Handler {
 
 object Healthcheck {
   def apply(
-    getByEmail: EmailAddress => \/[GetByEmail.ApiError, IdentityId],
+    getByEmail: HttpOp[EmailAddress, GetByEmail.MaybeValidatedEmail],
     countZuoraAccountsForIdentityId: IdentityId => ClientFailableOp[Int],
     sfAuth: LazyClientFailableOp[Any]
   ): ApiResponse =
     (for {
-      identityId <- getByEmail(EmailAddress("john.duffell@guardian.co.uk"))
+      maybeIdentityId <- getByEmail.runRequest(EmailAddress("john.duffell@guardian.co.uk"))
         .toApiGatewayOp("problem with email").withLogging("healthcheck getByEmail")
+      identityId <- maybeIdentityId match {
+        case GetByEmail.ValidatedEmail(identityId) => ContinueProcessing(identityId)
+        case other =>
+          logger.error(s"failed healthcheck with $other")
+          ReturnWithResponse(ApiGatewayResponse.internalServerError("test identity id was not present"))
+      }
       _ <- countZuoraAccountsForIdentityId(identityId).toApiGatewayOp("get zuora accounts for identity id")
       _ <- sfAuth.value.toApiGatewayOp("Failed to authenticate with Salesforce")
     } yield ApiGatewayResponse.successfulExecution).apiResponse
+
+}
+
+object WireRequestToDomainObject {
+
+  object WireModel {
+
+    case class IdentityBackfillRequest(
+      emailAddress: String,
+      dryRun: Boolean
+    )
+    implicit val identityBackfillRequest: Reads[IdentityBackfillRequest] = Json.reads[IdentityBackfillRequest]
+
+  }
+
+  def apply(
+    steps: DomainRequest => ResponseModels.ApiResponse
+  ): ApiGatewayRequest => ResponseModels.ApiResponse = req =>
+    (for {
+      wireInput <- req.bodyAsCaseClass[IdentityBackfillRequest]()
+      mergeRequest = toDomainRequest(wireInput)
+    } yield steps(mergeRequest)).apiResponse
+
+  def toDomainRequest(request: IdentityBackfillRequest): DomainRequest =
+    DomainRequest(
+      EmailAddress(request.emailAddress),
+      request.dryRun
+    )
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -14,9 +14,8 @@ import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import com.gu.identityBackfill.salesforce._
 import com.gu.identityBackfill.zuora.{AddIdentityIdToAccount, CountZuoraAccountsForIdentityId, GetZuoraAccountsForEmail, GetZuoraSubTypeForAccount}
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
-import com.gu.salesforce.SalesforceClient.StringHttpRequest
+import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse, ResponseModels}
@@ -24,9 +23,10 @@ import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
+import com.gu.util.resthttp.JsonHttp.StringHttpRequest
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, PatchRequest}
 import com.gu.util.resthttp.Types.ClientFailableOp
-import com.gu.util.resthttp.{HttpOp, LazyClientFailableOp, RestRequestMaker}
+import com.gu.util.resthttp.{HttpOp, JsonHttp, LazyClientFailableOp, RestRequestMaker}
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
 import play.api.libs.json.{JsValue, Json, Reads}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountEffectsTest.scala
@@ -1,0 +1,60 @@
+package com.gu.identity
+
+import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.identityBackfill.Types.EmailAddress
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.salesforce.JsonHttp
+import com.gu.test.EffectsTest
+import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.HttpOp.HttpOpWrapper
+import com.gu.util.resthttp.RestRequestMaker
+import com.gu.util.resthttp.RestRequestMaker.{GetRequestWithParams, RelativePath, UrlParams}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsValue, Json, Reads}
+import scalaz.\/-
+
+import scala.util.Random
+
+class CreateGuestAccountEffectsTest extends FlatSpec with Matchers {
+
+  it should "create a guest account" taggedAs EffectsTest in {
+
+    val unique = s"${Random.nextLong.toHexString}"
+    val testContact = EmailAddress(s"sx.CreateGuestAccountEffectsTest+$unique@gu.com")
+
+    val actual = for {
+      identityConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[IdentityConfig]
+      response = RawEffects.response
+      identityClient = IdentityClient(response, identityConfig)
+      createGuestAccount = identityClient.wrapWith(JsonHttp.post).wrapWith(CreateGuestAccount.wrapper)
+      createdId <- createGuestAccount.runRequest(testContact).toDisjunction
+      fetchedId <- identityClient.wrapWith(JsonHttp.getWithParams).wrapWith(GetByEmailForTesting.wrapper).runRequest(testContact).toDisjunction
+    } yield (createdId, fetchedId)
+
+    val failure = actual.map {
+      case (createdId, fetchedId) if createdId == fetchedId =>
+        None
+      case (createdId, fetchedId) =>
+        Some(s"for email $testContact createdId by email address was $createdId but afterwards fetchedId by email address was $fetchedId")
+    }
+    failure should be(\/-(None))
+
+  }
+
+}
+
+object GetByEmailForTesting {
+
+  case class User(id: String)
+  implicit val userReads: Reads[User] = Json.reads[User]
+
+  case class UserResponse(user: User)
+  implicit val userResponseReads: Reads[UserResponse] = Json.reads[UserResponse]
+
+  val wrapper: HttpOpWrapper[EmailAddress, GetRequestWithParams, JsValue, IdentityId] =
+    HttpOpWrapper[EmailAddress, GetRequestWithParams, JsValue, IdentityId](
+      emailAddress => GetRequestWithParams(RelativePath(s"/user"), UrlParams(Map("emailAddress" -> emailAddress.value))),
+      RestRequestMaker.toResult[UserResponse](_).map((wire: UserResponse) => IdentityId(wire.user.id))
+    )
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountEffectsTest.scala
@@ -3,11 +3,10 @@ package com.gu.identity
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
-import com.gu.salesforce.JsonHttp
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.resthttp.HttpOp.HttpOpWrapper
-import com.gu.util.resthttp.RestRequestMaker
+import com.gu.util.resthttp.{JsonHttp, RestRequestMaker}
 import com.gu.util.resthttp.RestRequestMaker.{GetRequestWithParams, RelativePath, UrlParams}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsValue, Json, Reads}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/CreateGuestAccountTest.scala
@@ -1,0 +1,26 @@
+package com.gu.identity
+
+import com.gu.identity.CreateGuestAccount.{WireGuestRegistrationResponse, WireIdentityResponse}
+import com.gu.identityBackfill.Types.EmailAddress
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.util.resthttp.RestRequestMaker.{PostRequest, RelativePath}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsObject, JsString}
+
+class CreateGuestAccountTest extends FlatSpec with Matchers {
+
+  it should "create a request ok" in {
+    val actual = CreateGuestAccount.toRequest(EmailAddress("hello@gu.com"))
+
+    val expected = new PostRequest(JsObject(List("primaryEmailAddress" -> JsString("hello@gu.com"))), RelativePath("/guest"))
+    actual should be(expected)
+  }
+
+  it should "crate a response ok" in {
+    val expected = IdentityId("useridhere")
+    val testData = WireIdentityResponse("ok", WireGuestRegistrationResponse("useridhere"))
+    val actual = CreateGuestAccount.toResponse(testData)
+    actual should be(expected)
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
@@ -4,9 +4,9 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identity.GetByEmail.ValidatedEmail
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
-import com.gu.salesforce.JsonHttp
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.JsonHttp
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
@@ -1,7 +1,7 @@
 package com.gu.identity
 
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.identity.GetByEmail.ValidatedEmail
+import com.gu.identity.GetByEmail.IdentityAccountWithValidatedEmail
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import com.gu.test.EffectsTest
@@ -23,7 +23,7 @@ class GetByEmailEffectsTest extends FlatSpec with Matchers {
       getByEmail = identityClient.wrapWith(JsonHttp.getWithParams).wrapWith(GetByEmail.wrapper)
       identityId <- getByEmail.runRequest(EmailAddress("john.duffell@guardian.co.uk")).toDisjunction
     } yield identityId
-    actual should be(\/-(ValidatedEmail(IdentityId("21814163"))))
+    actual should be(\/-(IdentityAccountWithValidatedEmail(IdentityId("21814163"))))
 
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
@@ -1,8 +1,10 @@
 package com.gu.identity
 
 import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.identity.GetByEmail.ValidatedEmail
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.salesforce.JsonHttp
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
 import org.scalatest.{FlatSpec, Matchers}
@@ -15,11 +17,13 @@ class GetByEmailEffectsTest extends FlatSpec with Matchers {
 
     val actual = for {
       identityConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[IdentityConfig]
-      identityId <- GetByEmail(RawEffects.response, identityConfig)(EmailAddress("john.duffell@guardian.co.uk"))
-    } yield {
-      identityId
-    }
-    actual should be(\/-(IdentityId("21814163")))
+
+      response = RawEffects.response
+      identityClient = IdentityClient(response, identityConfig)
+      getByEmail = identityClient.wrapWith(JsonHttp.getWithParams).wrapWith(GetByEmail.wrapper)
+      identityId <- getByEmail.runRequest(EmailAddress("john.duffell@guardian.co.uk")).toDisjunction
+    } yield identityId
+    actual should be(\/-(ValidatedEmail(IdentityId("21814163"))))
 
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -1,6 +1,6 @@
 package com.gu.identity
 
-import com.gu.identity.GetByEmail.{NotValidated, ValidatedEmail}
+import com.gu.identity.GetByEmail.{IdentityAccountWithUnvalidatedEmail, IdentityAccountWithValidatedEmail}
 import com.gu.identity.GetByEmailTest.{NotValidatedTestData, TestData}
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
@@ -20,13 +20,13 @@ class GetByEmailTest extends FlatSpec with Matchers {
   it should "get successful ok" in {
     val actual = GetByEmail.wrapper.toNewResponse(Json.parse(TestData.dummyIdentityResponse))
 
-    actual should be(ClientSuccess(ValidatedEmail(IdentityId("1234"))))
+    actual should be(ClientSuccess(IdentityAccountWithValidatedEmail(IdentityId("1234"))))
   }
 
   it should "get not validated with an error" in {
     val actual = GetByEmail.wrapper.toNewResponse(Json.parse(NotValidatedTestData.dummyIdentityResponse))
 
-    actual should be(ClientSuccess(NotValidated))
+    actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail))
   }
 
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -1,38 +1,32 @@
 package com.gu.identity
 
-import com.gu.effects.TestingRawEffects
-import com.gu.effects.TestingRawEffects.HTTPResponse
-import com.gu.identity.GetByEmail.{NotFound, NotValidated}
-import com.gu.identity.GetByEmailTest.{NotFoundTestData, NotValidatedTestData, TestData}
+import com.gu.identity.GetByEmail.{NotValidated, ValidatedEmail}
+import com.gu.identity.GetByEmailTest.{NotValidatedTestData, TestData}
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.util.resthttp.RestRequestMaker.{GetRequestWithParams, RelativePath, UrlParams}
+import com.gu.util.resthttp.Types.ClientSuccess
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.{-\/, \/, \/-}
+import play.api.libs.json.Json
 
 class GetByEmailTest extends FlatSpec with Matchers {
 
-  it should "get successful ok" in {
-    val actual = geyByEmailFromResponses(TestData.responses)
+  it should "formulate a request" in {
+    val actual = GetByEmail.wrapper.fromNewParam(EmailAddress("email@address"))
 
-    actual should be(\/-(IdentityId("1234")))
+    actual should be(GetRequestWithParams(RelativePath("/user"), UrlParams(Map("emailAddress" -> "email@address"))))
+  }
+
+  it should "get successful ok" in {
+    val actual = GetByEmail.wrapper.toNewResponse(Json.parse(TestData.dummyIdentityResponse))
+
+    actual should be(ClientSuccess(ValidatedEmail(IdentityId("1234"))))
   }
 
   it should "get not validated with an error" in {
-    val actual = geyByEmailFromResponses(NotValidatedTestData.responses)
+    val actual = GetByEmail.wrapper.toNewResponse(Json.parse(NotValidatedTestData.dummyIdentityResponse))
 
-    actual should be(-\/(NotValidated))
-  }
-
-  it should "get not found" in {
-    val actual = geyByEmailFromResponses(NotFoundTestData.responses)
-
-    actual should be(-\/(NotFound))
-  }
-
-  private def geyByEmailFromResponses(responses: Map[String, HTTPResponse]): GetByEmail.ApiError \/ IdentityId = {
-    val testingRawEffects = new TestingRawEffects(responses = responses)
-
-    GetByEmail(testingRawEffects.response, IdentityConfig("http://baseurl", "apitoken"))(EmailAddress("email@address"))
+    actual should be(ClientSuccess(NotValidated))
   }
 
 }
@@ -40,10 +34,6 @@ class GetByEmailTest extends FlatSpec with Matchers {
 object GetByEmailTest {
 
   object TestData {
-
-    def responses: Map[String, HTTPResponse] = Map(
-      "/user?emailAddress=email@address" -> HTTPResponse(200, dummyIdentityResponse)
-    )
 
     val dummyIdentityResponse: String =
       """
@@ -73,10 +63,6 @@ object GetByEmailTest {
 
   object NotValidatedTestData {
 
-    def responses: Map[String, HTTPResponse] = Map(
-      "/user?emailAddress=email@address" -> HTTPResponse(200, dummyIdentityResponse)
-    )
-
     val dummyIdentityResponse: String =
       """
         |{
@@ -98,26 +84,6 @@ object GetByEmailTest {
         |        "primaryEmailAddress": "john.duffell@guardian.co.uk",
         |        "id": "1234"
         |    }
-        |}
-      """.stripMargin
-
-  }
-
-  object NotFoundTestData {
-
-    def responses: Map[String, HTTPResponse] = Map(
-      "/user?emailAddress=email@address" -> HTTPResponse(404, dummyIdentityResponse)
-    )
-    val dummyIdentityResponse: String =
-      """
-        |{
-        |    "status": "error",
-        |    "errors": [
-        |        {
-        |            "message": "Not found",
-        |            "description": "Resource not found"
-        |        }
-        |    ]
         |}
       """.stripMargin
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.gu.effects.TestingRawEffects.{BasicRequest, HTTPResponse, POSTRequest}
 import com.gu.effects.{FakeFetchString, TestingRawEffects}
-import com.gu.identity.GetByEmailTest
+import com.gu.identity.GetByEmailTest.TestData.dummyIdentityResponse
 import com.gu.identityBackfill.EndToEndData._
 import com.gu.identityBackfill.Runner._
 import com.gu.identityBackfill.salesforce.getContact.GetSFContactSyncCheckFieldsTest
@@ -109,8 +109,12 @@ object EndToEndData {
     )
   }
 
+  def GetByEmailTestresponses: Map[String, HTTPResponse] = Map(
+    "/user?emailAddress=email@address" -> HTTPResponse(200, dummyIdentityResponse)
+  )
+
   def responses: Map[String, HTTPResponse] =
-    GetByEmailTest.TestData.responses ++ responsesGetSFContactSyncCheckFieldsTest
+    GetByEmailTestresponses ++ responsesGetSFContactSyncCheckFieldsTest
   def postResponses: Map[POSTRequest, HTTPResponse] =
     GetZuoraAccountsForEmailData.postResponses(false) ++
       CountZuoraAccountsForIdentityIdData.postResponses(false) ++

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
@@ -1,7 +1,7 @@
 package com.gu.identityBackfill
 
 import com.gu.identity.GetByEmail
-import com.gu.identity.GetByEmail.{NotFound, NotValidated}
+import com.gu.identity.GetByEmail.{NotValidated, ValidatedEmail}
 import com.gu.identityBackfill.PreReqCheck.PreReqResult
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
@@ -10,7 +10,7 @@ import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.resthttp.LazyClientFailableOp
-import com.gu.util.resthttp.Types.ClientSuccess
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, NotFound}
 import org.scalatest.{FlatSpec, Matchers}
 
 class PreReqCheckTest extends FlatSpec with Matchers {
@@ -19,14 +19,29 @@ class PreReqCheckTest extends FlatSpec with Matchers {
 
     val result =
       PreReqCheck(
-        email => scalaz.\/-(IdentityId("asdf")),
+        email => ClientSuccess(ValidatedEmail(IdentityId("asdf"))),
         email => ContinueProcessing(ZuoraAccountIdentitySFContact(AccountId("acc"), None, SFContactId("sf"))),
         identityId => ContinueProcessing(()),
         _ => ContinueProcessing(()),
         _ => LazyClientFailableOp(() => ClientSuccess(ContinueProcessing(())))
       )(EmailAddress("email@address"))
 
-    val expectedResult = ContinueProcessing(PreReqResult(AccountId("acc"), SFContactId("sf"), IdentityId("asdf")))
+    val expectedResult = ContinueProcessing(PreReqResult(AccountId("acc"), SFContactId("sf"), Some(IdentityId("asdf"))))
+    result should be(expectedResult)
+  }
+
+  it should "go through a happy case with no existing identity" in {
+
+    val result =
+      PreReqCheck(
+        email => NotFound("so we will return None"),
+        email => ContinueProcessing(ZuoraAccountIdentitySFContact(AccountId("acc"), None, SFContactId("sf"))),
+        identityId => ContinueProcessing(()),
+        _ => ContinueProcessing(()),
+        _ => LazyClientFailableOp(() => ClientSuccess(ContinueProcessing(())))
+      )(EmailAddress("email@address"))
+
+    val expectedResult = ContinueProcessing(PreReqResult(AccountId("acc"), SFContactId("sf"), None))
     result should be(expectedResult)
   }
 
@@ -66,25 +81,17 @@ class PreReqCheckTest extends FlatSpec with Matchers {
     result should be(expectedResult)
   }
 
-  it should "stop processing if it can't find an identity id for the required email" in {
-
-    val result = emailCheckFailure(NotFound)
-
-    val expectedResult = ReturnWithResponse(ApiGatewayResponse.notFound("user doesn't have identity"))
-    result should be(expectedResult)
-  }
-
   it should "stop processing if it finds a non validated identity account" in {
 
-    val result = emailCheckFailure(NotValidated)
+    val result = emailCheckFailure(ClientSuccess(NotValidated))
 
     val expectedResult = ReturnWithResponse(ApiGatewayResponse.notFound("identity email not validated"))
     result should be(expectedResult)
   }
 
-  private def emailCheckFailure(identityError: GetByEmail.ApiError) = {
+  private def emailCheckFailure(identityError: ClientFailableOp[GetByEmail.MaybeValidatedEmail]) = {
     PreReqCheck(
-      email => scalaz.-\/(identityError),
+      email => identityError,
       email => fail("shouldn't be called 1"),
       identityId => fail("shouldn't be called 2"),
       _ => fail("shouldn't be called 3"),

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
@@ -1,7 +1,7 @@
 package com.gu.identityBackfill
 
 import com.gu.identity.GetByEmail
-import com.gu.identity.GetByEmail.{NotValidated, ValidatedEmail}
+import com.gu.identity.GetByEmail.{IdentityAccountWithUnvalidatedEmail, IdentityAccountWithValidatedEmail}
 import com.gu.identityBackfill.PreReqCheck.PreReqResult
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
@@ -19,7 +19,7 @@ class PreReqCheckTest extends FlatSpec with Matchers {
 
     val result =
       PreReqCheck(
-        email => ClientSuccess(ValidatedEmail(IdentityId("asdf"))),
+        email => ClientSuccess(IdentityAccountWithValidatedEmail(IdentityId("asdf"))),
         email => ContinueProcessing(ZuoraAccountIdentitySFContact(AccountId("acc"), None, SFContactId("sf"))),
         identityId => ContinueProcessing(()),
         _ => ContinueProcessing(()),
@@ -83,13 +83,13 @@ class PreReqCheckTest extends FlatSpec with Matchers {
 
   it should "stop processing if it finds a non validated identity account" in {
 
-    val result = emailCheckFailure(ClientSuccess(NotValidated))
+    val result = emailCheckFailure(ClientSuccess(IdentityAccountWithUnvalidatedEmail))
 
     val expectedResult = ReturnWithResponse(ApiGatewayResponse.notFound("identity email not validated"))
     result should be(expectedResult)
   }
 
-  private def emailCheckFailure(identityError: ClientFailableOp[GetByEmail.MaybeValidatedEmail]) = {
+  private def emailCheckFailure(identityError: ClientFailableOp[GetByEmail.IdentityAccount]) = {
     PreReqCheck(
       email => identityError,
       email => fail("shouldn't be called 1"),

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsEffectsTest.scala
@@ -18,7 +18,7 @@ class GetSFContactSyncCheckFieldsEffectsTest extends FlatSpec with Matchers {
     val actual = for {
       sfConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[SFAuthConfig]
       sfAuth <- SalesforceClient(RawEffects.response, sfConfig).value.toDisjunction
-      getOp = sfAuth.wrap(JsonHttp.get)
+      getOp = sfAuth.wrapWith(JsonHttp.get)
       result <- GetSFContactSyncCheckFields(getOp).apply(SFEffectsData.testContactHasNamePhoneOtherAddress).value.toDisjunction
     } yield result
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/GetSFContactSyncCheckFieldsEffectsTest.scala
@@ -3,11 +3,12 @@ package com.gu.identityBackfill.salesforce.getContact
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields.ContactSyncCheckFields
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
+import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.dev.SFEffectsData
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.JsonHttp
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -24,9 +24,9 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
       sfConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[SFAuthConfig]
       response = RawEffects.response
       auth <- SalesforceClient(response, sfConfig).value.toDisjunction
-      updateSalesforceIdentityId = UpdateSalesforceIdentityId(auth.wrap(JsonHttp.patch))
+      updateSalesforceIdentityId = UpdateSalesforceIdentityId(auth.wrapWith(JsonHttp.patch))
       _ <- updateSalesforceIdentityId.runRequestMultiArg(testContact, IdentityId(unique)).toDisjunction
-      getSalesforceIdentityId = GetSalesforceIdentityId(auth.wrap(JsonHttp.get))
+      getSalesforceIdentityId = GetSalesforceIdentityId(auth.wrapWith(JsonHttp.get))
       identityId <- getSalesforceIdentityId(testContact).value.toDisjunction
     } yield identityId
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -3,11 +3,12 @@ package com.gu.identityBackfill.salesforce.updateSFIdentityId
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
+import com.gu.salesforce.SalesforceClient
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.dev.SFEffectsData
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.JsonHttp
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -49,11 +49,11 @@ object Handler {
 
     } yield Operation.noHealthcheck {
       WireRequestToDomainObject {
-        val sfGet = sfAuth.wrap(JsonHttp.get)
+        val sfGet = sfAuth.wrapWith(JsonHttp.get)
         val getSfContact = GetSfContact(sfGet.setupRequest(ToSfContactRequest.apply).parse[WireResult].map(WireContactToSfContact.apply))
         DomainSteps(
           ZuoraSteps(GetIdentityAndZuoraEmailsForAccountsSteps(zuoraQuerier)),
-          UpdateSFContacts(UpdateSalesforceIdentityId(sfAuth.wrap(JsonHttp.patch))),
+          UpdateSFContacts(UpdateSalesforceIdentityId(sfAuth.wrapWith(JsonHttp.patch))),
           UpdateAccountSFLinks(requests.put),
           SFSteps(getSfContact)
         )

--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/Handler.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
+import com.gu.salesforce.SalesforceClient
 import com.gu.sf_contact_merge.DomainSteps.MergeRequest
 import com.gu.sf_contact_merge.SFSteps.GetSfContact
 import com.gu.sf_contact_merge.TypeConvert._
@@ -22,6 +22,7 @@ import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayR
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.{LoadConfigModule, Stage}
 import com.gu.util.reader.Types._
+import com.gu.util.resthttp.JsonHttp
 import com.gu.util.resthttp.RestOp.HttpOpParseOp
 import com.gu.util.zuora.SafeQueryBuilder.MaybeNonEmptyList
 import com.gu.util.zuora.{ZuoraQuery, ZuoraRestConfig, ZuoraRestRequestMaker}

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/GetSfAddressEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/GetSfAddressEffectsTest.scala
@@ -3,7 +3,7 @@ package com.gu.sf_contact_merge.getsfcontacts
 import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.dev.SFEffectsData
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
+import com.gu.salesforce.SalesforceClient
 import com.gu.sf_contact_merge.Types.IdentityId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.EmailAddress
 import com.gu.sf_contact_merge.getsfcontacts.ToSfContactRequest.WireResult
@@ -11,6 +11,7 @@ import com.gu.sf_contact_merge.getsfcontacts.WireContactToSfContact.Types._
 import com.gu.util.resthttp.RestOp._
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.JsonHttp
 import org.scalatest.{FlatSpec, Matchers}
 import scalaz.\/-
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/GetSfAddressEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/getsfcontacts/GetSfAddressEffectsTest.scala
@@ -24,7 +24,7 @@ class GetSfAddressEffectsTest extends FlatSpec with Matchers {
       sfConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[SFAuthConfig]
       response = RawEffects.response
       sfAuth <- SalesforceClient(response, sfConfig).value.toDisjunction
-      getSfContact = sfAuth.wrap(JsonHttp.get).setupRequest(ToSfContactRequest.apply).parse[WireResult].map(WireContactToSfContact.apply)
+      getSfContact = sfAuth.wrapWith(JsonHttp.get).setupRequest(ToSfContactRequest.apply).parse[WireResult].map(WireContactToSfContact.apply)
       address <- getSfContact.runRequest(testContact).toDisjunction
     } yield address
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -47,7 +47,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
       sfConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[SFAuthConfig]
       response = RawEffects.response
       sfClient <- SalesforceClient(response, sfConfig).value.toDisjunction
-      patch = sfClient.wrap(JsonHttp.patch)
+      patch = sfClient.wrapWith(JsonHttp.patch)
       updateSalesforceIdentityId = UpdateSalesforceIdentityId(patch)
       sFContactUpdate = SFContactUpdate(
         Some(testIdentityId),
@@ -56,7 +56,7 @@ class UpdateSalesforceIdentityIdEffectsTest extends FlatSpec with Matchers {
         Some(testEmail)
       )
       _ <- updateSalesforceIdentityId.apply(testContact, sFContactUpdate).toDisjunction
-      getSalesforceIdentityId = GetSalesforceIdentityId(sfClient.wrap(JsonHttp.get)) _
+      getSalesforceIdentityId = GetSalesforceIdentityId(sfClient.wrapWith(JsonHttp.get)) _
       updatedIdentityId <- getSalesforceIdentityId(testContact).toDisjunction
     } yield updatedIdentityId
 

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/update/updateSFIdentityId/UpdateSalesforceIdentityIdEffectsTest.scala
@@ -4,7 +4,7 @@ import com.gu.effects.{GetFromS3, RawEffects}
 import com.gu.salesforce.SalesforceAuthenticate.SFAuthConfig
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.salesforce.dev.SFEffectsData
-import com.gu.salesforce.{JsonHttp, SalesforceClient}
+import com.gu.salesforce.SalesforceClient
 import com.gu.sf_contact_merge.Types.IdentityId
 import com.gu.sf_contact_merge.getaccounts.GetZuoraContactDetails.{EmailAddress, FirstName}
 import com.gu.sf_contact_merge.getsfcontacts.GetSfAddressOverride.OverrideAddressWith
@@ -14,7 +14,7 @@ import com.gu.sf_contact_merge.update.UpdateSalesforceIdentityId.{SFContactUpdat
 import com.gu.sf_contact_merge.update.updateSFIdentityId.GetSalesforceIdentityId.WireResult
 import com.gu.test.EffectsTest
 import com.gu.util.config.{LoadConfigModule, Stage}
-import com.gu.util.resthttp.HttpOp
+import com.gu.util.resthttp.{HttpOp, JsonHttp}
 import com.gu.util.resthttp.RestOp.HttpOpParseOp
 import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
 import com.gu.util.resthttp.Types.ClientFailableOp

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/HttpOp.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/HttpOp.scala
@@ -1,6 +1,6 @@
 package com.gu.util.resthttp
 
-import com.gu.util.resthttp.HttpOp.HttpWrapper
+import com.gu.util.resthttp.HttpOp.HttpOpWrapper
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 import okhttp3.{Request, Response}
 import play.api.libs.json.{JsValue, Reads}
@@ -17,7 +17,7 @@ case class HttpOp[PARAM, RESPONSE](
   def flatMap[NEWRESPONSE](toNewResponse: RESPONSE => ClientFailableOp[NEWRESPONSE]): HttpOp[PARAM, NEWRESPONSE] =
     HttpOp(inputToRequest, effect, responseToOutput.andThen(_.flatMap(toNewResponse)))
 
-  def wrap[UPDATEDPARAM, NEWRESPONSE](both: HttpWrapper[UPDATEDPARAM, PARAM, RESPONSE, NEWRESPONSE]): HttpOp[UPDATEDPARAM, NEWRESPONSE] =
+  def wrapWith[UPDATEDPARAM, NEWRESPONSE](both: HttpOpWrapper[UPDATEDPARAM, PARAM, RESPONSE, NEWRESPONSE]): HttpOp[UPDATEDPARAM, NEWRESPONSE] =
     setupRequest(both.fromNewParam).flatMap(both.toNewResponse)
 
   def runRequest(in: PARAM): ClientFailableOp[RESPONSE] =
@@ -35,10 +35,16 @@ case class HttpOp[PARAM, RESPONSE](
 
 object HttpOp {
 
-  trait HttpWrapper[UPDATEDPARAM, PARAM, RESPONSE, NEWRESPONSE] {
-    def fromNewParam(updatedParam: UPDATEDPARAM): PARAM
+  case class HttpOpWrapper[UPDATEDPARAM, PARAM, RESPONSE, NEWRESPONSE](
+    fromNewParam: UPDATEDPARAM => PARAM,
+    toNewResponse: RESPONSE => ClientFailableOp[NEWRESPONSE]
+  ) {
 
-    def toNewResponse(response: RESPONSE): ClientFailableOp[NEWRESPONSE]
+    def wrapWith[MOREUPDATEDPARAM, MORENEWRESPONSE](
+      wrapper: HttpOpWrapper[MOREUPDATEDPARAM, UPDATEDPARAM, NEWRESPONSE, MORENEWRESPONSE]
+    ): HttpOpWrapper[MOREUPDATEDPARAM, PARAM, RESPONSE, MORENEWRESPONSE] =
+      HttpOpWrapper(wrapper.fromNewParam.andThen(fromNewParam), toNewResponse.andThen(_.flatMap(wrapper.toNewResponse)))
+
   }
 
   def apply(getResponse: Request => Response): HttpOp[Request, Response] =

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/JsonHttp.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/JsonHttp.scala
@@ -1,14 +1,29 @@
-package com.gu.salesforce
+package com.gu.util.resthttp
 
-import com.gu.salesforce.SalesforceClient._
 import com.gu.util.resthttp.HttpOp.HttpOpWrapper
 import com.gu.util.resthttp.RestRequestMaker._
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import okhttp3.Request
 import play.api.libs.json.{JsValue, Json}
 
 import scala.util.Try
 
 object JsonHttp {
+
+  sealed trait RequestMethod {
+    def builder: Request.Builder
+  }
+  case class PostMethod(body: BodyAsString) extends RequestMethod {
+    override def builder: Request.Builder = new Request.Builder().post(createBodyFromString(body))
+  }
+  case class PatchMethod(body: BodyAsString) extends RequestMethod {
+    override def builder: Request.Builder = new Request.Builder().patch(createBodyFromString(body))
+  }
+  case object GetMethod extends RequestMethod {
+    override def builder: Request.Builder = new Request.Builder().get()
+  }
+
+  case class StringHttpRequest(requestMethod: RequestMethod, relativePath: RelativePath, urlParams: UrlParams)
 
   val patch =
     HttpOpWrapper[PatchRequest, StringHttpRequest, BodyAsString, Unit](

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
@@ -66,8 +66,15 @@ object RestRequestMaker extends Logging {
 
   case class GetRequest(path: RelativePath)
 
+  case class GetRequestWithParams(path: RelativePath, urlParams: UrlParams)
+
   case class JsonResponse(bodyAsJson: JsValue) {
     def value[RESP: Reads] = toResult[RESP](bodyAsJson)
+  }
+
+  case class UrlParams(value: Map[String, String])
+  object UrlParams {
+    val empty = UrlParams(Map.empty)
   }
 
   class Requests(

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/RestRequestMaker.scala
@@ -17,10 +17,10 @@ object RestRequestMaker extends Logging {
       val body = response.body.string
 
       val truncated = body.take(500) + (if (body.length > 500) "..." else "")
-      logger.error(s"Request to Zuora was unsuccessful, response status was ${response.code}, response body: \n $response\n$truncated")
+      logger.error(s"HTTP request was unsuccessful, response status was ${response.code}, response body: \n $response\n$truncated")
       if (response.code == 404) {
         NotFound(response.message)
-      } else GenericError("Request to Zuora was unsuccessful")
+      } else GenericError("HTTP request was unsuccessful")
     }
   }
 
@@ -29,8 +29,8 @@ object RestRequestMaker extends Logging {
       case success: JsSuccess[T] =>
         ClientSuccess(success.get)
       case error: JsError => {
-        logger.error(s"Failed to convert Zuora response to case case $error. Response body was: \n $bodyAsJson")
-        GenericError(s"Error when converting Zuora response to case class: $error")
+        logger.error(s"Failed to convert JSON response to case case $error. Response body was: \n $bodyAsJson")
+        GenericError(s"Error when converting JSON response to case class: $error")
       }
     }
   }

--- a/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
+++ b/lib/restHttp/src/test/scala/com/gu/util/RestRequestMakerTest.scala
@@ -72,13 +72,13 @@ class RestRequestMakerTest extends AsyncFlatSpec {
   "convertResponseToCaseClass" should "return a left[String] for an unsuccessful response code" in {
     val response = constructTestResponse(500)
     val either = RestRequestMaker.httpIsSuccessful(response)
-    assert(either == GenericError("Request to Zuora was unsuccessful"))
+    assert(either == GenericError("HTTP request was unsuccessful"))
   }
 
   it should "return a left[String] if the body of a successful response cannot be de-serialized to that case class" in {
     val either = RestRequestMaker.toResult[BasicAccountInfo](validZuoraNoOtherFields)
     val result = either.mapFailure(first => GenericError(first.message.split(":")(0)))
-    assert(result == GenericError("Error when converting Zuora response to case class"))
+    assert(result == GenericError("Error when converting JSON response to case class"))
   }
 
   it should "return a right[T] if the body of a successful response deserializes to T" in {

--- a/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -9,11 +9,11 @@ import okhttp3.{Request, Response}
 object SalesforceClient {
 
   def apply(
-    response: Request => Response,
+    getResponse: Request => Response,
     config: SFAuthConfig
   ): LazyClientFailableOp[HttpOp[StringHttpRequest, BodyAsString]] =
-    SalesforceAuthenticate(response)(config).map { sfAuth =>
-      HttpOp(response).flatMap {
+    SalesforceAuthenticate(getResponse)(config).map { sfAuth =>
+      HttpOp(getResponse).flatMap {
         toClientFailableOp
       }.setupRequest[StringHttpRequest] {
         withAuth(sfAuth)

--- a/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -1,7 +1,7 @@
 package com.gu.salesforce
 
 import com.gu.salesforce.SalesforceAuthenticate.{SFAuthConfig, SalesforceAuth}
-import com.gu.util.resthttp.RestRequestMaker.{BodyAsString, RelativePath, createBodyFromString, toClientFailableOp}
+import com.gu.util.resthttp.RestRequestMaker._
 import com.gu.util.resthttp.{HttpOp, LazyClientFailableOp}
 import okhttp3.{Request, Response}
 
@@ -39,6 +39,6 @@ object SalesforceClient {
     override def builder: Request.Builder = new Request.Builder().get()
   }
 
-  case class StringHttpRequest(relativePath: RelativePath, requestMethod: RequestMethod)
+  case class StringHttpRequest(requestMethod: RequestMethod, relativePath: RelativePath, urlParams: UrlParams)
 
 }

--- a/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceClient.scala
+++ b/lib/salesforce/src/main/scala/com/gu/salesforce/SalesforceClient.scala
@@ -1,6 +1,7 @@
 package com.gu.salesforce
 
 import com.gu.salesforce.SalesforceAuthenticate.{SFAuthConfig, SalesforceAuth}
+import com.gu.util.resthttp.JsonHttp.StringHttpRequest
 import com.gu.util.resthttp.RestRequestMaker._
 import com.gu.util.resthttp.{HttpOp, LazyClientFailableOp}
 import okhttp3.{Request, Response}
@@ -25,20 +26,5 @@ object SalesforceClient {
     val url = sfAuth.instance_url + requestInfo.relativePath.value
     authedBuilder.url(url).build()
   }
-
-  sealed trait RequestMethod {
-    def builder: Request.Builder
-  }
-  case class PostMethod(body: BodyAsString) extends RequestMethod {
-    override def builder: Request.Builder = new Request.Builder().post(createBodyFromString(body))
-  }
-  case class PatchMethod(body: BodyAsString) extends RequestMethod {
-    override def builder: Request.Builder = new Request.Builder().patch(createBodyFromString(body))
-  }
-  case object GetMethod extends RequestMethod {
-    override def builder: Request.Builder = new Request.Builder().get()
-  }
-
-  case class StringHttpRequest(requestMethod: RequestMethod, relativePath: RelativePath, urlParams: UrlParams)
 
 }


### PR DESCRIPTION
So far we have always looked for an existing identity account when trying to find an identity account for an existing zuora/SF account.

This has made it hard to meet our targets for linking, as most people who need linking don't actually have an account.

This PR will make it create a guest (ghost) account for anyone with no existing identity account.  This means that as soon as they take control of their account (by setting the password) they will have access to manage it online.

There is a possible future PR possible to add their name to the identity account i.e. (privateFields-> (firstName, secondName)) [subs frontend reference](https://github.com/guardian/subscriptions-frontend/blob/e057a5b8dfd8ec94c48ebae4455f0e1fcb6aed5c/app/services/IdentityService.scala#L128) but this isn't done at present.  Anyway, it would be added by any identity sync from SF in future.

@paulbrown1982 see what you think
Also @pvighi @jacobwinch @twrichards might have suggestions especially naming/clarity