### PR TITLE
Improve zuora/salesforce identity id backfill

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
@@ -20,7 +20,10 @@ object GetByEmail {
     case class StatusFields(userEmailValidated: Boolean)
     implicit val statusFieldsReads: Reads[StatusFields] = Json.reads[StatusFields]
 
-    case class User(id: String, statusFields: StatusFields)
+    case class User(id: String, statusFields: Option[StatusFields]) {
+      val isUserEmailValidated: Boolean = statusFields.exists(_.userEmailValidated)
+    }
+
     implicit val userReads: Reads[User] = Json.reads[User]
 
     case class UserResponse(status: String, user: User)
@@ -42,7 +45,7 @@ object GetByEmail {
   def wireToDomainModel(userResponse: UserResponse): ClientFailableOp[IdentityAccount] = {
     for {
       user <- userFromResponse(userResponse)
-      identityId = if (user.statusFields.userEmailValidated) IdentityAccountWithValidatedEmail(IdentityId(user.id)) else IdentityAccountWithUnvalidatedEmail(IdentityId(user.id))
+      identityId = if (user.isUserEmailValidated) IdentityAccountWithValidatedEmail(IdentityId(user.id)) else IdentityAccountWithUnvalidatedEmail(IdentityId(user.id))
     } yield identityId
 
   }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByEmail.scala
@@ -13,7 +13,7 @@ object GetByEmail {
 
   sealed trait IdentityAccount
   case class IdentityAccountWithValidatedEmail(identityId: IdentityId) extends IdentityAccount
-  case object IdentityAccountWithUnvalidatedEmail extends IdentityAccount
+  case class IdentityAccountWithUnvalidatedEmail(identityId: IdentityId) extends IdentityAccount
 
   object RawWireModel {
 
@@ -42,7 +42,7 @@ object GetByEmail {
   def wireToDomainModel(userResponse: UserResponse): ClientFailableOp[IdentityAccount] = {
     for {
       user <- userFromResponse(userResponse)
-      identityId = if (user.statusFields.userEmailValidated) IdentityAccountWithValidatedEmail(IdentityId(user.id)) else IdentityAccountWithUnvalidatedEmail
+      identityId = if (user.statusFields.userEmailValidated) IdentityAccountWithValidatedEmail(IdentityId(user.id)) else IdentityAccountWithUnvalidatedEmail(IdentityId(user.id))
     } yield identityId
 
   }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identity/GetByIdentityId.scala
@@ -1,0 +1,45 @@
+package com.gu.identity
+
+import com.gu.identity.GetByIdentityId.RawWireModel.{User, UserResponse}
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.util.resthttp.HttpOp.HttpOpWrapper
+import com.gu.util.resthttp.RestRequestMaker
+import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import play.api.libs.json.{JsValue, Json, Reads}
+
+object GetByIdentityId {
+
+  case class IdentityUser(id: IdentityId, hasPassword: Boolean)
+
+  object RawWireModel {
+
+    case class User(id: String, hasPassword: Boolean)
+    implicit val userReads: Reads[User] = Json.reads[User]
+
+    case class UserResponse(status: String, user: User)
+    implicit val userResponseReads: Reads[UserResponse] = Json.reads[UserResponse]
+
+  }
+
+  val jsToWireModel: JsValue => ClientFailableOp[UserResponse] = RestRequestMaker.toResult[UserResponse]
+
+  def userFromResponse(userResponse: UserResponse): ClientFailableOp[User] =
+    userResponse match {
+      case UserResponse("ok", user) => ClientSuccess(user)
+      case error => GenericError(s"not an OK response from api: $error")
+    }
+
+  def wireToDomainModel(userResponse: UserResponse): ClientFailableOp[IdentityUser] = {
+    for {
+      user <- userFromResponse(userResponse)
+    } yield IdentityUser(IdentityId(user.id), user.hasPassword)
+  }
+
+  val wrapper: HttpOpWrapper[IdentityId, GetRequest, JsValue, IdentityUser] =
+    HttpOpWrapper[IdentityId, GetRequest, JsValue, IdentityUser](
+      fromNewParam = id => GetRequest(RelativePath(s"/user/${id.value}")),
+      toNewResponse = jsToWireModel.andThen(_.flatMap(wireToDomainModel))
+    )
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/FindExistingIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/FindExistingIdentityId.scala
@@ -1,0 +1,37 @@
+package com.gu.identityBackfill
+
+import com.gu.identity.GetByEmail.IdentityAccount
+import com.gu.identity.{GetByEmail, GetByIdentityId}
+import com.gu.identity.GetByIdentityId.IdentityUser
+import com.gu.identityBackfill.Types.EmailAddress
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.ApiGatewayOp
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess, NotFound}
+
+object FindExistingIdentityId {
+
+  def apply(
+    getByEmail: EmailAddress => ClientFailableOp[GetByEmail.IdentityAccount],
+    getByIdentityId: IdentityId => ClientFailableOp[GetByIdentityId.IdentityUser]
+  )(emailAddress: EmailAddress): ApiGatewayOp[Option[IdentityId]] = {
+
+    def continueIfNoPassword(identityId: IdentityId) = {
+      getByIdentityId(identityId) match {
+        case ClientSuccess(IdentityUser(_, false)) => ContinueProcessing(Some(identityId))
+        case _ => ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set $identityId"))
+      }
+    }
+
+    val result = getByEmail(emailAddress) match {
+      case ClientSuccess(IdentityAccount(identityId, true)) => ContinueProcessing(Some(identityId))
+      case ClientSuccess(IdentityAccount(identityId, false)) => continueIfNoPassword(identityId)
+      case NotFound(_) => ContinueProcessing(None)
+      case other: ClientFailure => ReturnWithResponse(ApiGatewayResponse.internalServerError(other.toString))
+    }
+
+    result.withLogging("FindExistingIdentityId")
+  }
+
+}

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Handler.scala
@@ -57,7 +57,7 @@ object Handler {
       val createGuestAccount = identityClient.wrapWith(JsonHttp.post).wrapWith(CreateGuestAccount.wrapper)
       val getByEmail = identityClient.wrapWith(JsonHttp.getWithParams).wrapWith(GetByEmail.wrapper)
       val getById = identityClient.wrapWith(JsonHttp.get).wrapWith(GetByIdentityId.wrapper)
-      val findExistingIdentityId = PreReqCheck.findExistingIdentityId(getByEmail.runRequest, getById.runRequest) _
+      val findExistingIdentityId = FindExistingIdentityId(getByEmail.runRequest, getById.runRequest) _
 
       val countZuoraAccounts: IdentityId => ClientFailableOp[Int] = CountZuoraAccountsForIdentityId(zuoraQuerier)
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailEffectsTest.scala
@@ -1,7 +1,7 @@
 package com.gu.identity
 
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.identity.GetByEmail.IdentityAccountWithValidatedEmail
+import com.gu.identity.GetByEmail.IdentityAccount
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import com.gu.test.EffectsTest
@@ -23,7 +23,7 @@ class GetByEmailEffectsTest extends FlatSpec with Matchers {
       getByEmail = identityClient.wrapWith(JsonHttp.getWithParams).wrapWith(GetByEmail.wrapper)
       identityId <- getByEmail.runRequest(EmailAddress("john.duffell@guardian.co.uk")).toDisjunction
     } yield identityId
-    actual should be(\/-(IdentityAccountWithValidatedEmail(IdentityId("21814163"))))
+    actual should be(\/-(IdentityAccount(IdentityId("21814163"), isUserEmailValidated = true)))
 
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -1,6 +1,6 @@
 package com.gu.identity
 
-import com.gu.identity.GetByEmail.{IdentityAccountWithUnvalidatedEmail, IdentityAccountWithValidatedEmail}
+import com.gu.identity.GetByEmail.IdentityAccount
 import com.gu.identity.GetByEmailTest.{NotValidatedTestData, TestData}
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
@@ -20,18 +20,18 @@ class GetByEmailTest extends FlatSpec with Matchers {
   it should "get successful ok" in {
     val actual = GetByEmail.wrapper.toNewResponse(Json.parse(TestData.dummyIdentityResponse))
 
-    actual should be(ClientSuccess(IdentityAccountWithValidatedEmail(IdentityId("1234"))))
+    actual should be(ClientSuccess(IdentityAccount(IdentityId("1234"), isUserEmailValidated = true)))
   }
 
   it should "get not validated with an error" in {
     val actual = GetByEmail.wrapper.toNewResponse(Json.parse(NotValidatedTestData.dummyIdentityResponse))
 
-    actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail(IdentityId("1234"))))
+    actual should be(ClientSuccess(IdentityAccount(IdentityId("1234"), isUserEmailValidated = false)))
   }
 
   it should "get not validated if the response has no statusFields" in {
     val actual = GetByEmail.wrapper.toNewResponse(Json.parse(NotValidatedTestData.identityResponseWithoutStatus))
-    actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail(IdentityId("1234"))))
+    actual should be(ClientSuccess(IdentityAccount(IdentityId("1234"), isUserEmailValidated = false)))
   }
 }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -26,7 +26,7 @@ class GetByEmailTest extends FlatSpec with Matchers {
   it should "get not validated with an error" in {
     val actual = GetByEmail.wrapper.toNewResponse(Json.parse(NotValidatedTestData.dummyIdentityResponse))
 
-    actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail))
+    actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail(IdentityId("1234"))))
   }
 
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByEmailTest.scala
@@ -29,6 +29,10 @@ class GetByEmailTest extends FlatSpec with Matchers {
     actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail(IdentityId("1234"))))
   }
 
+  it should "get not validated if the response has no statusFields" in {
+    val actual = GetByEmail.wrapper.toNewResponse(Json.parse(NotValidatedTestData.identityResponseWithoutStatus))
+    actual should be(ClientSuccess(IdentityAccountWithUnvalidatedEmail(IdentityId("1234"))))
+  }
 }
 
 object GetByEmailTest {
@@ -82,6 +86,16 @@ object GetByEmailTest {
         |            "userEmailValidated": false
         |        },
         |        "primaryEmailAddress": "john.duffell@guardian.co.uk",
+        |        "id": "1234"
+        |    }
+        |}
+      """.stripMargin
+
+    val identityResponseWithoutStatus: String =
+      """
+        |{
+        |    "status": "ok",
+        |    "user": {
         |        "id": "1234"
         |    }
         |}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByIdentityIdEffectsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByIdentityIdEffectsTest.scala
@@ -1,0 +1,29 @@
+package com.gu.identity
+
+import com.gu.effects.{GetFromS3, RawEffects}
+import com.gu.identity.GetByIdentityId.IdentityUser
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.test.EffectsTest
+import com.gu.util.config.{LoadConfigModule, Stage}
+import com.gu.util.resthttp.JsonHttp
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/-
+
+// run this manually
+class GetByIdentityIdEffectsTest extends FlatSpec with Matchers {
+
+  it should "successfull run the health check using the local code against real backend" taggedAs EffectsTest in {
+
+    val actual = for {
+      identityConfig <- LoadConfigModule(Stage("DEV"), GetFromS3.fetchString)[IdentityConfig]
+
+      response = RawEffects.response
+      identityClient = IdentityClient(response, identityConfig)
+      getByIdentityId = identityClient.wrapWith(JsonHttp.get).wrapWith(GetByIdentityId.wrapper)
+      identityId <- getByIdentityId.runRequest(IdentityId("21814163")).toDisjunction
+    } yield identityId
+    actual should be(\/-(IdentityUser(IdentityId("21814163"), hasPassword = true)))
+
+  }
+
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identity/GetByIdentityIdTest.scala
@@ -1,0 +1,44 @@
+package com.gu.identity
+
+import com.gu.identity.GetByIdentityId.IdentityUser
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.util.resthttp.RestRequestMaker.{GetRequest, RelativePath}
+import com.gu.util.resthttp.Types.ClientSuccess
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.Json
+
+class GetByIdentityIdTest extends FlatSpec with Matchers {
+  it should "formulate a request" in {
+    GetByIdentityId.wrapper.fromNewParam(IdentityId("1234")) should be(GetRequest(RelativePath("/user/1234")))
+  }
+
+  it should "extract user with password" in {
+    val identityResponse: String =
+      """
+        |{
+        |    "status": "ok",
+        |    "user": {
+        |        "id": "1234",
+        |        "hasPassword": true
+        |    }
+        |}
+      """.stripMargin
+    val actual = GetByIdentityId.wrapper.toNewResponse(Json.parse(identityResponse))
+    actual should be(ClientSuccess(IdentityUser(IdentityId("1234"), hasPassword = true)))
+  }
+
+  it should "extract user without password" in {
+    val identityResponse: String =
+      """
+        |{
+        |    "status": "ok",
+        |    "user": {
+        |        "id": "1234",
+        |        "hasPassword": false
+        |    }
+        |}
+      """.stripMargin
+    val actual = GetByIdentityId.wrapper.toNewResponse(Json.parse(identityResponse))
+    actual should be(ClientSuccess(IdentityUser(IdentityId("1234"), hasPassword = false)))
+  }
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/FindExistingIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/FindExistingIdentityIdTest.scala
@@ -1,0 +1,54 @@
+package com.gu.identityBackfill
+
+import com.gu.identity.GetByEmail.IdentityAccount
+import com.gu.identity.GetByIdentityId.IdentityUser
+import com.gu.identityBackfill.Types.EmailAddress
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+import com.gu.util.resthttp.Types.{ClientSuccess, GenericError, NotFound}
+import org.scalatest.{FlatSpec, Matchers}
+
+class FindExistingIdentityIdTest extends FlatSpec with Matchers {
+  "findExistingIdentityId" should "continue processing with identity id for existing validated account" in {
+    FindExistingIdentityId(
+      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = true)),
+      _ => fail("Should not be called")
+    )(EmailAddress("email@email.email")) should be(ContinueProcessing(Some(IdentityId("100"))))
+  }
+
+  "findExistingIdentityId" should "continue processing with identity id for existing unvalidated account with no password" in {
+    FindExistingIdentityId(
+      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
+      _ => ClientSuccess(IdentityUser(IdentityId("100"), hasPassword = false))
+    )(EmailAddress("email@email.email")) should be(ContinueProcessing(Some(IdentityId("100"))))
+  }
+
+  "findExistingIdentityId" should "continue processing for not found identity user" in {
+    FindExistingIdentityId(
+      _ => NotFound("not found"),
+      _ => fail("should not be called")
+    )(EmailAddress("email@email.email")) should be(ContinueProcessing(None))
+  }
+
+  "findExistingIdentityId" should "ReturnWithResponse for unvalidated account with password" in {
+    FindExistingIdentityId(
+      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
+      _ => ClientSuccess(IdentityUser(IdentityId("100"), hasPassword = true))
+    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set IdentityId(100)")))
+  }
+
+  "findExistingIdentityId" should "ReturnWithResponse for unexpected identity response" in {
+    FindExistingIdentityId(
+      _ => GenericError("error"),
+      _ => fail("should not be called")
+    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.internalServerError("error")))
+  }
+
+  "findExistingIdentityId" should "ReturnWithResponse for unexpected identity response for get by id" in {
+    FindExistingIdentityId(
+      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
+      _ => GenericError("error"),
+    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set IdentityId(100)")))
+  }
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
@@ -2,7 +2,6 @@ package com.gu.identityBackfill
 
 import com.gu.identity.GetByEmail
 import com.gu.identity.GetByEmail.IdentityAccount
-import com.gu.identity.GetByIdentityId.IdentityUser
 import com.gu.identityBackfill.PreReqCheck.PreReqResult
 import com.gu.identityBackfill.Types._
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
@@ -11,7 +10,7 @@ import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.resthttp.LazyClientFailableOp
-import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess, GenericError, NotFound}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess}
 import org.scalatest.{FlatSpec, Matchers}
 
 class PreReqCheckTest extends FlatSpec with Matchers {
@@ -129,47 +128,5 @@ class PreReqCheckTest extends FlatSpec with Matchers {
   "acceptable reader type" should "not allow a combination of valid and invalid" in {
     val readerTypes = List(ReaderType.ReaderTypeValue("Direct"), ReaderType.ReaderTypeValue("Gift"))
     PreReqCheck.acceptableReaderType(ClientSuccess(readerTypes)).toDisjunction.leftMap(_.statusCode) should be(scalaz.-\/("404"))
-  }
-
-  "findExistingIdentityId" should "continue processing with identity id for existing validated account" in {
-    PreReqCheck.findExistingIdentityId(
-      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = true)),
-      _ => fail("Should not be called")
-    )(EmailAddress("email@email.email")) should be(ContinueProcessing(Some(IdentityId("100"))))
-  }
-
-  "findExistingIdentityId" should "continue processing with identity id for existing unvalidated account with no password" in {
-    PreReqCheck.findExistingIdentityId(
-      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
-      _ => ClientSuccess(IdentityUser(IdentityId("100"), hasPassword = false))
-    )(EmailAddress("email@email.email")) should be(ContinueProcessing(Some(IdentityId("100"))))
-  }
-
-  "findExistingIdentityId" should "continue processing for not found identity user" in {
-    PreReqCheck.findExistingIdentityId(
-      _ => NotFound("not found"),
-      _ => fail("should not be called")
-    )(EmailAddress("email@email.email")) should be(ContinueProcessing(None))
-  }
-
-  "findExistingIdentityId" should "ReturnWithResponse for unvalidated account with password" in {
-    PreReqCheck.findExistingIdentityId(
-      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
-      _ => ClientSuccess(IdentityUser(IdentityId("100"), hasPassword = true))
-    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set IdentityId(100)")))
-  }
-
-  "findExistingIdentityId" should "ReturnWithResponse for unexpected identity response" in {
-    PreReqCheck.findExistingIdentityId(
-      _ => GenericError("error"),
-      _ => fail("should not be called")
-    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.internalServerError("error")))
-  }
-
-  "findExistingIdentityId" should "ReturnWithResponse for unexpected identity response for get by id" in {
-    PreReqCheck.findExistingIdentityId(
-      _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
-      _ => GenericError("error"),
-    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set IdentityId(100)")))
   }
 }


### PR DESCRIPTION
Work done:

- If an identity user has an unvalidated email and they have no password then we can use this identity id in the backfill
- statusFields optional in identity response - not all users have status fields

Why are we doing this:

Increase the number of users backfilled with existing accounts.