### PR TITLE
sf datalake export improvements

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -11,10 +11,11 @@ Parameters:
     Default: CODE
 Mappings:
   StageMap:
-    CODE: #we should write into a bucket in the ophan account really
-      destBucketArn: "arn:aws:s3:::gu-salesforce-export-test/*"
+    CODE:
+      destBuckets: "arn:aws:s3:::gu-salesforce-export-test/CODE/*"
     PROD:
-      destBucketArn: "arn:aws:s3:::gu-salesforce-export-test/*"
+      destBuckets: ["arn:aws:s3:::gu-salesforce-export-test/PROD/*", "arn:aws:s3:::ophan-clean-salesforce-customer-data-*"]
+
 Resources:
   StartJobRole:
     Type: AWS::IAM::Role
@@ -143,7 +144,7 @@ Resources:
           - Effect: Allow
             Action: s3:GetObject
             Resource: !Sub "arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfExportAuth-${Stage}*.json"
-      - PolicyName: DestBucket
+      - PolicyName: DestBuckets
         PolicyDocument:
           Statement:
           - Effect: Allow
@@ -157,7 +158,7 @@ Resources:
             - s3:PutObject
             - s3:GetObjectVersion
             - s3:DeleteObjectVersion
-            Resource: !FindInMap [StageMap, !Ref Stage, destBucketArn]
+            Resource: !FindInMap [StageMap, !Ref Stage, destBuckets]
   DownloadBatch:
     Type: AWS::Lambda::Function
     Properties:

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
@@ -89,7 +89,7 @@ object DownloadBatchHandler {
       resultId <- getBatchResultId(getIdRequest).toTry
       downloadRequest = DownloadResultsRequest(jobId, batchId, resultId)
       fileContent <- getBatchResult(downloadRequest).toTry
-      fileName = FileName(s"${jobName.value}-${jobId.value}-${resultId.id}.csv")
+      fileName = FileName(s"${jobName.value}_${jobId.value}_${resultId.id}.csv")
       file = File(fileName, fileContent)
       basePath = basePathFor(objectName, uploadToDataLake)
       _ <- uploadFile(basePath, file)
@@ -97,11 +97,8 @@ object DownloadBatchHandler {
   }
 
   def uploadBasePath(stage: Stage)(objectName: ObjectName, uploadToDataLake: UploadToDataLake) = stage match {
-    case Stage("PROD") if uploadToDataLake.value => {
-      //todo actually upload to the bucket when we are ready
-      val bucketName = s"opan-raw-salesforce-${objectName.value.toLowerCase}"
-      BasePath(s"gu-salesforce-export-test/PROD/raw/Datalake/$bucketName")
-    }
+    case Stage("PROD") if uploadToDataLake.value =>  BasePath(s"ophan-raw-salesforce-${objectName.value.toLowerCase}")
+
     case Stage(stageName) => BasePath(s"gu-salesforce-export-test/$stageName/raw")
   }
 

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
@@ -129,7 +129,7 @@ object DownloadBatchHandler {
   }
 
   def steps(
-    downloadBatch: (JobName,ObjectName, JobId, BatchId) => Try[Unit]
+    downloadBatch: (JobName, ObjectName, JobId, BatchId) => Try[Unit]
   )(request: WireState): Try[WireState] = for {
     batches <- IList(request.batches: _*).traverse(WireBatch.toBatch).map(_.toList).toTry
     pendingBatches = batches.filter(b => b.state == Completed)

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
@@ -67,7 +67,7 @@ object DownloadBatchHandler {
   }
 
   def download(
-    uploadFile: (File) => Try[_],
+    uploadFile: File => Try[_],
     getBatchResultId: GetBatchResultRequest => ClientFailableOp[BatchResultId],
     getBatchResult: DownloadResultsRequest => ClientFailableOp[FileContent]
   )(

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/DownloadBatchHandler.scala
@@ -97,7 +97,7 @@ object DownloadBatchHandler {
   }
 
   def uploadBasePath(stage: Stage)(objectName: ObjectName, uploadToDataLake: UploadToDataLake) = stage match {
-    case Stage("PROD") if uploadToDataLake.value =>  BasePath(s"ophan-raw-salesforce-${objectName.value.toLowerCase}")
+    case Stage("PROD") if uploadToDataLake.value => BasePath(s"ophan-raw-salesforce-customer-data-${objectName.value.toLowerCase}")
 
     case Stage(stageName) => BasePath(s"gu-salesforce-export-test/$stageName/raw")
   }

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/GetBatchesHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/GetBatchesHandler.scala
@@ -22,7 +22,8 @@ object GetBatchesHandler {
 
   case class WireRequest(
     jobId: String,
-    jobName: String
+    jobName: String,
+    objectName: String
   )
 
   object WireRequest {
@@ -56,6 +57,7 @@ object GetBatchesHandler {
   case class WireResponse(
     jobId: String,
     jobName: String,
+    objectName: String,
     jobStatus: String,
     batches: Seq[WireBatch]
   )
@@ -103,6 +105,7 @@ object GetBatchesHandler {
     } yield WireResponse(
       jobId = request.jobId,
       jobName = request.jobName,
+      objectName = request.objectName,
       jobStatus = status.name,
       batches = batches.map(WireBatch.fromBatch)
     )

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/GetBatchesHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/GetBatchesHandler.scala
@@ -23,7 +23,8 @@ object GetBatchesHandler {
   case class WireRequest(
     jobId: String,
     jobName: String,
-    objectName: String
+    objectName: String,
+    uploadToDataLake: Boolean
   )
 
   object WireRequest {
@@ -59,7 +60,8 @@ object GetBatchesHandler {
     jobName: String,
     objectName: String,
     jobStatus: String,
-    batches: Seq[WireBatch]
+    batches: Seq[WireBatch],
+    uploadToDataLake: Boolean
   )
 
   object WireResponse {
@@ -107,6 +109,7 @@ object GetBatchesHandler {
       jobName = request.jobName,
       objectName = request.objectName,
       jobStatus = status.name,
+      uploadToDataLake = request.uploadToDataLake,
       batches = batches.map(WireBatch.fromBatch)
     )
   }

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/StartJobHandler.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/handlers/StartJobHandler.scala
@@ -34,7 +34,8 @@ object StartJobHandler {
 
   case class WireResponse(
     jobId: String,
-    jobName: String
+    jobName: String,
+    objectName: String
   )
 
   object WireResponse {
@@ -52,8 +53,8 @@ object StartJobHandler {
       jobId <- createJob(createJobRequest).toTry
       addQueryRequest = AddQueryRequest(sfQueryInfo.soql, jobId)
       _ <- addQuery(addQueryRequest).toTry
-      jobName = s"${sfQueryInfo.objectName.value}_${getCurrentDate()}"
-    } yield WireResponse(jobId.value, jobName)
+      jobName = s"${objectName.value}_${getCurrentDate()}"
+    } yield WireResponse(jobId.value, jobName, objectName.value)
   }
 
   def operation(

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
@@ -4,8 +4,8 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.amazonaws.util.IOUtils
+import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.ObjectName
 import com.gu.util.Logging
-import com.gu.util.config.Stage
 
 import scala.util.Try
 object S3UploadFile extends Logging {
@@ -14,9 +14,9 @@ object S3UploadFile extends Logging {
   case class FileName(value: String) extends AnyVal
   case class File(fileName: FileName, content: FileContent)
   def apply(
-    basePath: BasePath,
     s3Write: PutObjectRequest => Try[PutObjectResult]
   )(
+    basePath: BasePath,
     file: File
   ): Try[PutObjectResult] = {
     logger.info(s"Uploading ${file.fileName.value} to S3...")

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
@@ -2,7 +2,7 @@ package com.gu.sf_datalake_export.salesforce_bulk_api
 
 import java.io.{ByteArrayInputStream, InputStream}
 
-import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult}
+import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.amazonaws.util.IOUtils
 import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.ObjectName
 import com.gu.util.Logging
@@ -25,12 +25,11 @@ object S3UploadFile extends Logging {
     val uploadMetadata = new ObjectMetadata()
     uploadMetadata.setContentLength(bytes.length.toLong)
     val putRequest = new PutObjectRequest(
-
       basePath.value,
       file.fileName.value,
       new ByteArrayInputStream(bytes),
       uploadMetadata
-    )
+    ).withCannedAcl(CannedAccessControlList.BucketOwnerRead)
 
     s3Write(putRequest)
 

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
@@ -4,7 +4,6 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata, PutObjectRequest, PutObjectResult}
 import com.amazonaws.util.IOUtils
-import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.ObjectName
 import com.gu.util.Logging
 
 import scala.util.Try

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFile.scala
@@ -9,12 +9,12 @@ import com.gu.util.config.Stage
 
 import scala.util.Try
 object S3UploadFile extends Logging {
-
+  case class BasePath(value: String) extends AnyVal
   case class FileContent(value: String) extends AnyVal
   case class FileName(value: String) extends AnyVal
   case class File(fileName: FileName, content: FileContent)
   def apply(
-    stage: Stage,
+    basePath: BasePath,
     s3Write: PutObjectRequest => Try[PutObjectResult]
   )(
     file: File
@@ -25,7 +25,8 @@ object S3UploadFile extends Logging {
     val uploadMetadata = new ObjectMetadata()
     uploadMetadata.setContentLength(bytes.length.toLong)
     val putRequest = new PutObjectRequest(
-      s"gu-salesforce-export-test/${stage.value}/raw",
+
+      basePath.value,
       file.fileName.value,
       new ByteArrayInputStream(bytes),
       uploadMetadata

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -23,11 +23,11 @@ object BulkApiParams {
   val cases = SfQueryInfo(Soql(SfQueries.cases), ObjectName("Case"), SfObjectName("Case"))
   val caseComment = SfQueryInfo(Soql(SfQueries.caseComment), ObjectName("CaseComment"), SfObjectName("CaseComment"))
   val csSurvey = SfQueryInfo(Soql(SfQueries.csSurvey), ObjectName("CsSurvey"), SfObjectName("CS_Survey__c"))
-  val discount = SfQueryInfo(Soql(SfQueries.discount), ObjectName("CsSurvey"), SfObjectName("Discount__c"))
+  val discount = SfQueryInfo(Soql(SfQueries.discount), ObjectName("Discount"), SfObjectName("Discount__c"))
   val fulfilmentProcessInformation = SfQueryInfo(Soql(SfQueries.fulfilmentProcessInformation), ObjectName("FulfilmentProcessInformation"), SfObjectName("Fulfilment_Process_Information__c"))
   val imovoContract = SfQueryInfo(Soql(SfQueries.imovoContract), ObjectName("ImovoContract"), SfObjectName("Imovo_Contract__c"))
   val paymentCard = SfQueryInfo(Soql(SfQueries.paymentCard), ObjectName("PaymentCard"), SfObjectName("Payment_Card__c"))
-  val paymentFailure = SfQueryInfo(Soql(SfQueries.paymentCard), ObjectName("PaymentFailure"), SfObjectName("paymentFailure"))
+  val paymentFailure = SfQueryInfo(Soql(SfQueries.paymentFailure), ObjectName("PaymentFailure"), SfObjectName("Payment_Failure__c"))
 
   val all = List(
     contact,
@@ -109,7 +109,8 @@ object SfQueries {
       |Voucher_Fulfilment_Cut_Off_Date__c,
       |Voucher_Start_Date__c,
       |RecordType.Name,
-      |LastName
+      |LastName,
+      |Membership_Tier__c
       |from Contact
       |where
       |Account.GDPR_Deletion_Pending__c = false
@@ -191,7 +192,6 @@ object SfQueries {
       |
   """.stripMargin
 
-  //removed compund ShippingAddress,BillingAddress
   //TODO BillingAccount__c doesn't exist ?
   val accounts =
     """

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -502,7 +502,6 @@ object SfQueries {
       |where Contact__r.Account.GDPR_Deletion_Pending__c =false
     """.stripMargin
 
-  //TODO do we need to do gdpr exclusions on this ? how?
   //the object Imovo_Contract__c doesn't seem to exist
   val imovoContract =
     """
@@ -529,9 +528,9 @@ object SfQueries {
       |SystemModstamp
       |from
       |Imovo_Contract__c
+      |where Contact__r.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
-  //TODO IS THIS THE CORRECT WAY TO DO GDPR EXCLUSION ? IM USING THE ZUORA FIELD INSTEAD OF THE ACCOUNT BOOLEAN
   val paymentCard =
     """
       |select
@@ -563,7 +562,7 @@ object SfQueries {
       |Zuora_ReferenceId__c
       |from
       |Payment_Card__c
-      |where Zuora_BillingAccount__r.ProcessingAdvice__c != 'DoNotProcess'
+      |where AccountID__r.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
   //Last_Attempt_Error_Code__c doesnt seem to exist

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -412,6 +412,7 @@ object SfQueries {
       |SystemModstamp
       |from
       |CaseComment
+      |where Parent.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
   //Date_Submitted__c, doesnt seem to exist

--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -107,7 +107,9 @@ object SfQueries {
       |Salutation,
       |Title,
       |Voucher_Fulfilment_Cut_Off_Date__c,
-      |Voucher_Start_Date__c
+      |Voucher_Start_Date__c,
+      |RecordType.Name,
+      |LastName
       |from Contact
       |where
       |Account.GDPR_Deletion_Pending__c = false
@@ -185,6 +187,7 @@ object SfQueries {
       |Zuora_Subscription_Salesforce_ID__c,
       |Zuora_Subscription_Name__c
       |from SF_Subscription__c
+      |where Buyer__r.Account.GDPR_Deletion_Pending__c = false
       |
   """.stripMargin
 
@@ -274,6 +277,8 @@ object SfQueries {
       |SystemModstamp
       |from
       |Cancellation_Survey_Voluntary__c
+      |where Contact__r.Account.GDPR_Deletion_Pending__c = false
+      |
     """.stripMargin
 
   val cardExpiry =
@@ -324,6 +329,7 @@ object SfQueries {
       |Term_End_Date__c
       |from
       |Card_Expiry__c
+      |where Contact__r.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
   val cases =
@@ -388,6 +394,7 @@ object SfQueries {
       |WinBack_Email__c
       |from
       |Case
+      |where Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
   val caseComment =
@@ -431,6 +438,7 @@ object SfQueries {
       |SystemModstamp
       |from
       |CS_Survey__c
+      |where Related_to_Contact__r.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
   val discount =
@@ -462,6 +470,7 @@ object SfQueries {
       |SystemModstamp
       |from
       |Discount__c
+      |where Contact__r.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 
   val fulfilmentProcessInformation =
@@ -490,8 +499,10 @@ object SfQueries {
       |SystemModstamp
       |from
       |Fulfilment_Process_Information__c
+      |where Contact__r.Account.GDPR_Deletion_Pending__c =false
     """.stripMargin
 
+  //TODO do we need to do gdpr exclusions on this ? how?
   //the object Imovo_Contract__c doesn't seem to exist
   val imovoContract =
     """
@@ -520,6 +531,7 @@ object SfQueries {
       |Imovo_Contract__c
     """.stripMargin
 
+  //TODO IS THIS THE CORRECT WAY TO DO GDPR EXCLUSION ? IM USING THE ZUORA FIELD INSTEAD OF THE ACCOUNT BOOLEAN
   val paymentCard =
     """
       |select
@@ -551,6 +563,7 @@ object SfQueries {
       |Zuora_ReferenceId__c
       |from
       |Payment_Card__c
+      |where Zuora_BillingAccount__r.ProcessingAdvice__c != 'DoNotProcess'
     """.stripMargin
 
   //Last_Attempt_Error_Code__c doesnt seem to exist
@@ -618,5 +631,6 @@ object SfQueries {
       |SystemModstamp
       |from
       |Payment_Failure__c
+      |where Contact__r.Account.GDPR_Deletion_Pending__c = false
     """.stripMargin
 }

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/DownloadBatchHandlerTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/DownloadBatchHandlerTest.scala
@@ -28,7 +28,7 @@ class DownloadBatchHandlerTest extends FlatSpec with Matchers {
 
   val twoBatchState = WireState(
     jobName = "someJobName",
-    objectName= "SomeObjectName",
+    objectName = "someObjectName",
     jobId = "someJobId",
     batches = List(wireBatch1, wireBatch2)
   )

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/DownloadBatchHandlerTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/DownloadBatchHandlerTest.scala
@@ -4,7 +4,7 @@ import com.gu.sf_datalake_export.handlers.DownloadBatchHandler
 import com.gu.sf_datalake_export.handlers.DownloadBatchHandler.{WireBatch, WireState}
 import com.gu.sf_datalake_export.handlers.StartJobHandler.UploadToDataLake
 import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams
-import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.{ObjectName, SfQueryInfo}
+import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.ObjectName
 import com.gu.sf_datalake_export.salesforce_bulk_api.CreateJob.JobId
 import com.gu.sf_datalake_export.salesforce_bulk_api.GetBatchResult.{DownloadResultsRequest, JobName}
 import com.gu.sf_datalake_export.salesforce_bulk_api.GetBatchResultId.{BatchResultId, GetBatchResultRequest}
@@ -59,7 +59,7 @@ class DownloadBatchHandlerTest extends FlatSpec with Matchers {
   "DownloadBatches.downloadBatch" should "download file contents and upload to s3 " in {
     def validatingUploadFile(basePath: BasePath, file: File): Try[Unit] = {
       basePath shouldBe BasePath("someBasePath")
-      file.fileName shouldBe FileName("someJobName-someJobId-someResultId.csv")
+      file.fileName shouldBe FileName("someJobName_someJobId_someResultId.csv")
       file.content shouldBe FileContent("someFileContent")
 
       Success(())
@@ -97,9 +97,22 @@ class DownloadBatchHandlerTest extends FlatSpec with Matchers {
     wiredDownloadBatch(JobName("someJobName"), ObjectName("someObjectName"), JobId("someJobId"), BatchId("someBatchId")) shouldBe Success(())
   }
 
-  "uploadBasePath" should "return test basePath for PROD requests with uploadToDataLake enabled" in {
+  "uploadBasePath" should "return ophan bucket basepath for PROD requests with uploadToDataLake enabled" in {
     val contactName = BulkApiParams.contact.objectName
     val actualBasePath = DownloadBatchHandler.uploadBasePath(Stage("PROD"))(contactName, UploadToDataLake(true))
-    actualBasePath shouldBe BasePath("gu-salesforce-export-test/PROD/raw/Datalake/opan-raw-salesforce-contact")
+    actualBasePath shouldBe BasePath("ophan-raw-salesforce-customer-data-contact")
+  }
+
+  it should "return test bucket basepath for PROD requests with uploadToDataLake disabled" in {
+    val contactName = BulkApiParams.contact.objectName
+    val actualBasePath = DownloadBatchHandler.uploadBasePath(Stage("PROD"))(contactName, UploadToDataLake(false))
+    actualBasePath shouldBe BasePath("gu-salesforce-export-test/PROD/raw")
+  }
+
+  it should "return test bucket basepath for non PROD requests regardless of the uploadToDataLake param" in {
+    val contactName = BulkApiParams.contact.objectName
+    val codeBasePath = DownloadBatchHandler.uploadBasePath(Stage("CODE"))(contactName, UploadToDataLake(false))
+    val codeBasePathUploadToDl = DownloadBatchHandler.uploadBasePath(Stage("CODE"))(contactName, UploadToDataLake(false))
+    List(codeBasePath, codeBasePathUploadToDl).distinct shouldBe List(BasePath("gu-salesforce-export-test/CODE/raw"))
   }
 }

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/DownloadBatchHandlerTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/DownloadBatchHandlerTest.scala
@@ -2,7 +2,7 @@ package com.com.gu.sf_datalake_export.handlers
 
 import com.gu.sf_datalake_export.handlers.DownloadBatchHandler
 import com.gu.sf_datalake_export.handlers.DownloadBatchHandler.{WireBatch, WireState}
-import com.gu.sf_datalake_export.handlers.StartJobHandler.UploadToDataLake
+import com.gu.sf_datalake_export.handlers.StartJobHandler.ShouldUploadToDataLake
 import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams
 import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.ObjectName
 import com.gu.sf_datalake_export.salesforce_bulk_api.CreateJob.JobId
@@ -80,14 +80,14 @@ class DownloadBatchHandlerTest extends FlatSpec with Matchers {
       ClientSuccess(FileContent("someFileContent"))
     }
 
-    def basePathFor(objectName: ObjectName, uploadToDataLake: UploadToDataLake) = {
-      uploadToDataLake shouldBe UploadToDataLake(false)
+    def basePathFor(objectName: ObjectName, shouldUploadtoDataLake: ShouldUploadToDataLake) = {
+      shouldUploadtoDataLake shouldBe ShouldUploadToDataLake(false)
       objectName shouldBe ObjectName("someObjectName")
       BasePath(s"someBasePath")
     }
 
     val wiredDownloadBatch = DownloadBatchHandler.download(
-      UploadToDataLake(false),
+      ShouldUploadToDataLake(false),
       basePathFor,
       validatingUploadFile,
       validatingGetBatchResultId,
@@ -99,20 +99,20 @@ class DownloadBatchHandlerTest extends FlatSpec with Matchers {
 
   "uploadBasePath" should "return ophan bucket basepath for PROD requests with uploadToDataLake enabled" in {
     val contactName = BulkApiParams.contact.objectName
-    val actualBasePath = DownloadBatchHandler.uploadBasePath(Stage("PROD"))(contactName, UploadToDataLake(true))
+    val actualBasePath = DownloadBatchHandler.uploadBasePath(Stage("PROD"))(contactName, ShouldUploadToDataLake(true))
     actualBasePath shouldBe BasePath("ophan-raw-salesforce-customer-data-contact")
   }
 
   it should "return test bucket basepath for PROD requests with uploadToDataLake disabled" in {
     val contactName = BulkApiParams.contact.objectName
-    val actualBasePath = DownloadBatchHandler.uploadBasePath(Stage("PROD"))(contactName, UploadToDataLake(false))
+    val actualBasePath = DownloadBatchHandler.uploadBasePath(Stage("PROD"))(contactName, ShouldUploadToDataLake(false))
     actualBasePath shouldBe BasePath("gu-salesforce-export-test/PROD/raw")
   }
 
   it should "return test bucket basepath for non PROD requests regardless of the uploadToDataLake param" in {
     val contactName = BulkApiParams.contact.objectName
-    val codeBasePath = DownloadBatchHandler.uploadBasePath(Stage("CODE"))(contactName, UploadToDataLake(false))
-    val codeBasePathUploadToDl = DownloadBatchHandler.uploadBasePath(Stage("CODE"))(contactName, UploadToDataLake(false))
+    val codeBasePath = DownloadBatchHandler.uploadBasePath(Stage("CODE"))(contactName, ShouldUploadToDataLake(false))
+    val codeBasePathUploadToDl = DownloadBatchHandler.uploadBasePath(Stage("CODE"))(contactName, ShouldUploadToDataLake(false))
     List(codeBasePath, codeBasePathUploadToDl).distinct shouldBe List(BasePath("gu-salesforce-export-test/CODE/raw"))
   }
 }

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/StartJobStepTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/StartJobStepTest.scala
@@ -3,7 +3,7 @@ package com.com.gu.sf_datalake_export.handlers
 import java.time.LocalDate
 
 import com.gu.sf_datalake_export.handlers.StartJobHandler
-import com.gu.sf_datalake_export.handlers.StartJobHandler.{UploadToDataLake, WireResponse}
+import com.gu.sf_datalake_export.handlers.StartJobHandler.{ShouldUploadToDataLake, WireResponse}
 import com.gu.sf_datalake_export.salesforce_bulk_api.AddQueryToJob.AddQueryRequest
 import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.{BatchSize, ObjectName, SfObjectName, Soql}
 import com.gu.sf_datalake_export.salesforce_bulk_api.CreateJob.{CreateJobRequest, JobId}
@@ -42,32 +42,32 @@ class StartJobStepTest extends FlatSpec with Matchers {
       jobName = "Contact_2018-10-22",
       uploadToDataLake = false
     )
-    testSteps(ObjectName("Contact"), UploadToDataLake(false)) shouldBe Success(expectedResponse)
+    testSteps(ObjectName("Contact"), ShouldUploadToDataLake(false)) shouldBe Success(expectedResponse)
   }
 
   it should "return failure if object in request is unknown" in {
-    testSteps(ObjectName("unknownObject"), UploadToDataLake(false)) shouldBe Failure(LambdaException("invalid object name unknownObject"))
+    testSteps(ObjectName("unknownObject"), ShouldUploadToDataLake(false)) shouldBe Failure(LambdaException("invalid object name unknownObject"))
   }
 
   "UploadToDataLake" should "be set to true by default in PROD" in {
-    UploadToDataLake(None, Stage("PROD")) shouldBe Success(UploadToDataLake(true))
+    ShouldUploadToDataLake(None, Stage("PROD")) shouldBe Success(ShouldUploadToDataLake(true))
   }
   it should "be set to true by default in non PROD stages" in {
-    UploadToDataLake(None, Stage("NOT-PROD")) shouldBe Success(UploadToDataLake(false))
+    ShouldUploadToDataLake(None, Stage("NOT-PROD")) shouldBe Success(ShouldUploadToDataLake(false))
   }
 
   it should "return an error if attempted to set to true in non PROD ENV" in {
-    UploadToDataLake(Some(true), Stage("NOT-PROD")) shouldBe Failure(LambdaException("uploadToDatalake can only be enabled in PROD"))
+    ShouldUploadToDataLake(Some(true), Stage("NOT-PROD")) shouldBe Failure(LambdaException("uploadToDatalake can only be enabled in PROD"))
   }
 
   it should "should be set to the correct value in PROD" in {
-    val actualTrue = UploadToDataLake(Some(true), Stage("PROD"))
-    val actualFalse = UploadToDataLake(Some(false), Stage("PROD"))
+    val actualTrue = ShouldUploadToDataLake(Some(true), Stage("PROD"))
+    val actualFalse = ShouldUploadToDataLake(Some(false), Stage("PROD"))
     val expectedResponses = (trueResponse, falseResponse)
     (actualTrue, actualFalse) shouldBe expectedResponses
 
   }
 
-  val trueResponse = Success(UploadToDataLake(true))
-  val falseResponse = Success(UploadToDataLake(false))
+  val trueResponse = Success(ShouldUploadToDataLake(true))
+  val falseResponse = Success(ShouldUploadToDataLake(false))
 }

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/StartJobStepTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/StartJobStepTest.scala
@@ -3,15 +3,17 @@ package com.com.gu.sf_datalake_export.handlers
 import java.time.LocalDate
 
 import com.gu.sf_datalake_export.handlers.StartJobHandler
-import com.gu.sf_datalake_export.handlers.StartJobHandler.WireResponse
+import com.gu.sf_datalake_export.handlers.StartJobHandler.{UploadToDataLake, WireResponse}
 import com.gu.sf_datalake_export.salesforce_bulk_api.AddQueryToJob.AddQueryRequest
 import com.gu.sf_datalake_export.salesforce_bulk_api.BulkApiParams.{BatchSize, ObjectName, SfObjectName, Soql}
 import com.gu.sf_datalake_export.salesforce_bulk_api.CreateJob.{CreateJobRequest, JobId}
 import com.gu.sf_datalake_export.salesforce_bulk_api.SfQueries
+import com.gu.util.config.Stage
 import com.gu.util.handlers.LambdaException
 import com.gu.util.resthttp.Types.ClientSuccess
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.util.parsing.combinator.Parsers
 import scala.util.{Failure, Success}
 
 class StartJobStepTest extends FlatSpec with Matchers {
@@ -37,13 +39,35 @@ class StartJobStepTest extends FlatSpec with Matchers {
     val expectedResponse = WireResponse(
       jobId = "someJobId",
       objectName = "Contact",
-      jobName = "Contact_2018-10-22"
+      jobName = "Contact_2018-10-22",
+      uploadToDataLake = false
     )
-    testSteps(ObjectName("Contact")) shouldBe Success(expectedResponse)
+    testSteps(ObjectName("Contact"), UploadToDataLake(false)) shouldBe Success(expectedResponse)
   }
 
   it should "return failure if object in request is unknown" in {
-    testSteps(ObjectName("unknownObject")) shouldBe Failure(LambdaException("invalid object name unknownObject"))
+    testSteps(ObjectName("unknownObject"), UploadToDataLake(false)) shouldBe Failure(LambdaException("invalid object name unknownObject"))
   }
 
+  "UploadToDataLake" should "be set to true by default in PROD" in {
+    UploadToDataLake(None, Stage("PROD")) shouldBe Success(UploadToDataLake(true))
+  }
+  it should "be set to true by default in non PROD stages" in {
+    UploadToDataLake(None, Stage("NOT-PROD")) shouldBe Success(UploadToDataLake(false))
+  }
+
+  it should "return an error if attempted to set to true in non PROD ENV" in {
+    UploadToDataLake(Some(true), Stage("NOT-PROD")) shouldBe Failure(LambdaException("uploadToDatalake can only be enabled in PROD"))
+  }
+
+  it should "should be set to the correct value in PROD" in {
+    val actualTrue = UploadToDataLake(Some(true), Stage("PROD"))
+    val actualFalse = UploadToDataLake(Some(false), Stage("PROD"))
+    val expectedResponses = (trueResponse, falseResponse)
+    (actualTrue, actualFalse) shouldBe expectedResponses
+
+  }
+
+  val trueResponse = Success(UploadToDataLake(true))
+  val falseResponse = Success(UploadToDataLake(false))
 }

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/StartJobStepTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/handlers/StartJobStepTest.scala
@@ -36,6 +36,7 @@ class StartJobStepTest extends FlatSpec with Matchers {
 
     val expectedResponse = WireResponse(
       jobId = "someJobId",
+      objectName = "Contact",
       jobName = "Contact_2018-10-22"
     )
     testSteps(ObjectName("Contact")) shouldBe Success(expectedResponse)

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/DownloadBatchManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/DownloadBatchManualTest.scala
@@ -11,6 +11,7 @@ object DownloadBatchManualTest extends App {
       |"jobId" : "7506E000004FloxQAC",
       |"jobName" : "Contact_2018-11-20",
       |"objectName" : "Contact",
+      |"uploadToDataLake" : false,
       |"batches" : [{
       | "batchId" : "7516E000003E9ejQAC",
       | "state" : "Completed"

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/DownloadBatchManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/DownloadBatchManualTest.scala
@@ -8,10 +8,11 @@ import com.gu.sf_datalake_export.handlers.DownloadBatchHandler
 object DownloadBatchManualTest extends App {
   val request =
     """{
-      |"jobId" : "7506E000004EnRoQAK",
-      |"jobName" : "sfSubscriptions",
+      |"jobId" : "7506E000004FloxQAC",
+      |"jobName" : "Contact_2018-11-20",
+      |"objectName" : "Contact",
       |"batches" : [{
-      | "batchId" : "7516E000003DjZnQAK",
+      | "batchId" : "7516E000003E9ejQAC",
       | "state" : "Completed"
       | }
       | ]

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndJobManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/EndJobManualTest.scala
@@ -8,7 +8,7 @@ import com.gu.sf_datalake_export.handlers.EndJobHandler
 object EndJobManualTest extends App {
   val request =
     """{
-      | "jobId" : "7506E000004Eq7hQAC"
+      | "jobId" : "7506E000004FloxQAC"
       |}
     """.stripMargin
 

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/GetJobBatchesManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/GetJobBatchesManualTest.scala
@@ -10,7 +10,8 @@ object GetJobBatchesManualTest extends App {
     """{
       |"jobId" : "7506E000004FloxQAC",
       |"jobName" : "Contact_2018-11-20",
-      |"objectName" : "Contact"
+      |"objectName" : "Contact",
+      |"uploadToDataLake" : false
       |}
     """.stripMargin
 

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/GetJobBatchesManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/GetJobBatchesManualTest.scala
@@ -8,8 +8,9 @@ import com.gu.sf_datalake_export.handlers.GetBatchesHandler
 object GetJobBatchesManualTest extends App {
   val request =
     """{
-      |"jobId" : "7506E000004EnRoQAK",
-      |"jobName" : "sfSubs"
+      |"jobId" : "7506E000004FloxQAC",
+      |"jobName" : "Contact_2018-11-20",
+      |"objectName" : "Contact"
       |}
     """.stripMargin
 

--- a/handlers/sf-datalake-export/src/test/scala/com/manual_test/StartJobManualTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/manual_test/StartJobManualTest.scala
@@ -3,16 +3,17 @@ package manualTest
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.gu.sf_datalake_export.handlers.StartJobHandler
-import com.gu.sf_datalake_export.salesforce_bulk_api.SfQueries
+import com.gu.sf_datalake_export.salesforce_bulk_api.{BulkApiParams, SfQueries}
 
 //This is just a way to locally run the lambda in dev
 object StartJobManualTest extends App {
 
-  val queryStr = SfQueries.contactQuery.replace("\n", " ")
+  val sfObject = BulkApiParams.contact
+  val queryStr = sfObject.soql.value.replace("\n", " ")
 
   val request =
     s"""{
-      |"objectName" : "Contact"
+      |"objectName" : "${sfObject.objectName.value}"
       |}
     """.stripMargin
 


### PR DESCRIPTION
- added some missing fields to contacts query
- added gdpr filters to queries
- upload to the ophan account when running in prod
- added a boolean input parameter "uploadToDataLake".  This param is true by default in prod and false in other stages. In fact setting it to true and running the state machine in anything other than PROD will return an error. This will allow us to run the state machine in prod without uploading anything to the data lake.
- also passed the object name along the state machine so that the downloader can use it to generate the destination bucket name

things still to do: 
- as we come to final agreement on the fields we need in the clean table, remove all the unused fields from the raw export queries
- add some error handling that always closes the sf export job even if the state machine fails 
