### PR TITLE
sf datalake export fixes

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -137,7 +137,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             - lambda:InvokeFunction
-            Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sf-get-batch-state-${Stage}:log-stream:*"
+            Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sf-download-batch-${Stage}:log-stream:*"
       - PolicyName: ReadPrivateCredentials
         PolicyDocument:
           Statement:
@@ -158,6 +158,7 @@ Resources:
             - s3:PutObject
             - s3:GetObjectVersion
             - s3:DeleteObjectVersion
+            - s3:PutObjectAcl
             Resource: !FindInMap [StageMap, !Ref Stage, destBuckets]
   DownloadBatch:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
- added permission needed to put object in ophan bucket
- fixed log group name that prevented logging in downloader lambda