### PR TITLE
Add lambda to be used for batch emails

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,8 @@ lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggreg
   `new-product-api`,
   `effects-sqs`,
   `effects-ses`,
-  `sf-datalake-export`
+  `sf-datalake-export`,
+  `batch-email-sender`
 ).dependsOn(zuora, handler, effectsDepIncludingTestFolder, `effects-sqs`, testDep)
 
 lazy val `identity-backfill` = all(project in file("handlers/identity-backfill")) // when using the "project identity-backfill" command it uses the lazy val name
@@ -205,6 +206,10 @@ lazy val `cancellation-sf-cases` = all(project in file("handlers/cancellation-sf
 lazy val `sf-datalake-export` = all(project in file("handlers/sf-datalake-export"))
   .enablePlugins(RiffRaffArtifact)
   .dependsOn(salesforce, handler, effectsDepIncludingTestFolder, testDep)
+
+lazy val `batch-email-sender` = all(project in file("handlers/batch-email-sender"))
+  .enablePlugins(RiffRaffArtifact)
+  .dependsOn(handler, effectsDepIncludingTestFolder, testDep)
 
 // ==== END handlers ====
 

--- a/handlers/batch-email-sender/README.md
+++ b/handlers/batch-email-sender/README.md
@@ -1,0 +1,53 @@
+# batch-email-sender
+There is work done in Salesforce that, on a schedule, generates information about emails that need to be sent. 
+
+This lambda receives a call from Salesforce with a batch of emails to be sent and adds items to the 
+contributions-thanks queue so that the email will be sent 
+
+
+
+### Sample request 
+
+`POST {url}/{CODE or PROD}/email-batch`
+
+body:
+```[  
+   {  
+      "payload":{  
+         "to_address":"dlasdj@dasd.com",
+         "subscriber_id":"A-S00044748",
+         "sf_contact_id":"0036E00000KtDaHQAV",
+         "product":"Membership",
+         "next_charge_date":"2018-09-03",
+         "last_name":"bla",
+         "identity_id":"30002177",
+         "first_name":"something",
+         "email_stage":"MBv1 - 1"
+      },
+      "object_name":"Card_Expiry__c"
+   },
+   {  
+      "payload":{  
+         "to_address":"dlasdj@dasd.com",
+         "subscriber_id":"A-S00044748",
+         "sf_contact_id":"0036E00000KtDaHQAV",
+         "product":"Membership",
+         "next_charge_date":"2018-09-03",
+         "last_name":"bla",
+         "identity_id":"30002177",
+         "first_name":"something",
+         "email_stage":"MBv1 - 1"
+      },
+      "object_name":"Card_Expiry__c"
+   }
+]
+```
+
+### Responses
+| Scenario      | Response code  | Response body | Retry ok? 
+| ------------- |-------------  | ---------------| ------|
+| All items added to queue     | 200 | None | No |
+| Request not parsed      | 400      | None | Yes |
+| No items added to queue (TBD!) | 502 | `{"message": "No ids added.}` | Yes |
+| Some emails added to queue (TBD!) | 502 | `{"message": "Some ids failed." failed_items: ["id1", "id2"]}` | Yes, for ids in the list. |
+

--- a/handlers/batch-email-sender/build.sbt
+++ b/handlers/batch-email-sender/build.sbt
@@ -1,0 +1,17 @@
+// "Any .sbt files in foo, say foo/build.sbt, will be merged with the build definition for the entire build, but scoped to the hello-foo project."
+// https://www.scala-sbt.org/0.13/docs/Multi-Project.html
+import Dependencies._
+
+name := "new-product-api"
+description:= "Receive batches of emails to be sent, munge them into an appropriate formate and put them on the email sending queue."
+
+scalacOptions += "-Ypartial-unification"
+
+assemblyJarName := "batch-email-sender.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := "MemSub::Membership Admin::Batch Email Sender"
+riffRaffArtifactResources += (file("handlers/batch-email-sender/cfn.yaml"), "cfn/cfn.yaml")
+
+libraryDependencies ++= Seq(supportInternationalisation)

--- a/handlers/batch-email-sender/build.sbt
+++ b/handlers/batch-email-sender/build.sbt
@@ -2,7 +2,7 @@
 // https://www.scala-sbt.org/0.13/docs/Multi-Project.html
 import Dependencies._
 
-name := "new-product-api"
+name := "batch-email-sender"
 description:= "Receive batches of emails to be sent, munge them into an appropriate formate and put them on the email sending queue."
 
 scalacOptions += "-Ypartial-unification"

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -93,11 +93,6 @@ Resources:
       PathPart: email-batch
       RestApiId: !Ref BatchEmailSenderApi
 
-  AddToBatchQueueApi:
-    Type: AWS::ApiGateway::RestApi
-    Properties:
-      Name: !Sub BatchEmailSender-${Stage}
-
   BatchEmailMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -111,7 +106,7 @@ Resources:
         IntegrationHttpMethod: POST
         Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BatchEmailSenderLambda.Arn}/invocations
     DependsOn:
-    - AddToBatchQueueApi
+    - BatchEmailSenderApi
     - BatchEmailSenderLambda
     - BatchEmailSenderApiGateway
 

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -1,0 +1,173 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: API to receive email batches from Salesforce and add the items to the queue.
+
+Parameters:
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - PROD
+      - CODE
+    Default: CODE
+
+Mappings:
+  StageMap:
+    CODE:
+      ApiName: batch-email-sender-CODE
+      EmailSendingQueue: contributions-thanks-dev
+    PROD:
+      ApiName: batch-email-sender-PROD
+      EmailSendingQueue: contributions-thanks
+
+Resources:
+  LogAndWriteToEmailQueueRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+                Service:
+                   - lambda.amazonaws.com
+            Action:
+                - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                - lambda:InvokeFunction
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/batch-email-sender-${Stage}:log-stream:*"
+
+        - PolicyName: SQSAddEmailRequest
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                - sqs:GetQueueUrl
+                - sqs:SendMessage
+                Resource:
+                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:contributions-thanks"
+                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:contributions-thanks-dev"
+
+  BatchEmailSenderLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Receives calls from Salesforce containing batches of emails to be added to the email sending queue.
+      FunctionName:
+        !Sub batch-email-sender-${Stage}
+      Code:
+        S3Bucket: zuora-auto-cancel-dist
+        S3Key: !Sub membership/${Stage}/batch-email-sender/batch-email-sender.jar
+      Handler: com.gu.batchemailsender.api.batchemail.Handler::apply
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+      Role:
+        Fn::GetAtt:
+        - "LogAndWriteToEmailQueueRole"
+        - Arn
+      MemorySize: 1536
+      Runtime: java8
+      Timeout: 300
+    DependsOn:
+    - "LogAndWriteToEmailQueueRole"
+
+  BatchEmailSenderApiPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !Sub batch-email-sender-${Stage}
+      Principal: apigateway.amazonaws.com
+    DependsOn: BatchEmailSenderLambda
+
+  BatchEmailSenderApiGateway:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt [BatchEmailSenderApi, RootResourceId]
+      PathPart: email-batch
+      RestApiId: !Ref AddToBatchQueueApi
+
+  AddToBatchQueueApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub BatchEmailSender-${Stage}
+
+  BatchEmailMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      ApiKeyRequired: true
+      RestApiId: !Ref BatchEmailSenderApi
+      ResourceId: !Ref BatchEmailSenderApiGateway
+      HttpMethod: POST
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BatchEmailSenderLambda.Arn}/invocations
+    DependsOn:
+    - AddToBatchQueueApi
+    - BatchEmailSenderLambda
+    - BatchEmailSenderApiGateway
+
+  BatchEmailSenderApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub BatchEmailSender-${Stage}
+
+  BatchEmailSenderApiStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      Description: Stage for batch email sender api
+      RestApiId: !Ref BatchEmailSenderApi
+      DeploymentId: !Ref BatchEmailSenderApiDeployment
+      StageName: !Sub ${Stage}
+    DependsOn:
+      - BatchEmailMethod
+
+  BatchEmailSenderApiDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      Description: Deploys batch-email-sender into an environment/stage
+      RestApiId: !Ref BatchEmailSenderApi
+    DependsOn:
+      - BatchEmailMethod
+
+  BatchEmailSenderApiKey:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Description: Key required to call batch email sender API
+      Enabled: true
+      Name: !Sub batch-email-sender-api-key-${Stage}
+      StageKeys:
+        - RestApiId: !Ref NewProductApi
+          StageName: !Sub ${Stage}
+    DependsOn:
+    - BatchEmailSenderApi
+    - BatchEmailSenderApiStage
+
+  BatchEmailSenderUsagePlan:
+    Type: "AWS::ApiGateway::UsagePlan"
+    Properties:
+      UsagePlanName: !Sub batch-email-sender-api-usage-plan-${Stage}
+      ApiStages:
+      - ApiId: !Ref BatchEmailSenderApi
+        Stage: !Ref BatchEmailSenderApiStage
+    DependsOn:
+    - BatchEmailSenderApi
+    - BatchEmailSenderApiStage
+
+  BatchEmailSenderUsagePlanKey:
+    Type: "AWS::ApiGateway::UsagePlanKey"
+    Properties:
+      KeyId: !Ref BatchEmailSenderApiKey
+      KeyType: API_KEY
+      UsagePlanId: !Ref BatchEmailSenderUsagePlan
+    DependsOn:
+    - BatchEmailSenderApiKey
+    - BatchEmailSenderUsagePlan

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -10,17 +10,8 @@ Parameters:
       - CODE
     Default: CODE
 
-Mappings:
-  StageMap:
-    CODE:
-      ApiName: batch-email-sender-CODE
-      EmailSendingQueue: contributions-thanks-dev
-    PROD:
-      ApiName: batch-email-sender-PROD
-      EmailSendingQueue: contributions-thanks
-
 Resources:
-  LogAndWriteToEmailQueueRole:
+  LogRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -44,17 +35,6 @@ Resources:
                 - lambda:InvokeFunction
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/batch-email-sender-${Stage}:log-stream:*"
 
-        - PolicyName: SQSAddEmailRequest
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action:
-                - sqs:GetQueueUrl
-                - sqs:SendMessage
-                Resource:
-                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:contributions-thanks"
-                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:contributions-thanks-dev"
-
   BatchEmailSenderLambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -70,13 +50,13 @@ Resources:
           Stage: !Ref Stage
       Role:
         Fn::GetAtt:
-        - "LogAndWriteToEmailQueueRole"
+        - "LogRole"
         - Arn
       MemorySize: 1536
       Runtime: java8
       Timeout: 300
     DependsOn:
-    - "LogAndWriteToEmailQueueRole"
+    - "LogRole"
 
   BatchEmailSenderApiPermission:
     Type: AWS::Lambda::Permission

--- a/handlers/batch-email-sender/cfn.yaml
+++ b/handlers/batch-email-sender/cfn.yaml
@@ -91,7 +91,7 @@ Resources:
     Properties:
       ParentId: !GetAtt [BatchEmailSenderApi, RootResourceId]
       PathPart: email-batch
-      RestApiId: !Ref AddToBatchQueueApi
+      RestApiId: !Ref BatchEmailSenderApi
 
   AddToBatchQueueApi:
     Type: AWS::ApiGateway::RestApi
@@ -145,7 +145,7 @@ Resources:
       Enabled: true
       Name: !Sub batch-email-sender-api-key-${Stage}
       StageKeys:
-        - RestApiId: !Ref NewProductApi
+        - RestApiId: !Ref BatchEmailSenderApi
           StageName: !Sub ${Stage}
     DependsOn:
     - BatchEmailSenderApi

--- a/handlers/batch-email-sender/riff-raff.yaml
+++ b/handlers/batch-email-sender/riff-raff.yaml
@@ -1,0 +1,21 @@
+stacks:
+- membership
+regions:
+- eu-west-1
+deployments:
+
+  cfn:
+    type: cloud-formation
+    app: batch-email-sender
+    parameters:
+      templatePath: cfn.yaml
+
+  batch-email-sender:
+    type: aws-lambda
+    parameters:
+      fileName: batch-email-sender.jar
+      bucket: zuora-auto-cancel-dist
+      prefixStack: false
+      functionNames:
+      - batch-email-sender-
+    dependencies: [cfn]

--- a/handlers/batch-email-sender/src/main/resources/log4j.properties
+++ b/handlers/batch-email-sender/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+log = .
+log4j.rootLogger = INFO, LAMBDA
+
+# Define the LAMBDA Appender
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
@@ -1,0 +1,24 @@
+package com.gu.newproduct.api.productcatalog
+
+import java.io.{InputStream, OutputStream}
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.gu.util.Logging
+import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
+import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
+import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
+
+object Handler extends Logging {
+
+  // Referenced in Cloudformation
+  def apply(inputStream: InputStream, outputStream: OutputStream, context: Context): Unit =
+    ApiGatewayHandler(LambdaIO(inputStream, outputStream, context)) {
+      ContinueProcessing(
+        Operation.noHealthcheck {
+          Req: ApiGatewayRequest => ApiGatewayResponse.messageResponse("200", "Hello, world!")
+        }
+      )
+    }
+}
+
+

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/Handler.scala
@@ -1,4 +1,4 @@
-package com.gu.newproduct.api.productcatalog
+package com.gu.batchemailsender.api.batchemail
 
 import java.io.{InputStream, OutputStream}
 


### PR DESCRIPTION
We need a lambda to receive a call from salesforce with information about card expiry emails to be sent. 

This adds a lambda behind an API gateway that requires an API key (that will eventually serve that purpose). Currently it just replies status: 200 message: hello world. This is in the spirit of keeping PRs small when possible. 

To follow:
- Parse + validate the request body 
- Add items to the contributions-thanks queue
- Deal with if the whole batch fails
- Deal with if the partial batch fails