### PR TITLE
Backfill identity ids for users with multiple zuora accounts

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/IdentityBackfillSteps.scala
@@ -49,6 +49,7 @@ object IdentityBackfillSteps extends Logging {
   def updateSalesforceAccounts(updateSalesforceAccounts: (SFContactId, IdentityId) => ApiGatewayOp[Unit])(sfContactIds: Set[SFContactId], identityId: IdentityId): ApiGatewayOp[Unit] = {
 
     val failures = sfContactIds
+      .toSeq
       .map(updateSalesforceAccounts(_, identityId))
       .collect {
         case returnWithResponse: ReturnWithResponse => returnWithResponse
@@ -64,6 +65,7 @@ object IdentityBackfillSteps extends Logging {
   def updateZuoraAccounts(updateZuoraIdentityId: (AccountId, IdentityId) => ClientFailableOp[Unit])(accountIds: Set[AccountId], identityId: IdentityId): ApiGatewayOp[Unit] = {
 
     val failures = accountIds
+      .toSeq
       .map(updateZuoraIdentityId(_, identityId))
       .collect {
         case clientFailure: ClientFailure => clientFailure
@@ -72,6 +74,6 @@ object IdentityBackfillSteps extends Logging {
     if (failures.isEmpty)
       ContinueProcessing(())
     else
-      ReturnWithResponse(ApiGatewayResponse.badRequest("updateZuoraAccounts mutiple errors: " + failures.map(_.message).mkString(", ")))
+      ReturnWithResponse(ApiGatewayResponse.badRequest("updateZuoraAccounts multiple errors: " + failures.map(_.message).mkString(", ")))
   }
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
@@ -9,26 +9,34 @@ import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp._
 import com.gu.util.reader.Types._
-import com.gu.util.resthttp.LazyClientFailableOp
 import com.gu.util.resthttp.Types.ClientFailableOp
 
 object PreReqCheck {
 
-  case class PreReqResult(zuoraAccountId: Types.AccountId, sFContactId: SFContactId, existingIdentityId: Option[IdentityId])
+  case class PreReqResult(zuoraAccountIds: Set[Types.AccountId], sFContactIds: Set[SFContactId], existingIdentityId: Option[IdentityId])
 
   def apply(
     findExistingIdentityId: EmailAddress => ApiGatewayOp[Option[IdentityId]],
-    getSingleZuoraAccountForEmail: EmailAddress => ApiGatewayOp[ZuoraAccountIdentitySFContact],
+    findAndValidateZuoraAccounts: EmailAddress => ApiGatewayOp[List[ZuoraAccountIdentitySFContact]],
     noZuoraAccountsForIdentityId: IdentityId => ApiGatewayOp[Unit],
     zuoraSubType: AccountId => ApiGatewayOp[Unit],
-    syncableSFToIdentity: SFContactId => LazyClientFailableOp[ApiGatewayOp[Unit]]
+    syncableSFToIdentity: List[SFContactId] => ApiGatewayOp[Unit]
   )(emailAddress: EmailAddress): ApiGatewayOp[PreReqResult] = {
     for {
       maybeExistingIdentityId <- findExistingIdentityId(emailAddress)
-      zuoraAccountForEmail <- getSingleZuoraAccountForEmail(emailAddress)
+      zuoraAccounts <- findAndValidateZuoraAccounts(emailAddress)
       _ <- maybeExistingIdentityId.map(noZuoraAccountsForIdentityId).getOrElse(ContinueProcessing(()))
-      _ <- syncableSFToIdentity(zuoraAccountForEmail.sfContactId).value.toApiGatewayOp("load SF contact").flatMap(identity)
-    } yield PreReqResult(zuoraAccountForEmail.accountId, zuoraAccountForEmail.sfContactId, maybeExistingIdentityId)
+      _ <- syncableSFToIdentity(zuoraAccounts.map(_.sfContactId))
+    } yield PreReqResult(zuoraAccounts.map(_.accountId).toSet, zuoraAccounts.map(_.sfContactId).toSet, maybeExistingIdentityId)
+  }
+
+  def checkSfContactsSyncable(syncableSFToIdentity: SFContactId => ApiGatewayOp[Unit])(sFContactIds: List[SFContactId]): ApiGatewayOp[Unit] = {
+    sFContactIds
+      .map(syncableSFToIdentity)
+      .collectFirst {
+        case returnWithResponse: ReturnWithResponse => returnWithResponse
+      }
+      .getOrElse(ContinueProcessing(()))
   }
 
   def noZuoraAccountsForIdentityId(
@@ -36,25 +44,37 @@ object PreReqCheck {
   ): ApiGatewayOp[Unit] = {
     for {
       zuoraAccountsForIdentityId <- countZuoraAccountsForIdentityId.toApiGatewayOp("count zuora accounts for identity id")
-      _ <- (zuoraAccountsForIdentityId == 0)
-        .toApiGatewayContinueProcessing(ApiGatewayResponse.notFound("already used that identity id"))
+      _ <- (zuoraAccountsForIdentityId == 0).toApiGatewayContinueProcessing(ApiGatewayResponse.notFound("already used that identity id"))
     } yield ()
   }
 
-  def getSingleZuoraAccountForEmail(
-    getZuoraAccountsForEmail: ClientFailableOp[List[ZuoraAccountIdentitySFContact]]
-  ): ApiGatewayOp[ZuoraAccountIdentitySFContact] = {
+  def validateZuoraAccountsFound(getZuoraAccountsForEmail: ClientFailableOp[List[ZuoraAccountIdentitySFContact]])(emailAddress: EmailAddress): ApiGatewayOp[List[ZuoraAccountIdentitySFContact]] = {
+
+    def validateNotEmpty(zuoraAccountsForEmail: List[ZuoraAccountIdentitySFContact]): ApiGatewayOp[Unit] = zuoraAccountsForEmail match {
+      case Nil => ReturnWithResponse(ApiGatewayResponse.notFound(s"no zuora accounts found for $emailAddress"))
+      case _ => ContinueProcessing(())
+    }
+
+    def validateOneCrmId(zuoraAccountsForEmail: List[ZuoraAccountIdentitySFContact]) = {
+      if (zuoraAccountsForEmail.headOption.forall(head => zuoraAccountsForEmail.forall(_.crmId == head.crmId)))
+        ContinueProcessing(())
+      else
+        ReturnWithResponse(ApiGatewayResponse.notFound(s"multiple CRM ids found for $emailAddress $zuoraAccountsForEmail"))
+    }
+
+    def validateNoIdentityIdsForEmail(zuoraAccountsForEmail: List[ZuoraAccountIdentitySFContact]) = {
+      if (zuoraAccountsForEmail.forall(_.identityId.isEmpty))
+        ContinueProcessing(())
+      else
+        ReturnWithResponse(ApiGatewayResponse.badRequest(s"identity ids found in zuora $emailAddress $zuoraAccountsForEmail"))
+    }
+
     for {
-      zuoraAccountsForEmail <- getZuoraAccountsForEmail.toApiGatewayOp("get zuora accounts for email address")
-      zuoraAccountForEmail <- zuoraAccountsForEmail match {
-        case one :: Nil => ContinueProcessing(one);
-        case _ => ReturnWithResponse(ApiGatewayResponse.notFound("should have exactly one zuora account per email at this stage"))
-      }
-      _ <- zuoraAccountForEmail match {
-        case zuoraAccount if zuoraAccount.identityId.isEmpty => ContinueProcessing(());
-        case _ => ReturnWithResponse(ApiGatewayResponse.notFound("the account we found was already populated with an identity id"))
-      }
-    } yield zuoraAccountForEmail
+      zuoraAccountsForEmail <- getZuoraAccountsForEmail.toApiGatewayOp(s"get zuora accounts for $emailAddress")
+      _ <- validateNotEmpty(zuoraAccountsForEmail)
+      _ <- validateOneCrmId(zuoraAccountsForEmail)
+      _ <- validateNoIdentityIdsForEmail(zuoraAccountsForEmail)
+    } yield zuoraAccountsForEmail
   }
 
   def acceptableReaderType(readerTypes: ClientFailableOp[List[GetZuoraSubTypeForAccount.ReaderType]]): ApiGatewayOp[Unit] = {

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/PreReqCheck.scala
@@ -51,7 +51,7 @@ object PreReqCheck {
   def validateZuoraAccountsFound(getZuoraAccountsForEmail: ClientFailableOp[List[ZuoraAccountIdentitySFContact]])(emailAddress: EmailAddress): ApiGatewayOp[List[ZuoraAccountIdentitySFContact]] = {
 
     def validateNotEmpty(zuoraAccountsForEmail: List[ZuoraAccountIdentitySFContact]): ApiGatewayOp[Unit] = zuoraAccountsForEmail match {
-      case Nil => ReturnWithResponse(ApiGatewayResponse.notFound(s"no zuora accounts found for $emailAddress"))
+      case Nil => ReturnWithResponse(ApiGatewayResponse.badRequest(s"no zuora accounts found for $emailAddress"))
       case _ => ContinueProcessing(())
     }
 
@@ -59,7 +59,7 @@ object PreReqCheck {
       if (zuoraAccountsForEmail.headOption.forall(head => zuoraAccountsForEmail.forall(_.crmId == head.crmId)))
         ContinueProcessing(())
       else
-        ReturnWithResponse(ApiGatewayResponse.notFound(s"multiple CRM ids found for $emailAddress $zuoraAccountsForEmail"))
+        ReturnWithResponse(ApiGatewayResponse.badRequest(s"multiple CRM ids found for $emailAddress $zuoraAccountsForEmail"))
     }
 
     def validateNoIdentityIdsForEmail(zuoraAccountsForEmail: List[ZuoraAccountIdentitySFContact]) = {

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Types.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/Types.scala
@@ -7,11 +7,13 @@ object Types {
 
   case class EmailAddress(value: String)
   case class AccountId(value: String)
+  case class CrmId(value: String)
 
   case class ZuoraAccountIdentitySFContact(
     accountId: AccountId,
     identityId: Option[IdentityId],
-    sfContactId: SFContactId
+    sfContactId: SFContactId,
+    crmId: CrmId
   )
 
 }

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmail.scala
@@ -13,30 +13,40 @@ object GetZuoraAccountsForEmail {
 
   case class WireResponseContact(Id: String)
   implicit val readsC = Json.reads[WireResponseContact]
+
   case class WireResponseAccount(
     Id: String,
     IdentityId__c: Option[String],
-    sfContactId__c: String
+    sfContactId__c: String,
+    CrmId: String
   )
   implicit val readsA = Json.reads[WireResponseAccount]
 
   def apply(zuoraQuerier: ZuoraQuerier)(emailAddress: EmailAddress): ClientFailableOp[List[ZuoraAccountIdentitySFContact]] = {
     val accounts = for {
-      contactWithEmail <- ListT(for {
-        contactQuery <- zoql"SELECT Id FROM Contact where WorkEmail=${emailAddress.value}"
-        queryResult <- zuoraQuerier[WireResponseContact](contactQuery).map(_.records)
-      } yield queryResult)
-      accountsWithEmail <- ListT(for {
-        accountQuery <- zoql"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId=${contactWithEmail.Id}"
-        queryResult <- zuoraQuerier[WireResponseAccount](accountQuery).map(_.records)
-      } yield queryResult)
+      contactWithEmail <- findZuoraContacts(zuoraQuerier, emailAddress)
+      accountsWithEmail <- findZuoraAccounts(zuoraQuerier, contactWithEmail)
     } yield ZuoraAccountIdentitySFContact(
       AccountId(accountsWithEmail.Id),
       accountsWithEmail.IdentityId__c.map(IdentityId.apply),
-      SFContactId(accountsWithEmail.sfContactId__c)
+      SFContactId(accountsWithEmail.sfContactId__c),
+      CrmId(accountsWithEmail.CrmId)
     )
 
     accounts.run
   }
 
+  private def findZuoraAccounts(zuoraQuerier: ZuoraQuerier, contactWithEmail: WireResponseContact) = ListT {
+    for {
+      accountQuery <- zoql"SELECT Id, IdentityId__c, sfContactId__c, CrmId FROM Account where BillToId=${contactWithEmail.Id}"
+      queryResult <- zuoraQuerier[WireResponseAccount](accountQuery).map(_.records)
+    } yield queryResult
+  }
+
+  private def findZuoraContacts(zuoraQuerier: ZuoraQuerier, emailAddress: EmailAddress): ListT[ClientFailableOp, WireResponseContact] = ListT {
+    for {
+      contactQuery <- zoql"SELECT Id FROM Contact where WorkEmail=${emailAddress.value}"
+      queryResult <- zuoraQuerier[WireResponseContact](contactQuery).map(_.records)
+    } yield queryResult
+  }
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/EndToEndHandlerTest.scala
@@ -34,7 +34,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
       BasicRequest("GET", "/services/data/v43.0/sobjects/Contact/00110000011AABBAAB", ""),
       BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
-      BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
+      BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c, CrmId FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
       BasicRequest("GET", "/user?emailAddress=email@address", "")
     ))
@@ -59,7 +59,7 @@ class EndToEndHandlerTest extends FlatSpec with Matchers {
       BasicRequest("GET", "/services/data/v43.0/sobjects/Contact/00110000011AABBAAB", ""),
       BasicRequest("POST", "/services/oauth2/token", """client_id=clientsfclient&client_secret=clientsecretsfsecret&username=usernamesf&password=passSFpasswordtokentokenSFtoken&grant_type=password"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Account where IdentityId__c='1234'"}"""),
-      BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
+      BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c, CrmId FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}"""),
       BasicRequest("POST", "/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}"""),
       BasicRequest("GET", "/user?emailAddress=email@address", "")
     ))

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
@@ -1,0 +1,66 @@
+package com.gu.identityBackfill
+
+import com.gu.identityBackfill.IdentityBackfillSteps.DomainRequest
+import com.gu.identityBackfill.PreReqCheck.PreReqResult
+import com.gu.identityBackfill.Types.{AccountId, EmailAddress}
+import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
+import com.gu.salesforce.TypesForSFEffectsData.SFContactId
+import com.gu.util.apigateway.ResponseModels.ApiResponse
+import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
+import org.scalatest.{FlatSpec, Matchers}
+
+class IdentityBackfillStepsTest extends FlatSpec with Matchers {
+
+  it should "backfill identity ids successfully" in {
+    val ApiResponse(statusCode, _, _) = IdentityBackfillSteps.apply(
+      _ => ContinueProcessing(PreReqResult(Set(AccountId("accountId")), Set(SFContactId("sfContactId")), None)),
+      _ => ClientSuccess(IdentityId("123")),
+      (_, _) => ContinueProcessing(()),
+      (_, _) => ContinueProcessing(())
+    )(DomainRequest(EmailAddress("test@gu.com"), dryRun = false))
+
+    statusCode shouldBe "200"
+  }
+
+  it should "return with bad request if prereq check fails" in {
+    val ApiResponse(statusCode, _, _) = IdentityBackfillSteps.apply(
+      _ => ReturnWithResponse(ApiResponse("400", "")),
+      _ => fail(),
+      (_, _) => fail(),
+      (_, _) => fail()
+    )(DomainRequest(EmailAddress("test@gu.com"), dryRun = false))
+
+    statusCode shouldBe "400"
+  }
+
+  "updateSalesforceAccounts" should "update salesforce accounts successfully" in {
+    val result = IdentityBackfillSteps.updateSalesforceAccounts(
+      (_, _) => ContinueProcessing(())
+    )(
+        Set(SFContactId("sfContactId1"), SFContactId("sfContactId2")), IdentityId("123")
+      )
+
+    result shouldBe ContinueProcessing(())
+  }
+
+  "updateSalesforceAccounts" should "propagate errors" in {
+    val ReturnWithResponse(result) = IdentityBackfillSteps.updateSalesforceAccounts(
+      (_, _) => ReturnWithResponse(ApiResponse("400", "error"))
+    )(
+        Set(SFContactId("sfContactId1"), SFContactId("sfContactId2")), IdentityId("123")
+      )
+
+    result.body should include("updateSalesforceAccounts multiple errors: error, error")
+  }
+
+  "updateZuoraAccounts" should "update salesforce accounts successfully" in {
+    val result = IdentityBackfillSteps.updateZuoraAccounts((_, _) => ClientSuccess(()))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
+    result shouldBe ContinueProcessing(())
+  }
+
+  "updateZuoraAccounts" should "propagate errors" in {
+    val ReturnWithResponse(result) = IdentityBackfillSteps.updateZuoraAccounts((_, _) => GenericError("error"))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
+    result.body should include("updateZuoraAccounts multiple errors: error, error")
+  }
+}

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
@@ -34,33 +34,17 @@ class IdentityBackfillStepsTest extends FlatSpec with Matchers {
     statusCode shouldBe "400"
   }
 
-  "updateSalesforceAccounts" should "update salesforce accounts successfully" in {
-    val result = IdentityBackfillSteps.updateSalesforceAccounts(
-      (_, _) => ContinueProcessing(())
-    )(
-        Set(SFContactId("sfContactId1"), SFContactId("sfContactId2")), IdentityId("123")
-      )
+  "updateAccountsWithIdentityId" should "update salesforce accounts successfully" in {
+    val result = IdentityBackfillSteps
+      .updateAccountsWithIdentityId[AccountId]((_, _) => ClientSuccess(()))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
 
-    result shouldBe ContinueProcessing(())
-  }
-
-  "updateSalesforceAccounts" should "propagate errors" in {
-    val ReturnWithResponse(result) = IdentityBackfillSteps.updateSalesforceAccounts(
-      (_, _) => ReturnWithResponse(ApiResponse("400", "error"))
-    )(
-        Set(SFContactId("sfContactId1"), SFContactId("sfContactId2")), IdentityId("123")
-      )
-
-    result.body should include("updateSalesforceAccounts multiple errors: error, error")
-  }
-
-  "updateZuoraAccounts" should "update salesforce accounts successfully" in {
-    val result = IdentityBackfillSteps.updateZuoraAccounts((_, _) => ClientSuccess(()))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
     result shouldBe ContinueProcessing(())
   }
 
   "updateZuoraAccounts" should "propagate errors" in {
-    val ReturnWithResponse(result) = IdentityBackfillSteps.updateZuoraAccounts((_, _) => GenericError("error"))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
-    result.body should include("updateZuoraAccounts multiple errors: error, error")
+    val ReturnWithResponse(result) = IdentityBackfillSteps
+      .updateAccountsWithIdentityId[AccountId]((_, _) => GenericError("error"))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
+
+    result.body should include("updateAccountsWithIdentityId multiple errors")
   }
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/IdentityBackfillStepsTest.scala
@@ -35,9 +35,14 @@ class IdentityBackfillStepsTest extends FlatSpec with Matchers {
   }
 
   "updateAccountsWithIdentityId" should "update salesforce accounts successfully" in {
-    val result = IdentityBackfillSteps
-      .updateAccountsWithIdentityId[AccountId]((_, _) => ClientSuccess(()))(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
+    var updated: List[(AccountId, IdentityId)] = Nil
 
+    val result = IdentityBackfillSteps.updateAccountsWithIdentityId[AccountId] { (accountId, identityId) =>
+      updated = accountId -> identityId :: updated
+      ClientSuccess(())
+    }(Set(AccountId("accountId1"), AccountId("accountId2")), IdentityId("123"))
+
+    updated shouldBe AccountId("accountId2") -> IdentityId("123") :: AccountId("accountId1") -> IdentityId("123") :: Nil
     result shouldBe ContinueProcessing(())
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/PreReqCheckTest.scala
@@ -72,8 +72,10 @@ class PreReqCheckTest extends FlatSpec with Matchers {
   }
 
   "checkSfContactsSyncable" should "ReturnWithResponse if contacts not syncable" in {
-    PreReqCheck.checkSfContactsSyncable(_ =>
-      ReturnWithResponse(ApiGatewayResponse.badRequest("bad request")))(List(SFContactId("sfContactId"))) shouldBe ReturnWithResponse(ApiGatewayResponse.badRequest("bad request"))
+    val ReturnWithResponse(result) = PreReqCheck
+      .checkSfContactsSyncable(_ => ReturnWithResponse(ApiGatewayResponse.badRequest("bad request")))(List(SFContactId("sfContactId")))
+
+    result.body should include("Bad request: multiple contacts are not syncable")
   }
 
   "checkSfContactsSyncable" should "continue processing if syncable" in {

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/StepsTest.scala
@@ -15,26 +15,26 @@ class StepsTest extends FlatSpec with Matchers {
 
   class StepsWithMocks {
 
-    var zuoraUpdate: Option[(AccountId, IdentityId)] = None // !!
-    var salesforceUpdate: Option[(SFContactId, IdentityId)] = None // !!
+    var zuoraUpdate: Option[(Set[AccountId], IdentityId)] = None // !!
+    var salesforceUpdate: Option[(Set[SFContactId], IdentityId)] = None // !!
     var emailToCheck: Option[EmailAddress] = None // !!
 
     def getSteps(succeed: Boolean = true): DomainRequest => ApiResponse = {
       val preReqCheck: EmailAddress => ApiGatewayOp[PreReqCheck.PreReqResult] = { email =>
         emailToCheck = Some(email)
         if (succeed)
-          ContinueProcessing(PreReqCheck.PreReqResult(AccountId("acc"), SFContactId("sf"), Some(IdentityId("existing"))))
+          ContinueProcessing(PreReqCheck.PreReqResult(Set(AccountId("acc")), Set(SFContactId("sf")), Some(IdentityId("existing"))))
         else
-          ContinueProcessing(PreReqCheck.PreReqResult(AccountId("acc"), SFContactId("sf"), None))
+          ContinueProcessing(PreReqCheck.PreReqResult(Set(AccountId("acc")), Set(SFContactId("sf")), None))
       }
       IdentityBackfillSteps(
         preReqCheck,
         createGuestAccount = email => ClientSuccess(IdentityId("created")),
-        updateZuoraIdentityId = (accountId, identityId) => {
-          zuoraUpdate = Some((accountId, identityId))
-          ClientSuccess(())
+        updateZuoraAccounts = (accountIds, idenitytId) => {
+          zuoraUpdate = Some((accountIds, idenitytId))
+          ContinueProcessing(())
         },
-        updateSalesforceIdentityId = (sFContactId, identityId) => {
+        updateSalesforceAccounts = (sFContactId, identityId) => {
           salesforceUpdate = Some((sFContactId, identityId))
           ContinueProcessing(())
         }
@@ -53,8 +53,8 @@ class StepsTest extends FlatSpec with Matchers {
 
     val expectedResult = ApiGatewayResponse.successfulExecution
     result should be(expectedResult)
-    zuoraUpdate should be(Some((AccountId("acc"), IdentityId("existing"))))
-    salesforceUpdate should be(Some((SFContactId("sf"), IdentityId("existing"))))
+    zuoraUpdate should be(Some((Set(AccountId("acc")), IdentityId("existing"))))
+    salesforceUpdate should be(Some((Set(SFContactId("sf")), IdentityId("existing"))))
     emailToCheck should be(Some(EmailAddress("email@address")))
   }
 
@@ -83,8 +83,8 @@ class StepsTest extends FlatSpec with Matchers {
 
     val expectedResult = ApiGatewayResponse.successfulExecution
     result should be(expectedResult)
-    zuoraUpdate should be(Some((AccountId("acc"), IdentityId("created"))))
-    salesforceUpdate should be(Some((SFContactId("sf"), IdentityId("created"))))
+    zuoraUpdate should be(Some((Set(AccountId("acc")), IdentityId("created"))))
+    salesforceUpdate should be(Some((Set(SFContactId("sf")), IdentityId("created"))))
     emailToCheck should be(Some(EmailAddress("email@address")))
   }
 

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/zuora/GetZuoraAccountsForEmailTest.scala
@@ -19,7 +19,8 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
       ZuoraAccountIdentitySFContact(
         AccountId("2c92a0fb4a38064e014a3f48f1663ad8"),
         Some(IdentityId("10101010")),
-        SFContactId("00110000011AABBAAB")
+        SFContactId("00110000011AABBAAB"),
+        CrmId("crmId")
       )
     ))
     contacts should be(expected)
@@ -30,7 +31,7 @@ class GetZuoraAccountsForEmailTest extends FlatSpec with Matchers {
     val requestMaker = ZuoraRestRequestMaker(effects.response, ZuoraRestConfig("https://zuora", "user", "pass"))
     val contacts = GetZuoraAccountsForEmail(ZuoraQuery(requestMaker))(EmailAddress("email@address"))
     val expected = ClientSuccess(List(
-      ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"))
+      ZuoraAccountIdentitySFContact(AccountId("2c92a0fb4a38064e014a3f48f1663ad8"), None, SFContactId("00110000011AABBAAB"), CrmId("crmId"))
     ))
     contacts should be(expected)
   }
@@ -42,7 +43,7 @@ object GetZuoraAccountsForEmailData {
   def postResponses(withIdentity: Boolean): Map[POSTRequest, HTTPResponse] = Map(
     POSTRequest("/action/query", """{"queryString":"SELECT Id FROM Contact where WorkEmail='email@address'"}""")
       -> HTTPResponse(200, contactQueryResponse),
-    POSTRequest("/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}""")
+    POSTRequest("/action/query", """{"queryString":"SELECT Id, IdentityId__c, sfContactId__c, CrmId FROM Account where BillToId='2c92a0fb4a38064e014a3f48f1713ada'"}""")
       -> HTTPResponse(200, accountQueryResponse(withIdentity))
   )
 
@@ -56,6 +57,7 @@ object GetZuoraAccountsForEmailData {
       else ""
     }
        |            "sfContactId__c": "00110000011AABBAAB",
+       |            "CrmId": "crmId",
        |            "Id": "2c92a0fb4a38064e014a3f48f1663ad8"
        |        }
        |    ],

--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -66,7 +66,7 @@ object ApiGatewayResponse extends Logging {
 
   def badRequest(reason: String) = messageResponse(
     "400",
-    s"Failure to parse JSON successfully: $reason"
+    s"Bad request: $reason"
   )
 
   val unauthorized = messageResponse(


### PR DESCRIPTION
Backfill identity ids for users with multiple zuora accounts.

The lambda would previously fail validation if an email did not have 1 associated zuora account.
Now, if there are multiple zuora accounts we check if the CRM IDs are identical. If they are, we backfill all the associated SF contacts and zuora accounts.

Why are we doing this?

Improve the number of SalesForce and Zuora accounts with Identity IDs