### PR TITLE
Return error message on 500s

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/TypeConvert.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/TypeConvert.scala
@@ -1,6 +1,6 @@
 package com.gu.identityBackfill
 
-import com.gu.util.apigateway.ApiGatewayResponse.badRequest
+import com.gu.util.apigateway.ApiGatewayResponse.messageResponse
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.reader.Types._
 
@@ -9,7 +9,10 @@ object TypeConvert {
   implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
     def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp { error =>
       logger.error(s"Failed to $action: $error")
-      badRequest(s"Failed to execute lambda - unable to $action")
+      messageResponse(
+        s"Failed to execute lambda - unable to $action, $error",
+        action
+      )
     }
   }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/TypeConvert.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/TypeConvert.scala
@@ -1,12 +1,16 @@
 package com.gu.identityBackfill
 
+import com.gu.util.apigateway.ApiGatewayResponse.badRequest
 import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.reader.Types._
 
 object TypeConvert {
 
   implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
-    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
+    def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp { error =>
+      logger.error(s"Failed to $action: $error")
+      badRequest(s"Failed to execute lambda - unable to $action")
+    }
   }
 
 }


### PR DESCRIPTION
When running scripts it's hard to tell what's happened on an internal server error. 

I can't see any secrets returned on 500s.  Is there a reason for hiding the message? Endusers don't hit any of this project's endpoints directly do they?

Edit: I've changed this to return 400s with error reasons on api client errors in Identity backfill.