### PR TITLE
fix for failing effect test

### DIFF
--- a/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
+++ b/handlers/digital-subscription-expiry/src/test/scala/com/gu/digitalSubscriptionExpiry/zuora/GetSubscriptionEffectsTest.scala
@@ -33,10 +33,10 @@ class GetSubscriptionEffectsTest extends FlatSpec with Matchers {
     val testSubscriptionId = SubscriptionId("A-S00044160")
 
     val customerAcceptanceDate = LocalDate.of(2017, 12, 15)
-    val startDate = LocalDate.of(2017, 11, 29)
+    val startDate = LocalDate.of(2018, 11, 29)
     val expected = SubscriptionResult(
       testSubscriptionId,
-      SubscriptionName("2c92c0f860017cd501600893134617b3"),
+      SubscriptionName("2c92c08567580c5901675ec91ccb0f17"),
       AccountId("2c92c0f860017cd501600893130317a7"),
       Some("2018-04-18T14:59:49.368"),
       customerAcceptanceDate,
@@ -56,7 +56,7 @@ class GetSubscriptionEffectsTest extends FlatSpec with Matchers {
           List(RatePlanCharge(
             name = "Digital Pack Monthly",
             effectiveStartDate = LocalDate.of(2017, 12, 15),
-            effectiveEndDate = LocalDate.of(2018, 11, 29)
+            effectiveEndDate = LocalDate.of(2019, 11, 29)
           ))
         )
       )


### PR DESCRIPTION
our test sub in dev was auto-renewed so the expected data in the test is out of date