### PR TITLE
Handle payment errors

### DIFF
--- a/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
+++ b/lib/handler/src/main/scala/com/gu/util/apigateway/ApiGatewayResponse.scala
@@ -74,6 +74,11 @@ object ApiGatewayResponse extends Logging {
     "Credentials are missing or invalid"
   )
 
+  val paymentRequired = messageResponse(
+    "402",
+    "Payment was declined"
+  )
+
   def forbidden(message: String) = messageResponse(
     "403",
     message

--- a/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
+++ b/lib/restHttp/src/main/scala/com/gu/util/resthttp/Types.scala
@@ -16,6 +16,8 @@ object Types {
 
   case class GenericError(message: String) extends ClientFailure
 
+  case class PaymentError(message: String) extends ClientFailure
+
   case class ClientSuccess[A](value: A) extends ClientFailableOp[A] {
     val isFailure = false
     override def toDisjunction: ClientFailure \/ A = \/-(value)

--- a/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
+++ b/lib/zuora/src/main/scala/com/gu/util/zuora/ZuoraRestRequestMaker.scala
@@ -1,7 +1,7 @@
 package com.gu.util.zuora
 
 import com.gu.util.resthttp.{Logging, RestRequestMaker}
-import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError, NotFound}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError, NotFound, PaymentError}
 import com.gu.util.zuora.ZuoraModels._
 import com.gu.util.zuora.ZuoraReaders._
 import okhttp3.{Request, Response}
@@ -30,9 +30,10 @@ object ZuoraRestRequestMaker extends Logging {
         logger.error(s"Zuora rejected our call $bodyAsJson")
         if (reasons.exists(_.code.toString.endsWith("40")))
           NotFound("Received a 'not found' response from Zuora")
+        else if (reasons.exists(_.code == 53000060))
+          PaymentError(s"Received a payment error from Zuora: $reasons")
         else
           GenericError(s"Received a failure result from Zuora: $reasons")
-
       }
       case error: JsError => {
         logger.error(s"Failed to read common fields from zuora response: $error. Response body was: \n $bodyAsJson")


### PR DESCRIPTION
We are currently serving a 500 if there is a payment failure when attempting to add a new product to an existing subscriber's account. This PR enables us to serve a more appropriate status code, which allows clients to handle these errors more gracefully. It should also stop us from getting so many false alarms.

Note that I can't find any documentation about the 53000060 error code from Zuora; but log inspection shows that this code is consistently returned on payment error.