### PR TITLE
extend Zuora Catalog timeout

### DIFF
--- a/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/EmailBatchTest.scala
@@ -58,7 +58,7 @@ class EmailBatchTest extends FlatSpec {
   }
 
   "EmailBatch.fromWire" should "throw a jsresult exception when a required field is missing" in {
-     val sampleBatch =
+    val sampleBatch =
       """
         |{
         |     "batch_items":

--- a/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFileTest.scala
+++ b/handlers/sf-datalake-export/src/test/scala/com/com/gu/sf_datalake_export/salesforce_bulk_api/S3UploadFileTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.{Success, Try}
 
-class S3UploadFileTest extends FlatSpec with Matchers{
+class S3UploadFileTest extends FlatSpec with Matchers {
   val testPath = S3Path(BucketName("someBucket"), None)
   val testFile = File(FileName("someName"), FileContent("these are the file contents"))
   val successS3Result = Success(new PutObjectResult())

--- a/lib/effects/src/main/scala/com/gu/effects/Http.scala
+++ b/lib/effects/src/main/scala/com/gu/effects/Http.scala
@@ -9,9 +9,11 @@ import okio.Buffer
 
 object Http extends Logging {
 
-  val response: Request => Response = {
+  val response: Request => Response = responseWithTimeout(15)
+
+  def responseWithTimeout(timeout: Int): Request => Response = {
     val restClient = new OkHttpClient().newBuilder()
-      .readTimeout(15, TimeUnit.SECONDS)
+      .readTimeout(timeout, TimeUnit.SECONDS)
       .build()
 
     def bodySummary(requestBody: RequestBody) = {


### PR DESCRIPTION
The default timeout is 15 seconds for all http calls.

However this afternoon things are timing out... 
![image](https://user-images.githubusercontent.com/7304387/50917858-898cb400-1436-11e9-9598-fb65f631fdfe.png)

which is causing a
```
java.net.SocketTimeoutException: timeout
```
which eventually caused an alarm
![image](https://user-images.githubusercontent.com/7304387/50917900-ae812700-1436-11e9-9275-1666efe0d3d9.png)


This PR extends the timeout to 2 minutes for that call.

The failing effects tests are due to changes in the SF contact that they use, there is now a health card in the SX trello to resolve this - thanks @twrichards !

I also noticed a few formatting issues which also got resolved by the scalaformat so they are in too.

@jacobwinch I will ship this tomorrow rather than rushing it out today.