### PR TITLE
Remove 4XX alarm

### DIFF
--- a/handlers/new-product-api/cfn.yaml
+++ b/handlers/new-product-api/cfn.yaml
@@ -326,26 +326,3 @@ Resources:
         Statistic: Sum
         Threshold: 5
         TreatMissingData: notBreaching
-    4xxApiAlarm:
-        Type: AWS::CloudWatch::Alarm
-        Condition: CreateProdMonitoring
-        Properties:
-          AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:subscriptions_dev
-          AlarmName:
-            !Sub
-             - 4XX rate from ${ApiName}
-             - { ApiName: !FindInMap [StageMap, !Ref Stage, ApiName] }
-          ComparisonOperator: GreaterThanThreshold
-          Dimensions:
-            - Name: ApiName
-              Value: !FindInMap [StageMap, !Ref Stage, ApiName]
-            - Name: Stage
-              Value: !Sub ${Stage}
-          EvaluationPeriods: 1
-          MetricName: 4XXError
-          Namespace: AWS/ApiGateway
-          Period: 3600
-          Statistic: Sum
-          Threshold: 5
-          TreatMissingData: notBreaching


### PR DESCRIPTION
4XX includes payment errors (402s), which should not trigger alerts.