### PR TITLE
Single cancellation reason in Salesforce subscriptions export

### DIFF
--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -105,7 +105,6 @@ object SfQueries {
       |Buyer__c,
       |Promo_Campaign__c,
       |Cancellation_Effective_Date__c,
-      |Cancellation_Reason__c,
       |Cancellation_Request_Date__c,
       |Cancellation_Source__c,
       |Cancellation_Survey_Voluntary__c,


### PR DESCRIPTION
Related PR: https://github.com/guardian/ophan-data-lake/pull/3294

`Reason_for_Cancellation__c` covers all cancellations and should map to `cancellation_reason` in `clean.salesforce_subscription`.