### PR TITLE
Add direct debit mandate failure emails

### DIFF
--- a/handlers/batch-email-sender/README.md
+++ b/handlers/batch-email-sender/README.md
@@ -4,9 +4,20 @@ There is work done in Salesforce that, on a schedule, generates information abou
 This lambda receives a call from Salesforce with a batch of emails to be sent and adds items to the 
 contributions-thanks queue so that the email will be sent 
 
+![sequence_diagram](https://user-images.githubusercontent.com/13835317/51552742-2a349800-1e69-11e9-8df4-55eec10b649d.png)
+
+Braze `Template API Identifiers` are stored in `membership-workflow.private.conf` under `braze.campaigns` 
+
+## How to add new email?
+
+1. Update SF trigger to post new `object_name` and `email_stage` 
+1. Update `EmailToSend.brazeCampaignId` match statement to handle the new case
+1. Add new email to `membership-workflow` [EmailName.EmailNamesByName](https://github.com/guardian/membership-workflow/blob/2e354b81888f6d222d9de0b4c2eda8e0f2b14729/app/model/EmailName.scala#L99)
+1. Add new Braze Template API Identifiers to `membership-workflow.private.conf` under `braze.campaigns`
+1. If you wish to add Identity magic link, then add email to [IdentityProxyBrazeClient.defaultProxiedEmailNames](https://github.com/guardian/membership-workflow/blob/2e354b81888f6d222d9de0b4c2eda8e0f2b14729/app/services/IdentityProxyBrazeClient.scala#L51)
 
 
-### Sample request 
+## Sample request 
 
 `POST {url}/{CODE or PROD}/email-batch`
 

--- a/handlers/batch-email-sender/README.md
+++ b/handlers/batch-email-sender/README.md
@@ -1,12 +1,30 @@
 # batch-email-sender
-There is work done in Salesforce that, on a schedule, generates information about emails that need to be sent. 
 
-This lambda receives a call from Salesforce with a batch of emails to be sent and adds items to the 
-contributions-thanks queue so that the email will be sent 
+This lambda is responsible for handling the following _service_ emails (non-marketing):
+
+| Service email                  | Salesforce `object_name` | Salesforce `email_stage` | Braze Campaign Name    |
+| ------------------------------ | ------------------------ | ------------------------ | ---------------------- |
+| Credit Card Expiry             | `Card_Expiry__c`        |                           | CC Expiry              |
+| Direct Debit Mandate failure 1 | `DD_Mandate_Failure__c` | `MF1`                     | Direct Debit - Email 1 |
+| Direct Debit Mandate failure 2 | `DD_Mandate_Failure__c` | `MF2`                     | Direct Debit - Email 2 |
+| Direct Debit Mandate failure 3 | `DD_Mandate_Failure__c` | `MF3`                     | Direct Debit - Email 3 |
+| Direct Debit Mandate failure 4 | `DD_Mandate_Failure__c` | `MF4`                     | Direct Debit - Email 4 |
+| Direct Debit Mandate failure 5 | `DD_Mandate_Failure__c` | `MF5`                     | Direct Debit - Email 5 |
+| Direct Debit Mandate failure 6 | `DD_Mandate_Failure__c` | `MF6`                     | Direct Debit - Email 6 |
+
+## How it works?
+
+1. Salesforce POST JSON batch emails
+1. `batch-email-sender` handles Salesforce POST
+1. `batch-email-sender` puts messages on the `contributions-thanks` SQS queue
+1. [`membership-workflow`](https://github.com/guardian/membership-workflow) processes the queue
+1. `membership-workflow` either [hits Braze](https://www.braze.com/docs/developer_guide/rest_api/messaging/#sending-messages-via-api-triggered-delivery) directly or delegates to Identity `payment-failure` to embed magic link
+1. [`payment-failure`](https://github.com/guardian/identity-processes/tree/master/payment-failure) embeds magic link and hists Braze
+1. [Braze](https://dashboard-01.braze.eu) schedules a campaign message send via [API Triggered Delivery](https://www.braze.com/docs/developer_guide/rest_api/messaging/#sending-messages-via-api-triggered-delivery)
 
 ![sequence_diagram](https://user-images.githubusercontent.com/13835317/51552742-2a349800-1e69-11e9-8df4-55eec10b649d.png)
 
-Braze `Template API Identifiers` are stored in `membership-workflow.private.conf` under `braze.campaigns` 
+Braze [`Campaign API Identifiers`](https://www.braze.com/docs/developer_guide/rest_api/messaging/#campaign-identifier) are stored in `membership-workflow.private.conf` under `braze.campaigns` 
 
 ## How to add new email?
 
@@ -14,10 +32,16 @@ Braze `Template API Identifiers` are stored in `membership-workflow.private.conf
 1. Update `EmailToSend.brazeCampaignId` match statement to handle the new case
 1. Add new email to `membership-workflow` [EmailName.EmailNamesByName](https://github.com/guardian/membership-workflow/blob/2e354b81888f6d222d9de0b4c2eda8e0f2b14729/app/model/EmailName.scala#L99)
 1. Add new Braze Template API Identifiers to `membership-workflow.private.conf` under `braze.campaigns`
-1. If you wish to add Identity magic link, then add email to [IdentityProxyBrazeClient.defaultProxiedEmailNames](https://github.com/guardian/membership-workflow/blob/2e354b81888f6d222d9de0b4c2eda8e0f2b14729/app/services/IdentityProxyBrazeClient.scala#L51)
+
+## How to embed magic link in an email?
+
+If you wish to add Identity magic link, then add Campaign ID to [IdentityProxyBrazeClient.defaultProxiedEmailNames](https://github.com/guardian/membership-workflow/blob/2e354b81888f6d222d9de0b4c2eda8e0f2b14729/app/services/IdentityProxyBrazeClient.scala#L51).
+In this case `membership-workflow` will delegate Braze request to Identity [`payment-failure`](https://github.com/guardian/identity-processes/tree/master/payment-failure) lambda.
 
 
-## Sample request 
+
+
+## Example request 
 
 `POST {url}/{CODE or PROD}/email-batch`
 
@@ -27,11 +51,12 @@ Content-Type: application-json
 x-api-key: {the api key}
 ```
 body:
-```
+```json
 {
     "batch_items": [  
        {  
-          "payload":{  
+          "payload":{
+             "record_id": "12345",  
              "to_address":"dlasdj@dasd.com",
              "subscriber_id":"A-S00044748",
              "sf_contact_id":"0036E00000KtDaHQAV",
@@ -45,7 +70,8 @@ body:
           "object_name":"Card_Expiry__c"
        },
        {  
-          "payload":{  
+          "payload":{
+             "record_id": "2222222",  
              "to_address":"dlasdj@dasd.com",
              "subscriber_id":"A-S00044748",
              "sf_contact_id":"0036E00000KtDaHQAV",
@@ -78,4 +104,103 @@ If there are failures in adding the the queue, the api will respond with a list 
     "message": "There were items that were not added to the queue.",
     "failed_item_ids": ["0036E00000KtDaABCD", "0036E00000KtDaEFGH", "0036E00000KtDaIJKL"]
 }
+```
+
+## How to test?
+
+### Salesforce message 
+
+```http request
+POST /CODE/email-batch HTTP/1.1
+Host: yoidgarsd5.execute-api.eu-west-1.amazonaws.com
+Content-Type: application/json
+x-api-key: ******************** 
+cache-control: no-cache
+{
+    "batch_items": [
+        {
+            "payload": {
+            	"record_id": "12345",
+                "to_address": "foo@example.com",
+                "subscriber_id": "A-S00048871",
+                "sf_contact_id": "0036E00000KtDaHQAV",
+                "product": "Guardian Weekly - Domestic",
+                "next_charge_date": "2018-09-03",
+                "last_name": "bla",
+                "identity_id": "100002283",
+                "first_name": "something",
+                "email_stage": "MF6"
+            },
+            "object_name": "DD_Mandate_Failure__c"
+        }
+    ]
+}
+```
+### SQS message to `contributions-thanks` queue
+
+| Stage         | SQS queue name           |
+| ------------- | ------------------------ |
+| CODE          | contributions-thanks-dev |
+| PROD          | contributions-thanks     |
+
+```json
+{
+  "To" : {
+    "Address" : "example@gu.com",
+    "SubscriberKey" : "example@gu.com",
+    "ContactAttributes" : {
+      "SubscriberAttributes" : {
+        "first_name" : "foo",
+        "next_charge_date" : "3 September 2018",
+        "subscriber_id" : "A-S00044748",
+        "last_name" : "bar",
+        "product" : "Membership"
+      }
+    }
+  },
+  "DataExtensionName" : "expired-card",
+  "SfContactId" : "0036E00000KtDaHQAV",
+  "IdentityUserId" : "30002177"
+}
+```
+
+### Braze message
+
+```http request
+POST /campaigns/trigger/send HTTP/1.1
+Host: rest.fra-01.braze.eu
+Content-Type: application/json
+cache-control: no-cache
+{
+    "api_key": "****************",
+    "campaign_id": "5bc1e0c9-c119-4540-9604-ffea46967257",
+    "recipients": [
+        {
+            "external_user_id": "100001617",
+            "trigger_properties": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "product": "Guardian Weekly - Domestic",
+                "emailToken": "abcde123.asdfklsdf"
+            }
+        }
+    ]
+}
+```
+
+
+### Logs
+`batch-email-sender`:
+```bash
+awslogs get --profile membership /aws/lambda/batch-email-sender-CODE ALL --watch
+```
+
+`membership-workflow`:
+```bash
+awslogs get --profile membership membership-workflow-CODE ALL --watch
+```
+
+`payment-failure`:
+```bash
+awslogs get --profile identity /aws/lambda/PaymentFailureLambda-CODE ALL --watch
 ```

--- a/handlers/batch-email-sender/README.md
+++ b/handlers/batch-email-sender/README.md
@@ -1,6 +1,6 @@
 # batch-email-sender
 
-This lambda is responsible for handling the following _service_ emails (non-marketing):
+This lambda is responsible for handling the following _service_ emails (non-marketing) via [Braze API Triggered Campaigns](https://www.braze.com/docs/user_guide/engagement_tools/campaigns/scheduling_and_organizing/scheduling_your_campaign/#api-triggered-campaigns-server-triggered-campaigns):
 
 | Service email                  | Salesforce `object_name` | Salesforce `email_stage` | Braze Campaign Name    |
 | ------------------------------ | ------------------------ | ------------------------ | ---------------------- |

--- a/handlers/batch-email-sender/README.md
+++ b/handlers/batch-email-sender/README.md
@@ -19,6 +19,7 @@ This lambda is responsible for handling the following _service_ emails (non-mark
 1. `batch-email-sender` puts messages on the `contributions-thanks` SQS queue
 1. [`membership-workflow`](https://github.com/guardian/membership-workflow) processes the queue
 1. `membership-workflow` either [hits Braze](https://www.braze.com/docs/developer_guide/rest_api/messaging/#sending-messages-via-api-triggered-delivery) directly or delegates to Identity `payment-failure` to embed magic link
+1. `membership-workflow` publishes SNS message to `identity-payment-failure-PROD` topic
 1. [`payment-failure`](https://github.com/guardian/identity-processes/tree/master/payment-failure) embeds magic link and hists Braze
 1. [Braze](https://dashboard-01.braze.eu) schedules a campaign message send via [API Triggered Delivery](https://www.braze.com/docs/developer_guide/rest_api/messaging/#sending-messages-via-api-triggered-delivery)
 

--- a/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/SqsSendBatch.scala
+++ b/handlers/batch-email-sender/src/main/scala/com/gu/batchemailsender/api/batchemail/SqsSendBatch.scala
@@ -19,8 +19,7 @@ object SqsSendBatch extends Logging {
     }
 
     emailBatchItems flatMap { emailBatchItem: EmailBatchItem =>
-
-      val emailToSend = EmailToSend.fromEmailBatchItem(emailBatchItem, "expired-card")
+      val emailToSend = EmailToSend.fromEmailBatchItem(emailBatchItem)
       val payloadString = Json.prettyPrint(Json.toJson(emailToSend))
 
       sendAndRetainItemIdOnFailure(Payload(payloadString), emailBatchItem.payload.record_id)

--- a/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
+++ b/handlers/batch-email-sender/src/test/scala/com/gu/batchemailsender/api/batchemail/model/EmailToSendTest.scala
@@ -3,45 +3,66 @@ package com.gu.batchemailsender.api.batchemail.model
 import org.scalatest.FlatSpec
 
 class EmailToSendTest extends FlatSpec {
+  val email = "dlasdj@dasd.com"
 
-  "EmailToSendTest.fromEmailBatchItem" should "create an email to send" in {
-    val email = "dlasdj@dasd.com"
-    val emailBatchItem = EmailBatchItem(
-      payload = EmailBatchItemPayload(
-        record_id = EmailBatchItemId("0038E00000KtDaHQUX"),
-        to_address = email,
-        subscriber_id = SubscriberId("A-S00044748"),
-        sf_contact_id = SfContactId("0036E00000KtDaHQAV"),
-        product = "Supporter",
-        next_charge_date = "3 September 2018",
-        last_name = "bla",
-        identity_id = Some(IdentityUserId("30002177")),
-        first_name = "something",
-        email_stage = "MBv1 - 1"
-      ),
-      object_name = "Card_Expiry__c"
+  val emailBatchItemPayloadStub =
+    EmailBatchItemPayload(
+      record_id = EmailBatchItemId("0038E00000KtDaHQUX"),
+      to_address = email,
+      subscriber_id = SubscriberId("A-S00044748"),
+      sf_contact_id = SfContactId("0036E00000KtDaHQAV"),
+      product = "Supporter",
+      next_charge_date = "3 September 2018",
+      last_name = "bla",
+      identity_id = Some(IdentityUserId("30002177")),
+      first_name = "something",
+      email_stage = "MBv1 - 1"
     )
 
-    val expected = EmailToSend(
-      To = EmailPayloadTo(
-        Address = email,
-        SubscriberKey = email,
-        ContactAttributes = EmailPayloadContactAttributes(
-          SubscriberAttributes = Map(
-            "first_name" -> "something",
-            "subscriber_id" -> "A-S00044748",
-            "last_name" -> "bla",
-            "next_charge_date" -> "3 September 2018",
-            "product" -> "Supporter"
-          )
+  val emailBatchItemStub = EmailBatchItem(
+    payload = emailBatchItemPayloadStub,
+    object_name = ""
+  )
+
+  val expectedStub = EmailToSend(
+    To = EmailPayloadTo(
+      Address = email,
+      SubscriberKey = email,
+      ContactAttributes = EmailPayloadContactAttributes(
+        SubscriberAttributes = Map(
+          "first_name" -> "something",
+          "subscriber_id" -> "A-S00044748",
+          "last_name" -> "bla",
+          "next_charge_date" -> "3 September 2018",
+          "product" -> "Supporter"
         )
-      ),
-      DataExtensionName = "expired-card",
-      SfContactId = Some("0036E00000KtDaHQAV"),
-      IdentityUserId = Some("30002177")
-    )
+      )
+    ),
+    DataExtensionName = "",
+    SfContactId = Some("0036E00000KtDaHQAV"),
+    IdentityUserId = Some("30002177")
+  )
 
-    assert(EmailToSend.fromEmailBatchItem(emailBatchItem, "expired-card") == expected)
+  "EmailToSendTest.fromEmailBatchItem" should "create CC Expiry email to send" in {
+    val emailBatchItemCC = emailBatchItemStub.copy(
+      object_name = "Card_Expiry__c",
+      payload = emailBatchItemPayloadStub.copy(email_stage = "MBv1 - 1")
+    )
+    val expectedCC = expectedStub.copy(DataExtensionName = "expired-card")
+    assert(EmailToSend.fromEmailBatchItem(emailBatchItemCC) == expectedCC)
   }
 
+  it should "create Direct Debit Mandate Failure email to send" in {
+    val emailBatchItemDD = emailBatchItemStub.copy(
+      object_name = "DD_Mandate_Failure__c",
+      payload = emailBatchItemPayloadStub.copy(email_stage = "MF1")
+    )
+    val expectedDD = expectedStub.copy(DataExtensionName = "dd-mandate-failure-1")
+    assert(EmailToSend.fromEmailBatchItem(emailBatchItemDD) == expectedDD)
+  }
+
+  it should "throw exception if it cannot recognize object_name" in {
+    val emailBatchItemUnrecognized = emailBatchItemStub.copy(object_name = "unrecognized_object_name")
+    assertThrows[RuntimeException](EmailToSend.fromEmailBatchItem(emailBatchItemUnrecognized))
+  }
 }


### PR DESCRIPTION
https://trello.com/c/fU7a3xTf/111-send-direct-debit-failure-emails

Salesforce will POST:

```
       {  
          "payload":{  
             ...
             "email_stage": MF1 | MF2 | ... | MF8
          },
          "object_name":"DD_Mandate_Failure__c"
       }
```

which we map to

```
      case ("DD_Mandate_Failure__c", "MF1") => "dd-mandate-failure-1"
      case ("DD_Mandate_Failure__c", "MF2") => "dd-mandate-failure-2"
      case ("DD_Mandate_Failure__c", "MF3") => "dd-mandate-failure-3"
      case ("DD_Mandate_Failure__c", "MF4") => "dd-mandate-failure-4"
      case ("DD_Mandate_Failure__c", "MF5") => "dd-mandate-failure-5"
      case ("DD_Mandate_Failure__c", "MF6") => "dd-mandate-failure-6"
```

which `membership-workflow` maps to corresponding Braze `Campaign API Identifier:`

Related PR: https://github.com/guardian/membership-workflow/pull/170