### PR TITLE
Handle errors related to existing direct debit payment methods gracefully

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/TypeConvert.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/TypeConvert.scala
@@ -50,7 +50,8 @@ object TypeConvert {
   }
 
   implicit class OptionToClientFailableOp[A](option: Option[A]) {
-    def toClientFailable(errorMessage: String) = option match {
+    def toClientFailable(errorMessage: String, acceptablePaymentMethod: Boolean = true) = option match {
+      case None if !acceptablePaymentMethod => PaymentError(errorMessage)
       case None => GenericError(errorMessage)
       case Some(value) => ClientSuccess(value)
     }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethod.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethod.scala
@@ -32,10 +32,10 @@ object GetPaymentMethod {
     }
 
     private def toDirectDebit: ClientFailableOp[DirectDebit] = for {
-      mandateId <- MandateID.toClientFailable("no MandateID in zuora direct debit")
-      accountName <- BankTransferAccountName.toClientFailable("no account name in zuora direct debit")
-      accountNumberMask <- BankTransferAccountNumberMask.toClientFailable("no account number mask in zuora direct debit")
-      sortCode <- BankCode.toClientFailable("no bank code in zuora direct debit")
+      mandateId <- MandateID.toClientFailable("no MandateID in zuora direct debit", acceptablePaymentMethod = false)
+      accountName <- BankTransferAccountName.toClientFailable("no account name in zuora direct debit", acceptablePaymentMethod = false)
+      accountNumberMask <- BankTransferAccountNumberMask.toClientFailable("no account number mask in zuora direct debit", acceptablePaymentMethod = false)
+      sortCode <- BankCode.toClientFailable("no bank code in zuora direct debit", acceptablePaymentMethod = false)
     } yield DirectDebit(
       toStatus(PaymentMethodStatus),
       BankAccountName(accountName),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethodTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/GetPaymentMethodTest.scala
@@ -6,7 +6,7 @@ import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodStatus.{ActivePa
 import com.gu.newproduct.api.addsubscription.zuora.PaymentMethodType._
 import com.gu.test.EffectsTest
 import com.gu.util.resthttp.RestRequestMaker.IsCheckNeeded
-import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError}
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientSuccess, GenericError, PaymentError}
 import org.scalatest.{FlatSpec, Matchers}
 
 class GetPaymentMethodTest extends FlatSpec with Matchers {
@@ -30,7 +30,7 @@ class GetPaymentMethodTest extends FlatSpec with Matchers {
     actual shouldBe GenericError("something failed!")
   }
 
-  "paymentMethodWires.toPayMentMethod" should "convert PayPal payment" in {
+  "paymentMethodWires.toPaymentMethod" should "convert PayPal payment" in {
     PaymentMethodWire("Active", "PayPal").toPaymentMethod shouldBe ClientSuccess(NonDirectDebitMethod(ActivePaymentMethod, PayPal))
   }
   it should "convert credit card payment" in {
@@ -54,19 +54,19 @@ class GetPaymentMethodTest extends FlatSpec with Matchers {
 
   it should "return error if missing mandate Id in direct debit payment method" in {
     val noMandateMethod = validDirectDebitWire.copy(MandateID = None)
-    noMandateMethod.toPaymentMethod shouldBe GenericError("no MandateID in zuora direct debit")
+    noMandateMethod.toPaymentMethod shouldBe PaymentError("no MandateID in zuora direct debit")
   }
   it should "return error if missing account number mask in direct debit payment method" in {
     val noAccountNumberPaymentMethod = validDirectDebitWire.copy(BankTransferAccountNumberMask = None)
-    noAccountNumberPaymentMethod.toPaymentMethod shouldBe GenericError("no account number mask in zuora direct debit")
+    noAccountNumberPaymentMethod.toPaymentMethod shouldBe PaymentError("no account number mask in zuora direct debit")
   }
   it should "return error if missing account name in direct debit payment method" in {
     val noAccountNamePaymentMethod = validDirectDebitWire.copy(BankTransferAccountName = None)
-    noAccountNamePaymentMethod.toPaymentMethod shouldBe GenericError("no account name in zuora direct debit")
+    noAccountNamePaymentMethod.toPaymentMethod shouldBe PaymentError("no account name in zuora direct debit")
   }
   it should "return error if missing sort code in direct debit payment method" in {
     val noSortCodePaymentMethod = validDirectDebitWire.copy(BankCode = None)
-    noSortCodePaymentMethod.toPaymentMethod shouldBe GenericError("no bank code in zuora direct debit")
+    noSortCodePaymentMethod.toPaymentMethod shouldBe PaymentError("no bank code in zuora direct debit")
   }
   it should "convert any other payment type to 'Other'" in {
     val wire = PaymentMethodWire("Active", "some other payment method")


### PR DESCRIPTION
When we serve a generic error (500) CSRs see this [message](https://github.com/guardian/crm-touchpoint/blob/master/src/classes/CreateSubscriptionController.cls#L85
):
_An internal error occurred. Please try again later. If the error persists, please contact support._

When we serve a payment error (402) CSRs see this [message](https://github.com/guardian/crm-touchpoint/blob/master/src/classes/CreateSubscriptionController.cls#L86):
_The subscription could not be created due to a problem with the customer\'s payment method. Please update the payment method associated with the customer\'s billing account and try again_

By serving payment errors when we detect a problem with a customer's existing direct debit mandate we:

1. Enable CSRs to fix problems for themselves (rather than pointlessly retrying an operation which will definitely fail or contacting support for a non-technical issue)
2. Prevent another class of noisy, unactionable alerts from interrupting us!
