### PR TITLE
do not put payment failure emails in the queue without an email address

### DIFF
--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
@@ -2,7 +2,7 @@ package com.gu.paymentFailure
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-
+import play.api.libs.json.Reads._
 import scala.util.Try
 
 case class BillingDetails(
@@ -50,7 +50,7 @@ object PaymentFailureCallout {
   implicit val jf: Reads[PaymentFailureCallout] = {
     (
       (JsPath \ "accountId").read[String] and
-      (JsPath \ "email").read[String] and
+      (JsPath \ "email").read(minLength[String](1)) and
       (JsPath \ "failureNumber").read[String].map(str => Try { Integer.parseInt(str) }).collect(JsonValidationError("int wasn't parsable"))({ case scala.util.Success(num) => num }) and
       (JsPath \ "firstName").read[String] and
       (JsPath \ "lastName").read[String] and

--- a/src/test/resources/paymentFailure/missingEmail.json
+++ b/src/test/resources/paymentFailure/missingEmail.json
@@ -1,0 +1,57 @@
+{
+  "resource": "/payment-failure",
+  "path": "/payment-failure",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept-Encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "Host": "321",
+    "Postman-Token": "123",
+    "User-Agent": "some user agent",
+    "Via": "test",
+    "X-Amz-Cf-Id": "test2",
+    "X-Amzn-Trace-Id": "3213",
+    "X-Forwarded-For": "222.222.222",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": {
+    "apiClientId": "validApiClientId",
+    "apiToken": "validApiToken"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "path": "/CODE/payment-failure",
+    "accountId": "someAccountId",
+    "resourceId": "someResourceId",
+    "stage": "CODE",
+    "requestId": "someRequestId",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "apiKey": "",
+      "sourceIp": "12.34.56.78",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "some agent",
+      "user": null
+    },
+    "resourcePath": "/payment-failure",
+    "httpMethod": "POST",
+    "apiId": "someApiId"
+  },
+  "body": "{\n \"paymentId\":\"somePaymentId\",\n    \"accountId\": \"accountId\",\n    \"email\": \"\",\n    \"failureNumber\": \"1\",\n    \"firstName\": \"Test\",\n    \"lastName\": \"User\",\n    \"paymentMethodType\": \"CreditCard\",\n    \"creditCardType\": \"Visa\",\n    \"creditCardExpirationMonth\": \"12\",\n    \"creditCardExpirationYear\": \"2017\",\n \"currency\": \"GBP\"\n,  \"tenantId\": \"testEnvTenantId\"\n, \"sfContactId\": \"1000000\"}",
+  "isBase64Encoded": false
+}

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -35,7 +35,13 @@ object TestData extends Matchers {
        |"body":"{\n  \"message\" : \"Credentials are missing or invalid\"\n}"
        |}
        |""".stripMargin
-
+  val missingEmailResponse =
+    """{
+      |"statusCode":"400",
+      |"headers":{"Content-Type":"application/json"},
+      |"body":"{\n  \"message\" : \"Bad request: request body couldn't be parsed: List((/email,List(JsonValidationError(List(error.minLength),WrappedArray(1)))))\"\n}"
+      |}
+      |""".stripMargin
   val successfulResponse =
     """{
        |"statusCode":"200",

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -41,6 +41,15 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
     responseString jsonMatches missingCredentialsResponse
   }
 
+  "lambda" should "return error if missing email" in {
+    val stream = getClass.getResourceAsStream("/paymentFailure/missingEmail.json")
+    val os = new ByteArrayOutputStream()
+    val op = Lambda.operationForEffects(\/-(TestData.fakeApiConfig), ContinueProcessing(basicOp()))
+    ApiGatewayHandler(LambdaIO(stream, os, null))(op)
+    val responseString = new String(os.toByteArray(), "UTF-8")
+    responseString jsonMatches missingEmailResponse
+  }
+
   "lambda" should "enqueue email and return success for a valid request" in {
     //set up
     val stream = getClass.getResourceAsStream("/paymentFailure/validRequest.json")


### PR DESCRIPTION
The contributions-thanks dead letters queue is getting filled with payment failure messages from accounts with no email address. 
With this change the payment failure callout from zuora will receive a bad request response if the json payload has no email.
