### PR TITLE
Handle no email

### DIFF
--- a/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
+++ b/src/main/scala/com/gu/autoCancel/AutoCancelCallout.scala
@@ -1,11 +1,11 @@
 package com.gu.autoCancel
 
-import play.api.libs.json.Json
+import play.api.libs.json.{JsResult, JsValue, Json, Reads}
 
 case class AutoCancelCallout(
   accountId: String,
   autoPay: String,
-  email: String,
+  email: Option[String],
   firstName: String,
   lastName: String,
   paymentMethodType: String,
@@ -21,5 +21,17 @@ case class AutoCancelCallout(
 }
 
 object AutoCancelCallout {
-  implicit val jf = Json.reads[AutoCancelCallout]
+
+  implicit val NoneForEmptyStringEMailReads: Reads[AutoCancelCallout] = new Reads[AutoCancelCallout] {
+
+    val standardReads = Json.reads[AutoCancelCallout]
+
+    override def reads(json: JsValue): JsResult[AutoCancelCallout] = standardReads.reads(json).map {
+      parsedCallout =>
+        parsedCallout.email match {
+          case Some("") => parsedCallout.copy(email = None)
+          case _ => parsedCallout
+        }
+    }
+  }
 }

--- a/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
+++ b/src/main/scala/com/gu/paymentFailure/GetPaymentData.scala
@@ -3,17 +3,15 @@ package com.gu.paymentFailure
 import java.time.LocalDate
 
 import com.gu.util.Logging
-import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
-import com.gu.util.reader.Types.ApiGatewayOp._
-import com.gu.util.reader.Types._
+import scalaz.syntax.std.option._
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.{InvoiceItem, InvoiceTransactionSummary, ItemisedInvoice}
+import scalaz.{-\/, \/}
 
 object GetPaymentData extends Logging {
 
   case class PaymentFailureInformation(subscriptionName: String, product: String, amount: Double, serviceStartDate: LocalDate, serviceEndDate: LocalDate)
 
-  //todo for now just return an option here but the error handling has to be refactored a little bit
-  def apply(message: String)(invoiceTransactionSummary: InvoiceTransactionSummary): ApiGatewayOp[PaymentFailureInformation] = {
+  def apply(message: String)(invoiceTransactionSummary: InvoiceTransactionSummary): String \/ PaymentFailureInformation = {
     logger.info(s"Attempting to get further details from account $message")
     val unpaidInvoices =
       invoiceTransactionSummary.invoices.filter {
@@ -23,18 +21,19 @@ object GetPaymentData extends Logging {
       case Some(invoice) => {
         logger.info(s"Found the following unpaid invoice: $invoice")
         val positiveInvoiceItems = invoice.invoiceItems.filter(item => invoiceItemFilter(item))
-        positiveInvoiceItems.headOption.map {
+        val maybePaymentFailureInfo = positiveInvoiceItems.headOption.map {
           item =>
             {
               val paymentFailureInfo = PaymentFailureInformation(item.subscriptionName, item.productName, invoice.amount, item.serviceStartDate, item.serviceEndDate)
               logger.info(s"Payment failure information for account: $message is: $paymentFailureInfo")
               paymentFailureInfo
             }
-        }.toApiGatewayContinueProcessing(internalServerError(s"Could not retrieve additional data for account $message"))
+        }
+        maybePaymentFailureInfo.toRightDisjunction(s"Could not retrieve additional data for account $message")
       }
       case None => {
         logger.error(s"No unpaid invoice found - nothing to do")
-        ReturnWithResponse(internalServerError(s"Could not retrieve additional data for account $message"))
+        -\/(s"Could not retrieve additional data for account $message")
       }
     }
   }

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
@@ -47,10 +47,15 @@ case class PaymentFailureCallout(
 
 object PaymentFailureCallout {
 
+  def emptyStringToNone(maybeString: Option[String]) = maybeString match {
+    case Some("") => None
+    case otherCase => otherCase
+  }
+
   implicit val jf: Reads[PaymentFailureCallout] = {
     (
       (JsPath \ "accountId").read[String] and
-      (JsPath \ "email").readNullable[String] and
+      (JsPath \ "email").readNullable[String].map(emptyStringToNone) and
       (JsPath \ "failureNumber").read[String].map(str => Try { Integer.parseInt(str) }).collect(JsonValidationError("int wasn't parsable"))({ case scala.util.Success(num) => num }) and
       (JsPath \ "firstName").read[String] and
       (JsPath \ "lastName").read[String] and

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureCallout.scala
@@ -29,7 +29,7 @@ object BillingDetails {
 }
 case class PaymentFailureCallout(
   accountId: String,
-  email: String,
+  email: Option[String],
   failureNumber: Int,
   firstName: String,
   lastName: String,
@@ -50,7 +50,7 @@ object PaymentFailureCallout {
   implicit val jf: Reads[PaymentFailureCallout] = {
     (
       (JsPath \ "accountId").read[String] and
-      (JsPath \ "email").read[String] and
+      (JsPath \ "email").readNullable[String] and
       (JsPath \ "failureNumber").read[String].map(str => Try { Integer.parseInt(str) }).collect(JsonValidationError("int wasn't parsable"))({ case scala.util.Success(num) => num }) and
       (JsPath \ "firstName").read[String] and
       (JsPath \ "lastName").read[String] and

--- a/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
+++ b/src/main/scala/com/gu/paymentFailure/PaymentFailureSteps.scala
@@ -4,13 +4,13 @@ import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.stripeCustomerSourceUpdated.TypeConvert._
 import com.gu.util._
 import com.gu.util.apigateway.ApiGatewayHandler.Operation
-import com.gu.util.apigateway.ApiGatewayResponse.{ResponseBody, toJsonBody, unauthorized}
+import com.gu.util.apigateway.ApiGatewayResponse.unauthorized
 import com.gu.util.apigateway.Auth.{TrustedApiConfig, validTenant}
 import com.gu.util.apigateway.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.email.{EmailId, EmailMessage}
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
-import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.resthttp.Types.{ClientFailableOp, GenericError, UnderlyingOps}
 import com.gu.util.zuora.ZuoraGetInvoiceTransactions.InvoiceTransactionSummary
 import scalaz.\/
 
@@ -21,15 +21,16 @@ object PaymentFailureSteps extends Logging {
   }
 
   def apply(
-    sendEmailRegardingAccount: (String, PaymentFailureInformation => String \/ EmailMessage) => ApiGatewayOp[Unit],
+    sendEmailRegardingAccount: (String, PaymentFailureInformation => String \/ EmailMessage) => ClientFailableOp[Unit],
     trustedApiConfig: TrustedApiConfig
   ): Operation = Operation.noHealthcheck({ apiGatewayRequest: ApiGatewayRequest =>
     (for {
       paymentFailureCallout <- apiGatewayRequest.bodyAsCaseClass[PaymentFailureCallout]()
+      _ <- paymentFailureCallout.email.toApiGatewayContinueProcessing(ApiGatewayResponse.badRequest("No email address provided"))
       _ = logger.info(s"received ${loggableData(paymentFailureCallout)}")
       _ <- validateTenantCallout(trustedApiConfig)(paymentFailureCallout.tenantId)
       paymentFailureInformationToEmail = makeEmailMessage(paymentFailureCallout) _
-      _ <- sendEmailRegardingAccount(paymentFailureCallout.accountId, paymentFailureInformationToEmail)
+      _ <- sendEmailRegardingAccount(paymentFailureCallout.accountId, paymentFailureInformationToEmail).toApiGatewayOp(error => ApiGatewayResponse.messageResponse("500", error.message))
     } yield ApiGatewayResponse.successfulExecution).apiResponse
   })
 
@@ -49,15 +50,14 @@ object PaymentFailureSteps extends Logging {
 object ZuoraEmailSteps {
 
   def sendEmailRegardingAccount(
-    sendEmail: EmailMessage => ApiGatewayOp[Unit],
+    sendEmail: EmailMessage => ClientFailableOp[Unit],
     getInvoiceTransactions: String => ClientFailableOp[InvoiceTransactionSummary]
-  )(accountId: String, toMessage: PaymentFailureInformation => String \/ EmailMessage): ApiGatewayOp[Unit] = {
+  )(accountId: String, toMessage: PaymentFailureInformation => String \/ EmailMessage): ClientFailableOp[Unit] = {
     for {
-      invoiceTransactionSummary <- getInvoiceTransactions(accountId).toApiGatewayOp("getInvoiceTransactions failed")
-      paymentInformation <- GetPaymentData(accountId)(invoiceTransactionSummary)
-      message <- toMessage(paymentInformation).toApiGatewayOp("get email message from paymentInformation")
-      _ <- sendEmail(message).mapResponse(resp =>
-        resp.copy(body = toJsonBody(ResponseBody(s"email not sent for account ${accountId}"))))
+      invoiceTransactionSummary <- getInvoiceTransactions(accountId)
+      paymentInformation <- GetPaymentData(accountId)(invoiceTransactionSummary).leftMap(GenericError(_)).toClientFailableOp
+      message <- toMessage(paymentInformation).leftMap(GenericError(_)).toClientFailableOp
+      _ <- sendEmail(message).withAmendedError(oldError => GenericError(s"email not sent for account ${accountId}, error: ${oldError.message}"))
     } yield ()
   }
 

--- a/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -7,6 +7,8 @@ import java.time.format.DateTimeFormatter
 import com.gu.autoCancel.AutoCancelCallout
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.util.email._
+import scalaz.{\/, \/-}
+
 import scalaz.{-\/, \/, \/-}
 
 import scala.math.BigDecimal.decimal
@@ -46,33 +48,32 @@ object ToMessage {
         DataExtensionName = sendId.id,
         SfContactId = paymentFailureCallout.sfContactId
       ))
-
     }
 
-  //todo handle missing email case ?
-  def apply(callout: AutoCancelCallout, paymentFailureInformation: PaymentFailureInformation, sendId: EmailId): String \/ EmailMessage = \/-(EmailMessage(
-    To = ToDef(
-      Address = callout.email,
-      SubscriberKey = callout.email,
-      ContactAttributes = ContactAttributesDef(
-        SubscriberAttributes = SubscriberAttributesDef(
-          subscriber_id = paymentFailureInformation.subscriptionName,
-          product = paymentFailureInformation.product,
-          payment_method = callout.paymentMethodType,
-          card_type = callout.creditCardType,
-          card_expiry_date = callout.creditCardExpirationMonth + "/" + callout.creditCardExpirationYear,
-          first_name = callout.firstName,
-          last_name = callout.lastName,
-          primaryKey = InvoiceId(callout.invoiceId),
-          price = price(paymentFailureInformation.amount, callout.currency),
-          serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
-          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)
+  def apply(callout: AutoCancelCallout, paymentFailureInformation: PaymentFailureInformation, sendId: EmailId): String \/ EmailMessage =
+    \/-(EmailMessage(
+      To = ToDef(
+        Address = callout.email.get,
+        SubscriberKey = callout.email.get,
+        ContactAttributes = ContactAttributesDef(
+          SubscriberAttributes = SubscriberAttributesDef(
+            subscriber_id = paymentFailureInformation.subscriptionName,
+            product = paymentFailureInformation.product,
+            payment_method = callout.paymentMethodType,
+            card_type = callout.creditCardType,
+            card_expiry_date = callout.creditCardExpirationMonth + "/" + callout.creditCardExpirationYear,
+            first_name = callout.firstName,
+            last_name = callout.lastName,
+            primaryKey = InvoiceId(callout.invoiceId),
+            price = price(paymentFailureInformation.amount, callout.currency),
+            serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
+            serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate)
+          )
         )
-      )
-    ),
-    DataExtensionName = sendId.id,
-    SfContactId = callout.sfContactId
-  ))
+      ),
+      DataExtensionName = sendId.id,
+      SfContactId = callout.sfContactId
+    ))
 
   val currencySymbol = Map("GBP" -> "£", "AUD" -> "$", "EUR" -> "€", "USD" -> "$", "CAD" -> "$", "NZD" -> "$")
 

--- a/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -3,45 +3,54 @@ package com.gu.paymentFailure
 import java.text.DecimalFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+
 import com.gu.autoCancel.AutoCancelCallout
 import com.gu.paymentFailure.GetPaymentData.PaymentFailureInformation
 import com.gu.util.email._
+import scalaz.{-\/, \/, \/-}
+
 import scala.math.BigDecimal.decimal
 
 object ToMessage {
 
-  def apply(paymentFailureCallout: PaymentFailureCallout, paymentFailureInformation: PaymentFailureInformation, sendId: EmailId) = EmailMessage(
-    To = ToDef(
-      Address = paymentFailureCallout.email,
-      SubscriberKey = paymentFailureCallout.email,
-      ContactAttributes = ContactAttributesDef(
-        SubscriberAttributes = SubscriberAttributesDef(
-          subscriber_id = paymentFailureInformation.subscriptionName,
-          product = paymentFailureInformation.product,
-          payment_method = paymentFailureCallout.paymentMethodType,
-          card_type = paymentFailureCallout.creditCardType,
-          card_expiry_date = paymentFailureCallout.creditCardExpirationMonth + "/" + paymentFailureCallout.creditCardExpirationYear,
-          first_name = paymentFailureCallout.firstName,
-          last_name = paymentFailureCallout.lastName,
-          primaryKey = PaymentId(paymentFailureCallout.paymentId),
-          price = price(paymentFailureInformation.amount, paymentFailureCallout.currency),
-          serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
-          serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate),
-          billing_address1 = paymentFailureCallout.billingDetails.address1,
-          billing_address2 = paymentFailureCallout.billingDetails.address2,
-          billing_postcode = paymentFailureCallout.billingDetails.postCode,
-          billing_city = paymentFailureCallout.billingDetails.city,
-          billing_state = paymentFailureCallout.billingDetails.state,
-          billing_country = paymentFailureCallout.billingDetails.country,
-          title = paymentFailureCallout.title
-        )
-      )
-    ),
-    DataExtensionName = sendId.id,
-    SfContactId = paymentFailureCallout.sfContactId
-  )
+  def apply(paymentFailureCallout: PaymentFailureCallout, paymentFailureInformation: PaymentFailureInformation, sendId: EmailId): String \/ EmailMessage =
+    paymentFailureCallout.email match {
+      case None => -\/(s"Cannot create email message: no email address associated with accountId: ${paymentFailureCallout.accountId} and sfContactId: ${paymentFailureCallout.sfContactId}")
+      case Some(emailAddress) => \/-(EmailMessage(
+        To = ToDef(
+          Address = emailAddress,
+          SubscriberKey = emailAddress,
+          ContactAttributes = ContactAttributesDef(
+            SubscriberAttributes = SubscriberAttributesDef(
+              subscriber_id = paymentFailureInformation.subscriptionName,
+              product = paymentFailureInformation.product,
+              payment_method = paymentFailureCallout.paymentMethodType,
+              card_type = paymentFailureCallout.creditCardType,
+              card_expiry_date = paymentFailureCallout.creditCardExpirationMonth + "/" + paymentFailureCallout.creditCardExpirationYear,
+              first_name = paymentFailureCallout.firstName,
+              last_name = paymentFailureCallout.lastName,
+              primaryKey = PaymentId(paymentFailureCallout.paymentId),
+              price = price(paymentFailureInformation.amount, paymentFailureCallout.currency),
+              serviceStartDate = serviceDateFormat(paymentFailureInformation.serviceStartDate),
+              serviceEndDate = serviceDateFormat(paymentFailureInformation.serviceEndDate),
+              billing_address1 = paymentFailureCallout.billingDetails.address1,
+              billing_address2 = paymentFailureCallout.billingDetails.address2,
+              billing_postcode = paymentFailureCallout.billingDetails.postCode,
+              billing_city = paymentFailureCallout.billingDetails.city,
+              billing_state = paymentFailureCallout.billingDetails.state,
+              billing_country = paymentFailureCallout.billingDetails.country,
+              title = paymentFailureCallout.title
+            )
+          )
+        ),
+        DataExtensionName = sendId.id,
+        SfContactId = paymentFailureCallout.sfContactId
+      ))
 
-  def apply(callout: AutoCancelCallout, paymentFailureInformation: PaymentFailureInformation, sendId: EmailId) = EmailMessage(
+    }
+
+  //todo handle missing email case ?
+  def apply(callout: AutoCancelCallout, paymentFailureInformation: PaymentFailureInformation, sendId: EmailId): String \/ EmailMessage = \/-(EmailMessage(
     To = ToDef(
       Address = callout.email,
       SubscriberKey = callout.email,
@@ -63,7 +72,7 @@ object ToMessage {
     ),
     DataExtensionName = sendId.id,
     SfContactId = callout.sfContactId
-  )
+  ))
 
   val currencySymbol = Map("GBP" -> "£", "AUD" -> "$", "EUR" -> "€", "USD" -> "$", "CAD" -> "$", "NZD" -> "$")
 

--- a/src/main/scala/com/gu/stripeCustomerSourceUpdated/TypeConvert.scala
+++ b/src/main/scala/com/gu/stripeCustomerSourceUpdated/TypeConvert.scala
@@ -1,12 +1,18 @@
 package com.gu.stripeCustomerSourceUpdated
 
+import com.gu.util.apigateway.ResponseModels.ApiResponse
+import com.gu.util.reader.Types.ApiGatewayOp.ContinueProcessing
 import com.gu.util.reader.Types._
-import com.gu.util.resthttp.Types.ClientFailableOp
+import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess}
 
 object TypeConvert {
 
   implicit class TypeConvertClientOp[A](clientOp: ClientFailableOp[A]) {
     def toApiGatewayOp(action: String): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(action)
+
+    def toApiGatewayOp(failureToApiResponse: ClientFailure => ApiResponse): ApiGatewayOp[A] = clientOp.toDisjunction.toApiGatewayOp(failureToApiResponse)
+
+    def withAmendedError(amendError: ClientFailure => ClientFailure) = clientOp.toDisjunction.leftMap(amendError(_)).toClientFailableOp
   }
 
 }

--- a/src/main/scala/com/gu/util/email/EmailSendSteps.scala
+++ b/src/main/scala/com/gu/util/email/EmailSendSteps.scala
@@ -5,6 +5,8 @@ import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.reader.Types._
 import play.api.libs.json.{Json, Writes, _}
+import scalaz.{-\/, \/, \/-}
+
 import scala.util.{Failure, Success, Try}
 
 case class ContactAttributesDef(SubscriberAttributes: SubscriberAttributesDef)
@@ -41,12 +43,12 @@ case class ToDef(Address: String, SubscriberKey: String, ContactAttributes: Cont
 case class EmailId(id: String) extends AnyVal
 
 object EmailId {
-  def paymentFailureId(i: Int) = i match {
-    case 1 => Some(EmailId("first-failed-payment-email"))
-    case 2 => Some(EmailId("second-failed-payment-email"))
-    case 3 => Some(EmailId("third-failed-payment-email"))
-    case 4 => Some(EmailId("fourth-failed-payment-email"))
-    case _ => None
+  def paymentFailureId(failureNumber: Int): String \/ EmailId = failureNumber match {
+    case 1 => \/-(EmailId("first-failed-payment-email"))
+    case 2 => \/-(EmailId("second-failed-payment-email"))
+    case 3 => \/-(EmailId("third-failed-payment-email"))
+    case 4 => \/-(EmailId("fourth-failed-payment-email"))
+    case _ => -\/(s"no Braze id configured for failure number: $failureNumber")
   }
   val cancelledId = EmailId("cancelled-payment-email")
 }

--- a/src/test/resources/paymentFailure/missingEmail.json
+++ b/src/test/resources/paymentFailure/missingEmail.json
@@ -1,0 +1,57 @@
+{
+  "resource": "/payment-failure",
+  "path": "/payment-failure",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept-Encoding": "gzip, deflate",
+    "cache-control": "no-cache",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Content-Type": "application/json",
+    "Host": "321",
+    "Postman-Token": "123",
+    "User-Agent": "some user agent",
+    "Via": "test",
+    "X-Amz-Cf-Id": "test2",
+    "X-Amzn-Trace-Id": "3213",
+    "X-Forwarded-For": "222.222.222",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "queryStringParameters": {
+    "apiClientId": "validApiClientId",
+    "apiToken": "validApiToken"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "path": "/CODE/payment-failure",
+    "accountId": "someAccountId",
+    "resourceId": "someResourceId",
+    "stage": "CODE",
+    "requestId": "someRequestId",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "apiKey": "",
+      "sourceIp": "12.34.56.78",
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "some agent",
+      "user": null
+    },
+    "resourcePath": "/payment-failure",
+    "httpMethod": "POST",
+    "apiId": "someApiId"
+  },
+  "body": "{\n \"paymentId\":\"somePaymentId\",\n    \"accountId\": \"accountId\",\n  \"failureNumber\": \"1\",\n    \"firstName\": \"Test\",\n    \"lastName\": \"User\",\n    \"paymentMethodType\": \"CreditCard\",\n    \"creditCardType\": \"Visa\",\n    \"creditCardExpirationMonth\": \"12\",\n    \"creditCardExpirationYear\": \"2017\",\n \"currency\": \"GBP\"\n,  \"tenantId\": \"testEnvTenantId\"\n, \"sfContactId\": \"1000000\"}",
+  "isBase64Encoded": false
+}

--- a/src/test/scala/com/gu/TestData.scala
+++ b/src/test/scala/com/gu/TestData.scala
@@ -44,22 +44,6 @@ object TestData extends Matchers {
        |}
        |""".stripMargin
 
-  val internalServerErrorResponse =
-    """{
-       |"statusCode":"500",
-       |"headers":{"Content-Type":"application/json"},
-       |"body":"{\n  \"message\" : \"Internal server error\"\n}"
-       |}
-       |""".stripMargin
-
-  val emailFailureResponse =
-    """{
-      |"statusCode":"500",
-      |"headers":{"Content-Type":"application/json"},
-      |"body":"{\n  \"message\" : \"email not sent for account accountId\"\n}"
-      |}
-      |""".stripMargin
-
   implicit class JsonMatcher(private val actual: String) {
     def jsonMatches(expected: String) = {
       val expectedJson = Json.parse(expected)

--- a/src/test/scala/com/gu/autoCancel/AutoCancelCalloutTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelCalloutTest.scala
@@ -1,0 +1,100 @@
+package com.gu.autoCancel
+
+import org.scalatest._
+import play.api.libs.json.Json
+
+class AutoCancelCalloutTest extends FlatSpec with Matchers {
+
+  "AutoCancelCallout" should "deserialise callout with email address correctly" in {
+    val calloutJson =
+      """{
+        |"accountId" : "someAccountId",
+        |"autoPay" : "true",
+        |"email" : "someEmail@domain.com",
+        |"firstName": "someFirstName",
+        |"lastName": "someLastName",
+        |"paymentMethodType": "card",
+        |"creditCardType": "visa",
+        |"creditCardExpirationMonth": "11",
+        |"creditCardExpirationYear":"2022",
+        |"invoiceId": "someInvoiceId",
+        |"currency": "gbp",
+        |"sfContactId": "someContactId"
+        |}
+      """.stripMargin
+
+    val expectedCallout = AutoCancelCallout(
+      accountId = "someAccountId",
+      autoPay = "true",
+      email = Some("someEmail@domain.com"),
+      firstName = "someFirstName",
+      lastName = "someLastName",
+      paymentMethodType = "card",
+      creditCardType = "visa",
+      creditCardExpirationMonth = "11",
+      creditCardExpirationYear = "2022",
+      invoiceId = "someInvoiceId",
+      currency = "gbp",
+      sfContactId = "someContactId"
+    )
+
+    Json.parse(calloutJson).as[AutoCancelCallout] shouldBe expectedCallout
+  }
+
+  val calloutWithNoEmail = AutoCancelCallout(
+    accountId = "someAccountId",
+    autoPay = "true",
+    email = None,
+    firstName = "someFirstName",
+    lastName = "someLastName",
+    paymentMethodType = "card",
+    creditCardType = "visa",
+    creditCardExpirationMonth = "11",
+    creditCardExpirationYear = "2022",
+    invoiceId = "someInvoiceId",
+    currency = "gbp",
+    sfContactId = "someContactId"
+  )
+
+  it should "deserialise callout with no email address correctly" in {
+    val noEmailCalloutJson =
+      """{
+        |"accountId" : "someAccountId",
+        |"autoPay" : "true",
+        |"firstName": "someFirstName",
+        |"lastName": "someLastName",
+        |"paymentMethodType": "card",
+        |"creditCardType": "visa",
+        |"creditCardExpirationMonth": "11",
+        |"creditCardExpirationYear":"2022",
+        |"invoiceId": "someInvoiceId",
+        |"currency": "gbp",
+        |"sfContactId": "someContactId"
+        |}
+      """.stripMargin
+
+    Json.parse(noEmailCalloutJson).as[AutoCancelCallout] shouldBe calloutWithNoEmail
+  }
+
+  it should "deserialise callout with empty string email address correctly" in {
+    val emptyStringEmailCalloutJson =
+      """{
+        |"accountId" : "someAccountId",
+        |"autoPay" : "true",
+        |"email" : "",
+        |"firstName": "someFirstName",
+        |"lastName": "someLastName",
+        |"paymentMethodType": "card",
+        |"creditCardType": "visa",
+        |"creditCardExpirationMonth": "11",
+        |"creditCardExpirationYear":"2022",
+        |"invoiceId": "someInvoiceId",
+        |"currency": "gbp",
+        |"sfContactId": "someContactId"
+        |}
+      """.stripMargin
+
+    Json.parse(emptyStringEmailCalloutJson).as[AutoCancelCallout] shouldBe calloutWithNoEmail
+  }
+
+}

--- a/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
+++ b/src/test/scala/com/gu/autoCancel/AutoCancelHandlerTest.scala
@@ -7,7 +7,7 @@ import scalaz.{-\/, \/-}
 object AutoCancelHandlerTest {
 
   def fakeCallout(autoPay: Boolean) = {
-    AutoCancelCallout(accountId = "id123", autoPay = s"$autoPay", paymentMethodType = "PayPal", email = "hi@hi.com", firstName = "john", lastName = "bloggs", creditCardType = "",
+    AutoCancelCallout(accountId = "id123", autoPay = s"$autoPay", paymentMethodType = "PayPal", email = Some("hi@hi.com"), firstName = "john", lastName = "bloggs", creditCardType = "",
       creditCardExpirationMonth = "", creditCardExpirationYear = "", invoiceId = "idid",
       currency = "GBP", sfContactId = "1000000")
   }

--- a/src/test/scala/com/gu/paymentFailure/GetPaymentDataTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/GetPaymentDataTest.scala
@@ -9,7 +9,7 @@ class GetPaymentDataTest extends FlatSpec {
 
   "getPaymentData" should "identify the correct product information" in {
     val actual = GetPaymentData(accountId)(weirdInvoiceTransactionSummary).map(_.product)
-    assert(actual.toDisjunction == \/.right("Supporter"))
+    assert(actual == \/.right("Supporter"))
   }
 
 }

--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureCalloutTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureCalloutTest.scala
@@ -1,0 +1,157 @@
+package com.gu.paymentFailure
+
+import org.scalatest._
+import play.api.libs.json.Json
+
+class PaymentFailureCalloutTest extends FlatSpec with Matchers {
+
+  val expectedBillingDetails = BillingDetails(
+    address1 = Some("someBilltoAddress1"),
+    address2 = Some("someBilltoAddress2"),
+    postCode = Some("somePostalCode"),
+    city = Some("someBilltoCity"),
+    state = Some("someBilltoState"),
+    country = Some("someBilltoCountry")
+  )
+
+  "PaymentFailureCallout" should "deserialise callout with email address correctly" in {
+    val calloutJson =
+      """{
+        |  "lastName": "someLastName",
+        |  "creditCardExpirationMonth": "4",
+        |  "billToContactPostalCode": "somePostalCode",
+        |  "creditCardExpirationYear": "2019",
+        |  "billToContactCountry": "someBilltoCountry",
+        |  "creditCardType": "Visa",
+        |  "title": "Mr",
+        |  "accountId": "someAccountId",
+        |  "billToContactState": "someBilltoState",
+        |  "firstName": "someFirstName",
+        |  "paymentId": "somePaymentId",
+        |  "sfContactId": "someSfContactId",
+        |  "tenantId": "someTenantId",
+        |  "billToContactAddress1": "someBilltoAddress1",
+        |  "billToContactCity": "someBilltoCity",
+        |  "currency": "GBP",
+        |  "billToContactAddress2": "someBilltoAddress2",
+        |  "paymentMethodType": "CreditCard",
+        |  "email": "someEmail@domain.com",
+        |  "failureNumber": "1"
+        |}
+      """.stripMargin
+
+    val expectedCallout = PaymentFailureCallout(
+      accountId = "someAccountId",
+      email = Some("someEmail@domain.com"),
+      failureNumber = 1,
+      firstName = "someFirstName",
+      lastName = "someLastName",
+      paymentMethodType = "CreditCard",
+      creditCardType = "Visa",
+      creditCardExpirationMonth = "4",
+      creditCardExpirationYear = "2019",
+      paymentId = "somePaymentId",
+      currency = "GBP",
+      tenantId = "someTenantId",
+      title = Some("Mr"),
+      billingDetails = expectedBillingDetails,
+      sfContactId = "someSfContactId"
+    )
+
+    Json.parse(calloutJson).as[PaymentFailureCallout] shouldBe expectedCallout
+  }
+
+  val calloutWithNoEmail = PaymentFailureCallout(
+    accountId = "someAccountId",
+    email = None,
+    failureNumber = 1,
+    firstName = "someFirstName",
+    lastName = "someLastName",
+    paymentMethodType = "CreditCard",
+    creditCardType = "Visa",
+    creditCardExpirationMonth = "4",
+    creditCardExpirationYear = "2019",
+    paymentId = "somePaymentId",
+    currency = "GBP",
+    tenantId = "someTenantId",
+    title = Some("Mr"),
+    billingDetails = expectedBillingDetails,
+    sfContactId = "someSfContactId"
+  )
+
+  it should "deserialise callout with no email address correctly" in {
+    val calloutWithoutEmailJson =
+      """{
+        |  "lastName": "someLastName",
+        |  "creditCardExpirationMonth": "4",
+        |  "billToContactPostalCode": "somePostalCode",
+        |  "creditCardExpirationYear": "2019",
+        |  "billToContactCountry": "someBilltoCountry",
+        |  "creditCardType": "Visa",
+        |  "title": "Mr",
+        |  "accountId": "someAccountId",
+        |  "billToContactState": "someBilltoState",
+        |  "firstName": "someFirstName",
+        |  "paymentId": "somePaymentId",
+        |  "sfContactId": "someSfContactId",
+        |  "tenantId": "someTenantId",
+        |  "billToContactAddress1": "someBilltoAddress1",
+        |  "billToContactCity": "someBilltoCity",
+        |  "currency": "GBP",
+        |  "billToContactAddress2": "someBilltoAddress2",
+        |  "paymentMethodType": "CreditCard",
+        |  "failureNumber": "1"
+        |}
+      """.stripMargin
+
+    val expectedBillingDetails = BillingDetails(
+      address1 = Some("someBilltoAddress1"),
+      address2 = Some("someBilltoAddress2"),
+      postCode = Some("somePostalCode"),
+      city = Some("someBilltoCity"),
+      state = Some("someBilltoState"),
+      country = Some("someBilltoCountry")
+    )
+
+    Json.parse(calloutWithoutEmailJson).as[PaymentFailureCallout] shouldBe calloutWithNoEmail
+  }
+
+  it should "deserialise callout with an empty string email address to a callout with no email" in {
+    val calloutWithEmptyStringEmail =
+      """{
+        |  "lastName": "someLastName",
+        |  "creditCardExpirationMonth": "4",
+        |  "billToContactPostalCode": "somePostalCode",
+        |  "creditCardExpirationYear": "2019",
+        |  "billToContactCountry": "someBilltoCountry",
+        |  "creditCardType": "Visa",
+        |  "title": "Mr",
+        |  "accountId": "someAccountId",
+        |  "billToContactState": "someBilltoState",
+        |  "firstName": "someFirstName",
+        |  "paymentId": "somePaymentId",
+        |  "sfContactId": "someSfContactId",
+        |  "tenantId": "someTenantId",
+        |  "billToContactAddress1": "someBilltoAddress1",
+        |  "billToContactCity": "someBilltoCity",
+        |  "currency": "GBP",
+        |  "billToContactAddress2": "someBilltoAddress2",
+        |  "paymentMethodType": "CreditCard",
+        |  "email": "",
+        |  "failureNumber": "1"
+        |}
+      """.stripMargin
+
+    val expectedBillingDetails = BillingDetails(
+      address1 = Some("someBilltoAddress1"),
+      address2 = Some("someBilltoAddress2"),
+      postCode = Some("somePostalCode"),
+      city = Some("someBilltoCity"),
+      state = Some("someBilltoState"),
+      country = Some("someBilltoCountry")
+    )
+
+    Json.parse(calloutWithEmptyStringEmail).as[PaymentFailureCallout] shouldBe calloutWithNoEmail
+  }
+
+}

--- a/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
+++ b/src/test/scala/com/gu/util/exacttarget/EmailSendStepsTest.scala
@@ -1,11 +1,11 @@
 package com.gu.util.exacttarget
 
 import com.gu.effects.sqs.AwsSQSSend.Payload
-import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.email._
-import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
+import com.gu.util.resthttp.Types.{ClientSuccess, GenericError}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.Json
+
 import scala.util.{Failure, Success, Try}
 
 class EmailSendStepsTest extends FlatSpec with Matchers {
@@ -40,7 +40,7 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
     var capturedPayload: Option[Payload] = None
     def sqsSend(payload: Payload): Try[Unit] = Success { capturedPayload = Some(payload) }
 
-    EmailSendSteps(sqsSend)(makeMessage("james@jameson.com")) shouldBe ContinueProcessing(())
+    EmailSendSteps(sqsSend)(makeMessage("james@jameson.com")) shouldBe ClientSuccess(())
     Json.parse(capturedPayload.get.value) shouldBe Json.parse(
       """
         |{
@@ -73,7 +73,7 @@ class EmailSendStepsTest extends FlatSpec with Matchers {
   "EmailSendSteps" should "return with response on failure" in {
     def sqsSend(payload: Payload): Try[Unit] = Failure(new RuntimeException("foo"))
 
-    EmailSendSteps(sqsSend)(makeMessage("james@jameson.com")) shouldBe ReturnWithResponse(ApiResponse("500", "failure to send email payload to sqs"))
+    EmailSendSteps(sqsSend)(makeMessage("james@jameson.com")) shouldBe GenericError("failure to send email payload to sqs")
   }
 
 }

--- a/src/test/scala/manualTest/EmailSendTest.scala
+++ b/src/test/scala/manualTest/EmailSendTest.scala
@@ -1,10 +1,12 @@
 package manualTest
 
 import java.util.UUID
+
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.effects.sqs.AwsSQSSend.QueueName
 import com.gu.util.Logging
 import com.gu.util.email._
+import scalaz.\/-
 
 // run this to send a one off email to yourself.  the email will take a few mins to arrive, but it proves the ET logic works
 object EmailSendTest extends App with Logging {
@@ -38,7 +40,7 @@ object EmailSendTest extends App with Logging {
   val emailNames: Seq[EmailId] = (1 to 4)
     .map(EmailId.paymentFailureId)
     .collect {
-      case Some(emailName) => emailName
+      case \/-(emailName) => emailName
     }
     .:+(EmailId.cancelledId)
 


### PR DESCRIPTION
We are getting a lot of items in the contributions-thanks dead letters queue. This is caused by payment failures / auto cancel email attempts on accounts that have no email address.

This PR will stop the auto-cancel api from putting messages in the queue with no destination email address:

- /payment-failure will return a "bad request" response with a message saying that the request must have an email address
- /auto-cancel will cancel the subscription and skip the email sending step if there is no email address. A warn messages will be logged but the call will return a successful response.

The payment failure changes have been tested in UAT, I'm currently in the process of testing the auto-cancel changes as it is not as simple.