### PR TITLE
Separate contributions and voucher code in new product api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/QueueNames.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/QueueNames.scala
@@ -1,0 +1,13 @@
+package com.gu.newproduct.api
+
+import com.gu.effects.sqs.AwsSQSSend.QueueName
+import com.gu.util.config.Stage
+
+case class EmailQueueNames(contributions: QueueName, voucher: QueueName)
+
+object EmailQueueNames {
+  def emailQueuesFor(stage: Stage) = stage match {
+    case Stage("PROD") | Stage("CODE") => EmailQueueNames(contributions = QueueName("contributions-thanks"), voucher = QueueName("subs-welcome-email"))
+    case _ => EmailQueueNames(contributions = QueueName("contributions-thanks-dev"), voucher = QueueName("subs-welcome-email-dev"))
+  }
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddVoucher.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddVoucher.scala
@@ -65,12 +65,10 @@ object AddVoucher {
     isValidStartDateForPlan: (PlanId, LocalDate) => ValidationResult[Unit],
     createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
     awsSQSSend: QueueName => AwsSQSSend.Payload => Future[Unit],
-    emailQueueNames: EmailQueueNames,
-    currentDate: () => LocalDate
-  ): AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
+    emailQueueNames: EmailQueueNames): AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
     val voucherSqsSend = awsSQSSend(emailQueueNames.voucher)
     val voucherEtSqsSend = EtSqsSend[VoucherEmailData](voucherSqsSend) _
-    val sendVoucherEmail = SendConfirmationEmailVoucher(voucherEtSqsSend, currentDate) _
+    val sendVoucherEmail = SendConfirmationEmailVoucher(voucherEtSqsSend) _
     val getZuoraIdForVoucherPlan = zuoraIds.voucherZuoraIds.byApiPlanId.get _
     val getVoucherData = getValidatedVoucherCustomerData(zuoraClient)
     steps(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddVoucher.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddVoucher.scala
@@ -65,7 +65,8 @@ object AddVoucher {
     isValidStartDateForPlan: (PlanId, LocalDate) => ValidationResult[Unit],
     createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
     awsSQSSend: QueueName => AwsSQSSend.Payload => Future[Unit],
-    emailQueueNames: EmailQueueNames): AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
+    emailQueueNames: EmailQueueNames
+  ): AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
     val voucherSqsSend = awsSQSSend(emailQueueNames.voucher)
     val voucherEtSqsSend = EtSqsSend[VoucherEmailData](voucherSqsSend) _
     val sendVoucherEmail = SendConfirmationEmailVoucher(voucherEtSqsSend) _

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Contributions.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Contributions.scala
@@ -1,0 +1,143 @@
+package com.gu.newproduct.api.addsubscription
+
+import java.time.LocalDate
+
+import com.gu.effects.sqs.AwsSQSSend
+import com.gu.effects.sqs.AwsSQSSend.QueueName
+import com.gu.i18n.Currency
+import com.gu.newproduct.api.EmailQueueNames
+import com.gu.newproduct.api.addsubscription.TypeConvert._
+import com.gu.newproduct.api.addsubscription.email.EtSqsSend
+import com.gu.newproduct.api.addsubscription.email.contributions.SendConfirmationEmailContributions.ContributionsEmailData
+import com.gu.newproduct.api.addsubscription.email.contributions.{ContributionFields, SendConfirmationEmailContributions}
+import com.gu.newproduct.api.addsubscription.validation.Validation._
+import com.gu.newproduct.api.addsubscription.validation._
+import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionValidations.ValidatableFields
+import com.gu.newproduct.api.addsubscription.validation.contribution.{ContributionAccountValidation, ContributionCustomerData, ContributionValidations, GetContributionCustomerData}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
+import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
+import com.gu.newproduct.api.addsubscription.zuora.GetContacts.BillToContact
+import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
+import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetAccountSubscriptions, GetContacts, GetPaymentMethod}
+import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
+import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanId, ZuoraIds}
+import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PlanId}
+import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
+import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
+import com.gu.util.reader.Types.{ApiGatewayOp, OptionOps}
+import com.gu.util.resthttp.RestRequestMaker.Requests
+import com.gu.util.resthttp.Types.ClientFailableOp
+
+import scala.concurrent.Future
+object Contributions {
+  def steps(
+    getPlanAndCharge: PlanId => Option[PlanAndCharge],
+    getCustomerData: ZuoraAccountId => ApiGatewayOp[ContributionCustomerData],
+    contributionValidations: (ValidatableFields, Currency) => ValidationResult[AmountMinorUnits],
+    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
+    sendConfirmationEmail: (Option[SfContactId], ContributionsEmailData) => AsyncApiGatewayOp[Unit]
+  )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = {
+    for {
+      customerData <- getCustomerData(request.zuoraAccountId).toAsync
+      ContributionCustomerData(account, paymentMethod, subscriptions, contacts) = customerData
+      validatableFields = ValidatableFields(request.amountMinorUnits, request.startDate)
+      amountMinorUnits <- contributionValidations(validatableFields, account.currency).toApiGatewayOp.toAsync
+      acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
+      planAndCharge <- getPlanAndCharge(request.planId).toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!")).toAsync
+      chargeOverride = ChargeOverride(amountMinorUnits, planAndCharge.productRatePlanChargeId)
+      zuoraCreateSubRequest = createZuoraSubRequest(request, acceptanceDate, Some(chargeOverride), planAndCharge.productRatePlanId)
+      subscriptionName <- createSubscription(zuoraCreateSubRequest).toAsyncApiGatewayOp("create monthly contribution")
+      contributionEmailData = toContributionEmailData(request, account.currency, paymentMethod, acceptanceDate, contacts.billTo, amountMinorUnits)
+      _ <- sendConfirmationEmail(account.sfContactId, contributionEmailData).recoverAndLog("send contribution confirmation email")
+    } yield subscriptionName
+  }
+
+  def wireSteps(
+    zuoraIds: ZuoraIds,
+    zuoraClient:Requests,
+    isValidStartDateForPlan: (PlanId, LocalDate) => ValidationResult[Unit],
+    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
+    awsSQSSend: QueueName => AwsSQSSend.Payload => Future[Unit],
+    emailQueueNames: EmailQueueNames,
+    currentDate: () => LocalDate
+  ) :AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
+
+    val planAndChargeForContributionPlanId = zuoraIds.contributionsZuoraIds.byApiPlanId.get _
+    val contributionIds = List(zuoraIds.contributionsZuoraIds.monthly.productRatePlanId, zuoraIds.contributionsZuoraIds.annual.productRatePlanId)
+    val getCustomerData = getValidatedContributionCustomerData(zuoraClient, contributionIds)
+    val isValidContributionStartDate = isValidStartDateForPlan(MonthlyContribution, _: LocalDate)
+    val validateRequest = ContributionValidations(isValidContributionStartDate, AmountLimits.limitsFor) _
+    val contributionSqsSend = awsSQSSend(emailQueueNames.contributions)
+    val contributionEtSqsSend = EtSqsSend[ContributionFields](contributionSqsSend) _
+    val sendConfirmationEmail = SendConfirmationEmailContributions(contributionEtSqsSend, currentDate) _
+
+    Contributions.steps(planAndChargeForContributionPlanId, getCustomerData, validateRequest, createSubscription, sendConfirmationEmail) _
+
+  }
+
+  //TODO DUPLICATION HERE
+  def createZuoraSubRequest(
+    request: AddSubscriptionRequest,
+    acceptanceDate: LocalDate,
+    chargeOverride: Option[ChargeOverride],
+    productRatePlanId: ProductRatePlanId
+  ) = ZuoraCreateSubRequest(
+    productRatePlanId = productRatePlanId,
+    accountId = request.zuoraAccountId,
+    maybeChargeOverride = chargeOverride,
+    acceptanceDate = acceptanceDate,
+    acquisitionCase = request.acquisitionCase,
+    acquisitionSource = request.acquisitionSource,
+    createdByCSR = request.createdByCSR
+  )
+
+  def paymentDelayFor(paymentMethod: PaymentMethod): Long = paymentMethod match {
+    case d: DirectDebit => 10l
+    case _ => 0l
+  }
+
+  def toContributionEmailData(
+    request: AddSubscriptionRequest,
+    currency: Currency,
+    paymentMethod: PaymentMethod,
+    firstPaymentDate: LocalDate,
+    billToContact: BillToContact,
+    amountMinorUnits: AmountMinorUnits
+  ) =
+    ContributionsEmailData(
+      accountId = request.zuoraAccountId,
+      currency = currency,
+      paymentMethod = paymentMethod,
+      amountMinorUnits = amountMinorUnits,
+      firstPaymentDate = firstPaymentDate,
+      billTo = billToContact,
+      planId = request.planId
+    )
+
+  def getValidatedContributionCustomerData(
+    zuoraClient: Requests,
+    contributionPlanIds: List[ProductRatePlanId]
+  ): ZuoraAccountId => ApiGatewayOp[ContributionCustomerData] = {
+
+    val validateAccount = ValidateAccount.apply _ thenValidate ContributionAccountValidation.apply _
+    val getValidatedAccount = GetAccount(zuoraClient.get[ZuoraAccount]) _ andValidateWith (
+      validate = validateAccount,
+      ifNotFoundReturn = Some("Zuora account id is not valid")
+    )
+    val getValidatedPaymentMethod = GetPaymentMethod(zuoraClient.get[PaymentMethodWire]) _ andValidateWith ValidatePaymentMethod.apply _
+    val validateSubs = ValidateSubscriptions(contributionPlanIds) _
+    val getValidatedSubs = GetAccountSubscriptions(zuoraClient.get[ZuoraSubscriptionsResponse]) _ andValidateWith validateSubs
+    val getContactsFromZuora = GetContacts(zuoraClient.get[GetContactsResponse]) _
+    val getUnvalidatedContacts = getContactsFromZuora.andThen(_.toApiGatewayOp("getting contacts from Zuora"))
+    GetContributionCustomerData(
+      getAccount = getValidatedAccount,
+      getPaymentMethod = getValidatedPaymentMethod,
+      getContacts = getUnvalidatedContacts,
+      getAccountSubscriptions = getValidatedSubs,
+      _
+    )
+  }
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -61,7 +61,6 @@ object Steps {
     }
   } yield ApiGatewayResponse(body = AddedSubscription(subscriptionName.value), statusCode = "200")).apiResponse
 
-
   def operationForEffects(
     response: Request => Response,
     stage: Stage,
@@ -95,8 +94,8 @@ object Steps {
       )
       createSubscription = CreateSubscription(zuoraClient.post[WireCreateRequest, WireSubscription], currentDate) _
 
-
-      contributionSteps = Contributions.wireSteps(zuoraIds,
+      contributionSteps = AddContribution.wireSteps(
+        zuoraIds,
         zuoraClient,
         isValidStartDateForPlan,
         createSubscription,
@@ -105,7 +104,7 @@ object Steps {
         currentDate
       )
 
-        voucherSteps = Vouchers.wireSteps(
+      voucherSteps = AddVoucher.wireSteps(
         catalog,
         zuoraIds,
         zuoraClient,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -99,8 +99,7 @@ object Steps {
         isValidStartDateForPlan,
         createSubscription,
         awsSQSSend,
-        queueNames,
-        currentDate
+        queueNames
       )
 
       addSubSteps = handleRequest(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -7,40 +7,27 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.effects.sqs.AwsSQSSend.QueueName
 import com.gu.effects.{GetFromS3, RawEffects}
-import com.gu.i18n.Currency
+import com.gu.newproduct.api.EmailQueueNames.emailQueuesFor
 import com.gu.newproduct.api.addsubscription.TypeConvert._
 import com.gu.newproduct.api.addsubscription.email.EtSqsSend
-import com.gu.newproduct.api.addsubscription.email.contributions.SendConfirmationEmailContributions.ContributionsEmailData
-import com.gu.newproduct.api.addsubscription.email.contributions.{ContributionFields, SendConfirmationEmailContributions}
-import com.gu.newproduct.api.addsubscription.email.voucher.{SendConfirmationEmailVoucher, VoucherEmailData}
-import com.gu.newproduct.api.addsubscription.validation.Validation._
-import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionValidations.ValidatableFields
-import com.gu.newproduct.api.addsubscription.validation.contribution.{ContributionAccountValidation, ContributionCustomerData, ContributionValidations, GetContributionCustomerData}
-import com.gu.newproduct.api.addsubscription.validation.voucher.{GetVoucherCustomerData, ValidateContactsForVoucher, VoucherAccountValidation, VoucherCustomerData}
-import com.gu.newproduct.api.addsubscription.validation.{ValidationResult, _}
+import com.gu.newproduct.api.addsubscription.email.contributions.ContributionFields
+import com.gu.newproduct.api.addsubscription.validation._
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.WireModel.{WireCreateRequest, WireSubscription}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest}
-import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
-import com.gu.newproduct.api.addsubscription.zuora.GetAccountSubscriptions.WireModel.ZuoraSubscriptionsResponse
-import com.gu.newproduct.api.addsubscription.zuora.GetContacts.BillToContact
-import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
-import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod, PaymentMethodWire}
-import com.gu.newproduct.api.addsubscription.zuora.{GetContacts, _}
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.{DirectDebit, PaymentMethod}
+import com.gu.newproduct.api.addsubscription.zuora._
 import com.gu.newproduct.api.productcatalog.PlanId.{AnnualContribution, MonthlyContribution}
-import com.gu.newproduct.api.productcatalog.ZuoraIds.{PlanAndCharge, ProductRatePlanId}
+import com.gu.newproduct.api.productcatalog.ZuoraIds.ProductRatePlanId
 import com.gu.newproduct.api.productcatalog._
 import com.gu.util.Logging
 import com.gu.util.apigateway.ApiGatewayHandler.{LambdaIO, Operation}
-import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
 import com.gu.util.apigateway.ResponseModels.ApiResponse
 import com.gu.util.apigateway.{ApiGatewayHandler, ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.util.config.LoadConfigModule.StringFromS3
 import com.gu.util.config.{LoadConfigModule, Stage, ZuoraEnvironment}
 import com.gu.util.reader.AsyncTypes._
 import com.gu.util.reader.Types._
-import com.gu.util.resthttp.RestRequestMaker.Requests
-import com.gu.util.resthttp.Types.ClientFailableOp
 import com.gu.util.zuora.{ZuoraRestConfig, ZuoraRestRequestMaker}
 import okhttp3.{Request, Response}
 
@@ -55,43 +42,11 @@ object Handler extends Logging {
 }
 
 object Steps {
-  def createZuoraSubRequest(
-    request: AddSubscriptionRequest,
-    acceptanceDate: LocalDate,
-    chargeOverride: Option[ChargeOverride],
-    productRatePlanId: ProductRatePlanId
-  ) = ZuoraCreateSubRequest(
-    productRatePlanId = productRatePlanId,
-    accountId = request.zuoraAccountId,
-    maybeChargeOverride = chargeOverride,
-    acceptanceDate = acceptanceDate,
-    acquisitionCase = request.acquisitionCase,
-    acquisitionSource = request.acquisitionSource,
-    createdByCSR = request.createdByCSR
-  )
 
   def paymentDelayFor(paymentMethod: PaymentMethod): Long = paymentMethod match {
     case d: DirectDebit => 10l
     case _ => 0l
   }
-
-  def toContributionEmailData(
-    request: AddSubscriptionRequest,
-    currency: Currency,
-    paymentMethod: PaymentMethod,
-    firstPaymentDate: LocalDate,
-    billToContact: BillToContact,
-    amountMinorUnits: AmountMinorUnits
-  ) =
-    ContributionsEmailData(
-      accountId = request.zuoraAccountId,
-      currency = currency,
-      paymentMethod = paymentMethod,
-      amountMinorUnits = amountMinorUnits,
-      firstPaymentDate = firstPaymentDate,
-      billTo = billToContact,
-      planId = request.planId
-    )
 
   def handleRequest(
     addContribution: AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName],
@@ -106,57 +61,6 @@ object Steps {
     }
   } yield ApiGatewayResponse(body = AddedSubscription(subscriptionName.value), statusCode = "200")).apiResponse
 
-  def addContributionSteps(
-    getPlanAndCharge: PlanId => Option[PlanAndCharge],
-    getCustomerData: ZuoraAccountId => ApiGatewayOp[ContributionCustomerData],
-    contributionValidations: (ValidatableFields, Currency) => ValidationResult[AmountMinorUnits],
-    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
-    sendConfirmationEmail: (Option[SfContactId], ContributionsEmailData) => AsyncApiGatewayOp[Unit]
-  )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = {
-    for {
-      customerData <- getCustomerData(request.zuoraAccountId).toAsync
-      ContributionCustomerData(account, paymentMethod, subscriptions, contacts) = customerData
-      validatableFields = ValidatableFields(request.amountMinorUnits, request.startDate)
-      amountMinorUnits <- contributionValidations(validatableFields, account.currency).toApiGatewayOp.toAsync
-      acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
-      planAndCharge <- getPlanAndCharge(request.planId).toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!")).toAsync
-      chargeOverride = ChargeOverride(amountMinorUnits, planAndCharge.productRatePlanChargeId)
-      zuoraCreateSubRequest = createZuoraSubRequest(request, acceptanceDate, Some(chargeOverride), planAndCharge.productRatePlanId)
-      subscriptionName <- createSubscription(zuoraCreateSubRequest).toAsyncApiGatewayOp("create monthly contribution")
-      contributionEmailData = toContributionEmailData(request, account.currency, paymentMethod, acceptanceDate, contacts.billTo, amountMinorUnits)
-      _ <- sendConfirmationEmail(account.sfContactId, contributionEmailData).recoverAndLog("send contribution confirmation email")
-    } yield subscriptionName
-  }
-
-  def addVoucherSteps(
-    getPlan: PlanId => Plan,
-    getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
-    getCustomerData: ZuoraAccountId => ApiGatewayOp[VoucherCustomerData],
-    validateStartDate: (PlanId, LocalDate) => ValidationResult[Unit],
-    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
-    sendConfirmationEmail: (Option[SfContactId], VoucherEmailData) => AsyncApiGatewayOp[Unit]
-  )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = for {
-    _ <- validateStartDate(request.planId, request.startDate).toApiGatewayOp.toAsync
-    customerData <- getCustomerData(request.zuoraAccountId).toAsync
-    zuoraRatePlanId <- getZuoraRateplanId(request.planId).toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!")).toAsync
-    createSubRequest = createZuoraSubRequest(
-      request = request,
-      acceptanceDate = request.startDate,
-      chargeOverride = None,
-      productRatePlanId = zuoraRatePlanId
-    )
-    subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create voucher subscription")
-    plan = getPlan(request.planId)
-    voucherEmailData = VoucherEmailData(
-      plan = plan,
-      firstPaymentDate = request.startDate,
-      firstPaperDate = request.startDate,
-      subscriptionName = subscriptionName,
-      contacts = customerData.contacts,
-      paymentMethod = customerData.paymentMethod
-    )
-    _ <- sendConfirmationEmail(customerData.account.sfContactId, voucherEmailData).recoverAndLog("send voucher confirmation email")
-  } yield subscriptionName
 
   def operationForEffects(
     response: Request => Response,
@@ -176,8 +80,9 @@ object Steps {
 
       contributionSqsSend = awsSQSSend(queueNames.contributions)
       contributionEtSqsSend = EtSqsSend[ContributionFields](contributionSqsSend) _
-      getCurrentDate = () => RawEffects.now().toLocalDate
-      validatorFor = DateValidator.validatorFor(getCurrentDate, _: DateRule)
+      currentDate = () => currentDatetime().toLocalDate
+
+      validatorFor = DateValidator.validatorFor(currentDate, _: DateRule)
       zuoraToPlanId = zuoraIds.voucherZuoraIds.zuoraIdToPlanid.get _
       zuoraEnv = ZuoraEnvironment.EnvForStage(stage)
       plansWithPrice <- PricesFromZuoraCatalog(zuoraEnv, fetchString, zuoraToPlanId).toApiGatewayOp("get prices from zuora catalog")
@@ -188,30 +93,28 @@ object Steps {
           StartDateValidator.fromRule(validatorFor, plan.startDateRules)
         }
       )
-      currentDate = () => currentDatetime().toLocalDate
       createSubscription = CreateSubscription(zuoraClient.post[WireCreateRequest, WireSubscription], currentDate) _
-      contributionIds = List(zuoraIds.contributionsZuoraIds.monthly.productRatePlanId, zuoraIds.contributionsZuoraIds.annual.productRatePlanId)
-      getCustomerData = getValidatedContributionCustomerData(zuoraClient, contributionIds)
-      isValidContributionStartDate = isValidStartDateForPlan(MonthlyContribution, _: LocalDate)
-      validateRequest = ContributionValidations(isValidContributionStartDate, AmountLimits.limitsFor) _
 
-      sendConfirmationEmail = SendConfirmationEmailContributions(contributionEtSqsSend, getCurrentDate) _
-      planAndChargeForContributionPlanId = zuoraIds.contributionsZuoraIds.byApiPlanId.get _
-      contributionSteps = addContributionSteps(planAndChargeForContributionPlanId, getCustomerData, validateRequest, createSubscription, sendConfirmationEmail) _
-      voucherSqsSend = awsSQSSend(queueNames.voucher)
-      voucherEtSqsSend = EtSqsSend[VoucherEmailData](voucherSqsSend) _
-      sendVoucherEmail = SendConfirmationEmailVoucher(voucherEtSqsSend, getCurrentDate) _
 
-      getZuoraIdForVoucherPlan = zuoraIds.voucherZuoraIds.byApiPlanId.get _
-      getVoucherData = getValidatedVoucherCustomerData(zuoraClient)
-      voucherSteps = addVoucherSteps(
-        catalog.planForId,
-        getZuoraIdForVoucherPlan,
-        getVoucherData,
+      contributionSteps = Contributions.wireSteps(zuoraIds,
+        zuoraClient,
         isValidStartDateForPlan,
         createSubscription,
-        sendVoucherEmail
-      ) _
+        awsSQSSend,
+        queueNames,
+        currentDate
+      )
+
+        voucherSteps = Vouchers.wireSteps(
+        catalog,
+        zuoraIds,
+        zuoraClient,
+        isValidStartDateForPlan,
+        createSubscription,
+        awsSQSSend,
+        queueNames,
+        currentDate
+      )
 
       addSubSteps = handleRequest(
         addContribution = contributionSteps,
@@ -224,54 +127,6 @@ object Steps {
           HealthCheck(GetAccount(zuoraClient.get[ZuoraAccount]), AccountIdentitys.accountIdentitys(stage))
       )
     } yield configuredOp
-
-  def getValidatedContributionCustomerData(
-    zuoraClient: Requests,
-    contributionPlanIds: List[ProductRatePlanId]
-  ): ZuoraAccountId => ApiGatewayOp[ContributionCustomerData] = {
-
-    val validateAccount = ValidateAccount.apply _ thenValidate ContributionAccountValidation.apply _
-    val getValidatedAccount = GetAccount(zuoraClient.get[ZuoraAccount]) _ andValidateWith (
-      validate = validateAccount,
-      ifNotFoundReturn = Some("Zuora account id is not valid")
-    )
-    val getValidatedPaymentMethod = GetPaymentMethod(zuoraClient.get[PaymentMethodWire]) _ andValidateWith ValidatePaymentMethod.apply _
-    val validateSubs = ValidateSubscriptions(contributionPlanIds) _
-    val getValidatedSubs = GetAccountSubscriptions(zuoraClient.get[ZuoraSubscriptionsResponse]) _ andValidateWith validateSubs
-    val getContactsFromZuora = GetContacts(zuoraClient.get[GetContactsResponse]) _
-    val getUnvalidatedContacts = getContactsFromZuora.andThen(_.toApiGatewayOp("getting contacts from Zuora"))
-    GetContributionCustomerData(
-      getAccount = getValidatedAccount,
-      getPaymentMethod = getValidatedPaymentMethod,
-      getContacts = getUnvalidatedContacts,
-      getAccountSubscriptions = getValidatedSubs,
-      _
-    )
-  }
-
-  def getValidatedVoucherCustomerData(zuoraClient: Requests): ZuoraAccountId => ApiGatewayOp[VoucherCustomerData] = {
-
-    val validateAccount = ValidateAccount.apply _ thenValidate VoucherAccountValidation.apply _
-    val getValidatedAccount = GetAccount(zuoraClient.get[ZuoraAccount]) _ andValidateWith (
-      validate = validateAccount,
-      ifNotFoundReturn = Some("Zuora account id is not valid")
-    )
-    val getValidatedPaymentMethod = GetPaymentMethod(zuoraClient.get[PaymentMethodWire]) _ andValidateWith ValidatePaymentMethod.apply _
-    val getContacts = GetContacts(zuoraClient.get[GetContactsResponse]) _
-    val getValidatedContacts = getContacts andValidateWith (ValidateContactsForVoucher.apply _)
-    GetVoucherCustomerData(
-      getAccount = getValidatedAccount,
-      getPaymentMethod = getValidatedPaymentMethod,
-      getContacts = getValidatedContacts,
-      _
-    )
-  }
-
-  case class EmailQueueNames(contributions: QueueName, voucher: QueueName)
-  def emailQueuesFor(stage: Stage) = stage match {
-    case Stage("PROD") | Stage("CODE") => EmailQueueNames(contributions = QueueName("contributions-thanks"), voucher = QueueName("subs-welcome-email"))
-    case _ => EmailQueueNames(contributions = QueueName("contributions-thanks-dev"), voucher = QueueName("subs-welcome-email-dev"))
-  }
 
 }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Vouchers.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Vouchers.scala
@@ -1,0 +1,120 @@
+package com.gu.newproduct.api.addsubscription
+
+import java.time.LocalDate
+
+import com.gu.effects.sqs.AwsSQSSend
+import com.gu.effects.sqs.AwsSQSSend.QueueName
+import com.gu.newproduct.api.EmailQueueNames
+import com.gu.newproduct.api.addsubscription.TypeConvert._
+import com.gu.newproduct.api.addsubscription.email.EtSqsSend
+import com.gu.newproduct.api.addsubscription.email.voucher.{SendConfirmationEmailVoucher, VoucherEmailData}
+import com.gu.newproduct.api.addsubscription.validation.Validation._
+import com.gu.newproduct.api.addsubscription.validation.voucher.{GetVoucherCustomerData, ValidateContactsForVoucher, VoucherAccountValidation, VoucherCustomerData}
+import com.gu.newproduct.api.addsubscription.validation.{ValidateAccount, ValidatePaymentMethod, ValidationResult}
+import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.{ChargeOverride, SubscriptionName, ZuoraCreateSubRequest}
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
+import com.gu.newproduct.api.addsubscription.zuora.GetAccount.WireModel.ZuoraAccount
+import com.gu.newproduct.api.addsubscription.zuora.GetContacts.WireModel.GetContactsResponse
+import com.gu.newproduct.api.addsubscription.zuora.GetPaymentMethod.PaymentMethodWire
+import com.gu.newproduct.api.addsubscription.zuora.{GetAccount, GetContacts, GetPaymentMethod}
+import com.gu.newproduct.api.productcatalog.ZuoraIds.{ProductRatePlanId, ZuoraIds}
+import com.gu.newproduct.api.productcatalog.{Catalog, Plan, PlanId}
+import com.gu.util.apigateway.ApiGatewayResponse.internalServerError
+import com.gu.util.reader.AsyncTypes.{AsyncApiGatewayOp, _}
+import com.gu.util.reader.Types.{ApiGatewayOp, OptionOps}
+import com.gu.util.resthttp.RestRequestMaker.Requests
+import com.gu.util.resthttp.Types.ClientFailableOp
+
+import scala.concurrent.Future
+
+object Vouchers {
+  def steps(
+    getPlan: PlanId => Plan,
+    getZuoraRateplanId: PlanId => Option[ProductRatePlanId],
+    getCustomerData: ZuoraAccountId => ApiGatewayOp[VoucherCustomerData],
+    validateStartDate: (PlanId, LocalDate) => ValidationResult[Unit],
+    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
+    sendConfirmationEmail: (Option[SfContactId], VoucherEmailData) => AsyncApiGatewayOp[Unit]
+  )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = for {
+    _ <- validateStartDate(request.planId, request.startDate).toApiGatewayOp.toAsync
+    customerData <- getCustomerData(request.zuoraAccountId).toAsync
+    zuoraRatePlanId <- getZuoraRateplanId(request.planId).toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!")).toAsync
+    createSubRequest = createZuoraSubRequest(
+      request = request,
+      acceptanceDate = request.startDate,
+      chargeOverride = None,
+      productRatePlanId = zuoraRatePlanId
+    )
+    subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create voucher subscription")
+    plan = getPlan(request.planId)
+    voucherEmailData = VoucherEmailData(
+      plan = plan,
+      firstPaymentDate = request.startDate,
+      firstPaperDate = request.startDate,
+      subscriptionName = subscriptionName,
+      contacts = customerData.contacts,
+      paymentMethod = customerData.paymentMethod
+    )
+    _ <- sendConfirmationEmail(customerData.account.sfContactId, voucherEmailData).recoverAndLog("send voucher confirmation email")
+  } yield subscriptionName
+
+
+  def wireSteps(
+    catalog: Catalog,
+    zuoraIds: ZuoraIds,
+    zuoraClient: Requests,
+    isValidStartDateForPlan: (PlanId, LocalDate) => ValidationResult[Unit],
+    createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
+    awsSQSSend: QueueName => AwsSQSSend.Payload => Future[Unit],
+    emailQueueNames: EmailQueueNames,
+    currentDate: () => LocalDate
+  ): AddSubscriptionRequest => AsyncApiGatewayOp[SubscriptionName] = {
+    val voucherSqsSend = awsSQSSend(emailQueueNames.voucher)
+    val voucherEtSqsSend = EtSqsSend[VoucherEmailData](voucherSqsSend) _
+    val sendVoucherEmail = SendConfirmationEmailVoucher(voucherEtSqsSend, currentDate) _
+    val  getZuoraIdForVoucherPlan = zuoraIds.voucherZuoraIds.byApiPlanId.get _
+    val  getVoucherData = getValidatedVoucherCustomerData(zuoraClient)
+    steps(
+      catalog.planForId,
+      getZuoraIdForVoucherPlan,
+      getVoucherData,
+      isValidStartDateForPlan,
+      createSubscription,
+      sendVoucherEmail
+    )
+  }
+
+  def getValidatedVoucherCustomerData(zuoraClient: Requests): ZuoraAccountId => ApiGatewayOp[VoucherCustomerData] = {
+
+    val validateAccount = ValidateAccount.apply _ thenValidate VoucherAccountValidation.apply _
+    val getValidatedAccount = GetAccount(zuoraClient.get[ZuoraAccount]) _ andValidateWith (
+      validate = validateAccount,
+      ifNotFoundReturn = Some("Zuora account id is not valid")
+    )
+    val getValidatedPaymentMethod = GetPaymentMethod(zuoraClient.get[PaymentMethodWire]) _ andValidateWith ValidatePaymentMethod.apply _
+    val getContacts = GetContacts(zuoraClient.get[GetContactsResponse]) _
+    val getValidatedContacts = getContacts andValidateWith (ValidateContactsForVoucher.apply _)
+    GetVoucherCustomerData(
+      getAccount = getValidatedAccount,
+      getPaymentMethod = getValidatedPaymentMethod,
+      getContacts = getValidatedContacts,
+      _
+    )
+  }
+
+//TODO DUPLICATION HERE
+  def createZuoraSubRequest(
+    request: AddSubscriptionRequest,
+    acceptanceDate: LocalDate,
+    chargeOverride: Option[ChargeOverride],
+    productRatePlanId: ProductRatePlanId
+  ) = ZuoraCreateSubRequest(
+    productRatePlanId = productRatePlanId,
+    accountId = request.zuoraAccountId,
+    maybeChargeOverride = chargeOverride,
+    acceptanceDate = acceptanceDate,
+    acquisitionCase = request.acquisitionCase,
+    acquisitionSource = request.acquisitionSource,
+    createdByCSR = request.createdByCSR
+  )
+}

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
@@ -15,9 +15,7 @@ import scala.concurrent.Future
 object SendConfirmationEmailVoucher extends Logging {
 
   def apply(
-    etSqsSend: ETPayload[VoucherEmailData] => Future[Unit],
-    getCurrentDate: () => LocalDate
-  )(
+    etSqsSend: ETPayload[VoucherEmailData] => Future[Unit])(
     sfContactId: Option[SfContactId],
     data: VoucherEmailData
   ): AsyncApiGatewayOp[Unit] = for {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucher.scala
@@ -1,7 +1,5 @@
 package com.gu.newproduct.api.addsubscription.email.voucher
 
-import java.time.LocalDate
-
 import com.gu.newproduct.api.addsubscription.email.{DataExtensionName, ETPayload}
 import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.util.Logging
@@ -15,7 +13,8 @@ import scala.concurrent.Future
 object SendConfirmationEmailVoucher extends Logging {
 
   def apply(
-    etSqsSend: ETPayload[VoucherEmailData] => Future[Unit])(
+    etSqsSend: ETPayload[VoucherEmailData] => Future[Unit]
+  )(
     sfContactId: Option[SfContactId],
     data: VoucherEmailData
   ): AsyncApiGatewayOp[Unit] = for {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscription.scala
@@ -88,6 +88,22 @@ object CreateSubscription {
     createdByCSR: CreatedByCSR
   )
 
+  object ZuoraCreateSubRequest {
+    def apply(
+      request: AddSubscriptionRequest,
+      acceptanceDate: LocalDate,
+      chargeOverride: Option[ChargeOverride],
+      productRatePlanId: ProductRatePlanId
+    ): ZuoraCreateSubRequest = ZuoraCreateSubRequest(
+      productRatePlanId = productRatePlanId,
+      accountId = request.zuoraAccountId,
+      maybeChargeOverride = chargeOverride,
+      acceptanceDate = acceptanceDate,
+      acquisitionCase = request.acquisitionCase,
+      acquisitionSource = request.acquisitionSource,
+      createdByCSR = request.createdByCSR
+    )
+  }
   case class SubscriptionName(value: String) extends AnyVal
 
   def apply(

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -26,79 +26,79 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class ContributionStepsTest extends FlatSpec with Matchers {
-
-  case class ExpectedOut(subscriptionNumber: String)
-
-  it should "run end to end with fakes" in {
-
-    val planAndCharge = PlanAndCharge(
-      ProductRatePlanId("ratePlanId"),
-      ProductRatePlanChargeId("ratePlanChargeId")
-    )
-
-    def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
-
-    val expectedIn = ZuoraCreateSubRequest(
-      planAndCharge.productRatePlanId,
-      ZuoraAccountId("acccc"),
-      Some(ChargeOverride(
-        AmountMinorUnits(123),
-        planAndCharge.productRatePlanChargeId
-      )),
-      LocalDate.of(2018, 7, 28),
-      CaseId("case"),
-      AcquisitionSource("CSR"),
-      CreatedByCSR("bob")
-    )
-
-    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
-      in shouldBe expectedIn
-      ClientSuccess(SubscriptionName("well done"))
-    }
-
-    def fakeSendEmails(sfContactId: Option[SfContactId], contributionsEmailData: ContributionsEmailData) = {
-      ContinueProcessing(()).toAsync
-    }
-
-    def fakeValidateRequest(fields: ValidatableFields, currency: Currency) = {
-      fields.amountMinorUnits.map(Passed(_)).getOrElse(Failed("missing amount"))
-    }
-
-    def fakeGetCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.contributionCustomerData)
-
-    val requestInput = JsObject(Map(
-      "acquisitionCase" -> JsString("case"),
-      "amountMinorUnits" -> JsNumber(123),
-      "startDate" -> JsString("2018-07-18"),
-      "zuoraAccountId" -> JsString("acccc"),
-      "acquisitionSource" -> JsString("CSR"),
-      "createdByCSR" -> JsString("bob"),
-      "planId" -> JsString("monthly_contribution")
-
-    ))
-
-    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
-    val expectedOutput = ExpectedOut("well done")
-
-    val fakeAddContributionSteps = Steps.addContributionSteps(
-      getPlanAndCharge,
-      fakeGetCustomerData,
-      fakeValidateRequest,
-      fakeCreate,
-      fakeSendEmails
-    ) _
-
-    val dummyVoucherSteps = (req: AddSubscriptionRequest) => {
-      fail("unexpected execution of voucher steps while processing contribution request!")
-    }
-    val futureActual = Steps.handleRequest(
-      addContribution = fakeAddContributionSteps,
-      addVoucher = dummyVoucherSteps
-    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
-
-    val actual = Await.result(futureActual, 30 seconds)
-    actual.statusCode should be("200")
-    actual.body jsonMatchesFormat expectedOutput
-  }
+//
+//  case class ExpectedOut(subscriptionNumber: String)
+//
+//  it should "run end to end with fakes" in {
+//
+//    val planAndCharge = PlanAndCharge(
+//      ProductRatePlanId("ratePlanId"),
+//      ProductRatePlanChargeId("ratePlanChargeId")
+//    )
+//
+//    def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
+//
+//    val expectedIn = ZuoraCreateSubRequest(
+//      planAndCharge.productRatePlanId,
+//      ZuoraAccountId("acccc"),
+//      Some(ChargeOverride(
+//        AmountMinorUnits(123),
+//        planAndCharge.productRatePlanChargeId
+//      )),
+//      LocalDate.of(2018, 7, 28),
+//      CaseId("case"),
+//      AcquisitionSource("CSR"),
+//      CreatedByCSR("bob")
+//    )
+//
+//    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
+//      in shouldBe expectedIn
+//      ClientSuccess(SubscriptionName("well done"))
+//    }
+//
+//    def fakeSendEmails(sfContactId: Option[SfContactId], contributionsEmailData: ContributionsEmailData) = {
+//      ContinueProcessing(()).toAsync
+//    }
+//
+//    def fakeValidateRequest(fields: ValidatableFields, currency: Currency) = {
+//      fields.amountMinorUnits.map(Passed(_)).getOrElse(Failed("missing amount"))
+//    }
+//
+//    def fakeGetCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.contributionCustomerData)
+//
+//    val requestInput = JsObject(Map(
+//      "acquisitionCase" -> JsString("case"),
+//      "amountMinorUnits" -> JsNumber(123),
+//      "startDate" -> JsString("2018-07-18"),
+//      "zuoraAccountId" -> JsString("acccc"),
+//      "acquisitionSource" -> JsString("CSR"),
+//      "createdByCSR" -> JsString("bob"),
+//      "planId" -> JsString("monthly_contribution")
+//
+//    ))
+//
+//    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
+//    val expectedOutput = ExpectedOut("well done")
+//
+//    val fakeAddContributionSteps = Steps.addContributionSteps(
+//      getPlanAndCharge,
+//      fakeGetCustomerData,
+//      fakeValidateRequest,
+//      fakeCreate,
+//      fakeSendEmails
+//    ) _
+//
+//    val dummyVoucherSteps = (req: AddSubscriptionRequest) => {
+//      fail("unexpected execution of voucher steps while processing contribution request!")
+//    }
+//    val futureActual = Steps.handleRequest(
+//      addContribution = fakeAddContributionSteps,
+//      addVoucher = dummyVoucherSteps
+//    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
+//
+//    val actual = Await.result(futureActual, 30 seconds)
+//    actual.statusCode should be("200")
+//    actual.body jsonMatchesFormat expectedOutput
+//  }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -26,79 +26,79 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class ContributionStepsTest extends FlatSpec with Matchers {
-//
-//  case class ExpectedOut(subscriptionNumber: String)
-//
-//  it should "run end to end with fakes" in {
-//
-//    val planAndCharge = PlanAndCharge(
-//      ProductRatePlanId("ratePlanId"),
-//      ProductRatePlanChargeId("ratePlanChargeId")
-//    )
-//
-//    def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
-//
-//    val expectedIn = ZuoraCreateSubRequest(
-//      planAndCharge.productRatePlanId,
-//      ZuoraAccountId("acccc"),
-//      Some(ChargeOverride(
-//        AmountMinorUnits(123),
-//        planAndCharge.productRatePlanChargeId
-//      )),
-//      LocalDate.of(2018, 7, 28),
-//      CaseId("case"),
-//      AcquisitionSource("CSR"),
-//      CreatedByCSR("bob")
-//    )
-//
-//    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
-//      in shouldBe expectedIn
-//      ClientSuccess(SubscriptionName("well done"))
-//    }
-//
-//    def fakeSendEmails(sfContactId: Option[SfContactId], contributionsEmailData: ContributionsEmailData) = {
-//      ContinueProcessing(()).toAsync
-//    }
-//
-//    def fakeValidateRequest(fields: ValidatableFields, currency: Currency) = {
-//      fields.amountMinorUnits.map(Passed(_)).getOrElse(Failed("missing amount"))
-//    }
-//
-//    def fakeGetCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.contributionCustomerData)
-//
-//    val requestInput = JsObject(Map(
-//      "acquisitionCase" -> JsString("case"),
-//      "amountMinorUnits" -> JsNumber(123),
-//      "startDate" -> JsString("2018-07-18"),
-//      "zuoraAccountId" -> JsString("acccc"),
-//      "acquisitionSource" -> JsString("CSR"),
-//      "createdByCSR" -> JsString("bob"),
-//      "planId" -> JsString("monthly_contribution")
-//
-//    ))
-//
-//    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
-//    val expectedOutput = ExpectedOut("well done")
-//
-//    val fakeAddContributionSteps = Steps.addContributionSteps(
-//      getPlanAndCharge,
-//      fakeGetCustomerData,
-//      fakeValidateRequest,
-//      fakeCreate,
-//      fakeSendEmails
-//    ) _
-//
-//    val dummyVoucherSteps = (req: AddSubscriptionRequest) => {
-//      fail("unexpected execution of voucher steps while processing contribution request!")
-//    }
-//    val futureActual = Steps.handleRequest(
-//      addContribution = fakeAddContributionSteps,
-//      addVoucher = dummyVoucherSteps
-//    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
-//
-//    val actual = Await.result(futureActual, 30 seconds)
-//    actual.statusCode should be("200")
-//    actual.body jsonMatchesFormat expectedOutput
-//  }
+
+  case class ExpectedOut(subscriptionNumber: String)
+
+  it should "run end to end with fakes" in {
+
+    val planAndCharge = PlanAndCharge(
+      ProductRatePlanId("ratePlanId"),
+      ProductRatePlanChargeId("ratePlanChargeId")
+    )
+
+    def getPlanAndCharge(planId: PlanId) = Some(planAndCharge)
+
+    val expectedIn = ZuoraCreateSubRequest(
+      planAndCharge.productRatePlanId,
+      ZuoraAccountId("acccc"),
+      Some(ChargeOverride(
+        AmountMinorUnits(123),
+        planAndCharge.productRatePlanChargeId
+      )),
+      LocalDate.of(2018, 7, 28),
+      CaseId("case"),
+      AcquisitionSource("CSR"),
+      CreatedByCSR("bob")
+    )
+
+    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
+      in shouldBe expectedIn
+      ClientSuccess(SubscriptionName("well done"))
+    }
+
+    def fakeSendEmails(sfContactId: Option[SfContactId], contributionsEmailData: ContributionsEmailData) = {
+      ContinueProcessing(()).toAsync
+    }
+
+    def fakeValidateRequest(fields: ValidatableFields, currency: Currency) = {
+      fields.amountMinorUnits.map(Passed(_)).getOrElse(Failed("missing amount"))
+    }
+
+    def fakeGetCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.contributionCustomerData)
+
+    val requestInput = JsObject(Map(
+      "acquisitionCase" -> JsString("case"),
+      "amountMinorUnits" -> JsNumber(123),
+      "startDate" -> JsString("2018-07-18"),
+      "zuoraAccountId" -> JsString("acccc"),
+      "acquisitionSource" -> JsString("CSR"),
+      "createdByCSR" -> JsString("bob"),
+      "planId" -> JsString("monthly_contribution")
+
+    ))
+
+    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
+    val expectedOutput = ExpectedOut("well done")
+
+    val fakeAddContributionSteps = AddContribution.steps(
+      getPlanAndCharge,
+      fakeGetCustomerData,
+      fakeValidateRequest,
+      fakeCreate,
+      fakeSendEmails
+    ) _
+
+    val dummyVoucherSteps = (req: AddSubscriptionRequest) => {
+      fail("unexpected execution of voucher steps while processing contribution request!")
+    }
+    val futureActual = Steps.handleRequest(
+      addContribution = fakeAddContributionSteps,
+      addVoucher = dummyVoucherSteps
+    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
+
+    val actual = Await.result(futureActual, 30 seconds)
+    actual.statusCode should be("200")
+    actual.body jsonMatchesFormat expectedOutput
+  }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -25,74 +25,74 @@ import scala.language.postfixOps
 
 class VoucherStepsTest extends FlatSpec with Matchers {
 
-  case class ExpectedOut(subscriptionNumber: String)
-
-  it should "run end to end with fakes" in {
-    val ratePlanId = ProductRatePlanId("ratePlanId")
-
-    def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
-
-    val requestInput = JsObject(Map(
-      "acquisitionCase" -> JsString("case"),
-      "amountMinorUnits" -> JsNumber(123),
-      "startDate" -> JsString("2018-07-18"),
-      "zuoraAccountId" -> JsString("acccc"),
-      "acquisitionSource" -> JsString("CSR"),
-      "createdByCSR" -> JsString("bob"),
-      "planId" -> JsString("voucher_everyday")
-
-    ))
-
-    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
-    val expectedOutput = ExpectedOut("well done")
-
-    val dummyContributionSteps = (req: AddSubscriptionRequest) => {
-      fail("unexpected execution of contribution steps while processing voucher request!")
-    }
-
-    val expectedIn = ZuoraCreateSubRequest(
-      ratePlanId,
-      ZuoraAccountId("acccc"),
-      None,
-      LocalDate.of(2018, 7, 18),
-      CaseId("case"),
-      AcquisitionSource("CSR"),
-      CreatedByCSR("bob")
-    )
-
-    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
-      in shouldBe expectedIn
-      ClientSuccess(SubscriptionName("well done"))
-    }
-
-    val fakeGetZuoraId = (planId: PlanId) => {
-      planId shouldBe VoucherEveryDay
-      Some(ratePlanId)
-    }
-
-    //todo maybe add assertions on the input params for these two
-    def fakeValidateVoucherStartDate(id: PlanId, d: LocalDate) = Passed(())
-
-    def fakeSendEmail(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData) = ContinueProcessing(()).toAsync
-
-    def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"))
-    val fakeAddVoucherSteps = Steps.addVoucherSteps(
-      fakeGetPlan,
-      fakeGetZuoraId,
-      fakeGetVoucherCustomerData,
-      fakeValidateVoucherStartDate,
-      fakeCreate,
-      fakeSendEmail
-    ) _
-
-    val futureActual = Steps.handleRequest(
-      addContribution = dummyContributionSteps,
-      addVoucher = fakeAddVoucherSteps
-    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
-
-    val actual = Await.result(futureActual, 30 seconds)
-    actual.statusCode should be("200")
-    actual.body jsonMatchesFormat expectedOutput
-  }
+//  case class ExpectedOut(subscriptionNumber: String)
+//
+//  it should "run end to end with fakes" in {
+//    val ratePlanId = ProductRatePlanId("ratePlanId")
+//
+//    def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
+//
+//    val requestInput = JsObject(Map(
+//      "acquisitionCase" -> JsString("case"),
+//      "amountMinorUnits" -> JsNumber(123),
+//      "startDate" -> JsString("2018-07-18"),
+//      "zuoraAccountId" -> JsString("acccc"),
+//      "acquisitionSource" -> JsString("CSR"),
+//      "createdByCSR" -> JsString("bob"),
+//      "planId" -> JsString("voucher_everyday")
+//
+//    ))
+//
+//    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
+//    val expectedOutput = ExpectedOut("well done")
+//
+//    val dummyContributionSteps = (req: AddSubscriptionRequest) => {
+//      fail("unexpected execution of contribution steps while processing voucher request!")
+//    }
+//
+//    val expectedIn = ZuoraCreateSubRequest(
+//      ratePlanId,
+//      ZuoraAccountId("acccc"),
+//      None,
+//      LocalDate.of(2018, 7, 18),
+//      CaseId("case"),
+//      AcquisitionSource("CSR"),
+//      CreatedByCSR("bob")
+//    )
+//
+//    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
+//      in shouldBe expectedIn
+//      ClientSuccess(SubscriptionName("well done"))
+//    }
+//
+//    val fakeGetZuoraId = (planId: PlanId) => {
+//      planId shouldBe VoucherEveryDay
+//      Some(ratePlanId)
+//    }
+//
+//    //todo maybe add assertions on the input params for these two
+//    def fakeValidateVoucherStartDate(id: PlanId, d: LocalDate) = Passed(())
+//
+//    def fakeSendEmail(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData) = ContinueProcessing(()).toAsync
+//
+//    def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"))
+//    val fakeAddVoucherSteps = Steps.addVoucherSteps(
+//      fakeGetPlan,
+//      fakeGetZuoraId,
+//      fakeGetVoucherCustomerData,
+//      fakeValidateVoucherStartDate,
+//      fakeCreate,
+//      fakeSendEmail
+//    ) _
+//
+//    val futureActual = Steps.handleRequest(
+//      addContribution = dummyContributionSteps,
+//      addVoucher = fakeAddVoucherSteps
+//    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
+//
+//    val actual = Await.result(futureActual, 30 seconds)
+//    actual.statusCode should be("200")
+//    actual.body jsonMatchesFormat expectedOutput
+//  }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/VoucherStepsTest.scala
@@ -25,74 +25,74 @@ import scala.language.postfixOps
 
 class VoucherStepsTest extends FlatSpec with Matchers {
 
-//  case class ExpectedOut(subscriptionNumber: String)
-//
-//  it should "run end to end with fakes" in {
-//    val ratePlanId = ProductRatePlanId("ratePlanId")
-//
-//    def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
-//
-//    val requestInput = JsObject(Map(
-//      "acquisitionCase" -> JsString("case"),
-//      "amountMinorUnits" -> JsNumber(123),
-//      "startDate" -> JsString("2018-07-18"),
-//      "zuoraAccountId" -> JsString("acccc"),
-//      "acquisitionSource" -> JsString("CSR"),
-//      "createdByCSR" -> JsString("bob"),
-//      "planId" -> JsString("voucher_everyday")
-//
-//    ))
-//
-//    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
-//    val expectedOutput = ExpectedOut("well done")
-//
-//    val dummyContributionSteps = (req: AddSubscriptionRequest) => {
-//      fail("unexpected execution of contribution steps while processing voucher request!")
-//    }
-//
-//    val expectedIn = ZuoraCreateSubRequest(
-//      ratePlanId,
-//      ZuoraAccountId("acccc"),
-//      None,
-//      LocalDate.of(2018, 7, 18),
-//      CaseId("case"),
-//      AcquisitionSource("CSR"),
-//      CreatedByCSR("bob")
-//    )
-//
-//    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
-//      in shouldBe expectedIn
-//      ClientSuccess(SubscriptionName("well done"))
-//    }
-//
-//    val fakeGetZuoraId = (planId: PlanId) => {
-//      planId shouldBe VoucherEveryDay
-//      Some(ratePlanId)
-//    }
-//
-//    //todo maybe add assertions on the input params for these two
-//    def fakeValidateVoucherStartDate(id: PlanId, d: LocalDate) = Passed(())
-//
-//    def fakeSendEmail(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData) = ContinueProcessing(()).toAsync
-//
-//    def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"))
-//    val fakeAddVoucherSteps = Steps.addVoucherSteps(
-//      fakeGetPlan,
-//      fakeGetZuoraId,
-//      fakeGetVoucherCustomerData,
-//      fakeValidateVoucherStartDate,
-//      fakeCreate,
-//      fakeSendEmail
-//    ) _
-//
-//    val futureActual = Steps.handleRequest(
-//      addContribution = dummyContributionSteps,
-//      addVoucher = fakeAddVoucherSteps
-//    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
-//
-//    val actual = Await.result(futureActual, 30 seconds)
-//    actual.statusCode should be("200")
-//    actual.body jsonMatchesFormat expectedOutput
-//  }
+  case class ExpectedOut(subscriptionNumber: String)
+
+  it should "run end to end with fakes" in {
+    val ratePlanId = ProductRatePlanId("ratePlanId")
+
+    def fakeGetVoucherCustomerData(zuoraAccountId: ZuoraAccountId) = ContinueProcessing(TestData.voucherCustomerData)
+
+    val requestInput = JsObject(Map(
+      "acquisitionCase" -> JsString("case"),
+      "amountMinorUnits" -> JsNumber(123),
+      "startDate" -> JsString("2018-07-18"),
+      "zuoraAccountId" -> JsString("acccc"),
+      "acquisitionSource" -> JsString("CSR"),
+      "createdByCSR" -> JsString("bob"),
+      "planId" -> JsString("voucher_everyday")
+
+    ))
+
+    implicit val format: OFormat[ExpectedOut] = Json.format[ExpectedOut]
+    val expectedOutput = ExpectedOut("well done")
+
+    val dummyContributionSteps = (req: AddSubscriptionRequest) => {
+      fail("unexpected execution of contribution steps while processing voucher request!")
+    }
+
+    val expectedIn = ZuoraCreateSubRequest(
+      ratePlanId,
+      ZuoraAccountId("acccc"),
+      None,
+      LocalDate.of(2018, 7, 18),
+      CaseId("case"),
+      AcquisitionSource("CSR"),
+      CreatedByCSR("bob")
+    )
+
+    def fakeCreate(in: CreateSubscription.ZuoraCreateSubRequest): Types.ClientFailableOp[CreateSubscription.SubscriptionName] = {
+      in shouldBe expectedIn
+      ClientSuccess(SubscriptionName("well done"))
+    }
+
+    val fakeGetZuoraId = (planId: PlanId) => {
+      planId shouldBe VoucherEveryDay
+      Some(ratePlanId)
+    }
+
+    //todo maybe add assertions on the input params for these two
+    def fakeValidateVoucherStartDate(id: PlanId, d: LocalDate) = Passed(())
+
+    def fakeSendEmail(sfContactId: Option[SfContactId], voucherEmailData: VoucherEmailData) = ContinueProcessing(()).toAsync
+
+    def fakeGetPlan(planId: PlanId) = Plan(VoucherEveryDay, PlanDescription("Everyday"))
+    val fakeAddVoucherSteps = AddVoucher.steps(
+      fakeGetPlan,
+      fakeGetZuoraId,
+      fakeGetVoucherCustomerData,
+      fakeValidateVoucherStartDate,
+      fakeCreate,
+      fakeSendEmail
+    ) _
+
+    val futureActual = Steps.handleRequest(
+      addContribution = dummyContributionSteps,
+      addVoucher = fakeAddVoucherSteps
+    )(ApiGatewayRequest(None, Some(Json.stringify(requestInput)), None, None))
+
+    val actual = Await.result(futureActual, 30 seconds)
+    actual.statusCode should be("200")
+    actual.body jsonMatchesFormat expectedOutput
+  }
 
 }

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucherTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/voucher/SendConfirmationEmailVoucherTest.scala
@@ -1,6 +1,7 @@
 package com.gu.newproduct.api.addsubscription.email.voucher
 
 import java.time.LocalDate
+
 import com.gu.newproduct.TestData
 import com.gu.newproduct.api.addsubscription.email.{DataExtensionName, ETPayload}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName
@@ -10,6 +11,7 @@ import com.gu.newproduct.api.productcatalog.{Plan, PlanDescription}
 import com.gu.util.apigateway.ApiGatewayResponse
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import org.scalatest.{AsyncFlatSpec, Matchers}
+
 import scala.concurrent.Future
 
 class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
@@ -19,7 +21,7 @@ class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
       ()
     }
 
-    val send = SendConfirmationEmailVoucher(sqsSend, today) _
+    val send = SendConfirmationEmailVoucher(sqsSend) _
     send(Some(SfContactId("sfContactId")), testVoucherData).underlying map {
       result => result shouldBe ContinueProcessing(())
     }
@@ -33,7 +35,7 @@ class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
 
     def sqsSend(payload: ETPayload[VoucherEmailData]): Future[Unit] = Future.successful(())
 
-    val send = SendConfirmationEmailVoucher(sqsSend, today) _
+    val send = SendConfirmationEmailVoucher(sqsSend) _
     send(Some(SfContactId("sfContactId")), noSoldToEmailVoucherData).underlying map {
       result => result shouldBe ReturnWithResponse(ApiGatewayResponse.internalServerError("some error"))
     }
@@ -43,14 +45,12 @@ class SendConfirmationEmailVoucherTest extends AsyncFlatSpec with Matchers {
 
     def sqsSend(payload: ETPayload[VoucherEmailData]): Future[Unit] = Future.failed(new RuntimeException("sqs error"))
 
-    val send = SendConfirmationEmailVoucher(sqsSend, today) _
+    val send = SendConfirmationEmailVoucher(sqsSend) _
 
     send(Some(SfContactId("sfContactId")), testVoucherData).underlying map {
       result => result shouldBe ReturnWithResponse(ApiGatewayResponse.internalServerError("some error"))
     }
   }
-
-  def today = () => LocalDate.of(2018, 8, 24)
 
   val testVoucherData = VoucherEmailData(
     plan = Plan(VoucherSunday, PlanDescription("Sunday")),

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -9,11 +9,11 @@ import play.api.libs.json.{JsString, Json}
 object AddSubscriptionManualTest extends App {
   val requestBody =
     """{
-      |   "zuoraAccountId":"2c92c0f9661ff980016633b4200228af",
-      |   "startDate":"2018-11-12",
+      |   "zuoraAccountId":"2c92c0f967640caa016764f73a0d22d3",
+      |   "startDate":"2019-02-25",
       |   "acquisitionSource":"CSR",
       |   "createdByCSR":"CSRName",
-      |   "amountMinorUnits": 500,
+      |   "amountMinorUnits": 520,
       |   "acquisitionCase": "caseID",
       |   "planId": "voucher_everyday"
       |}

--- a/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/AddSubscriptionManualTest.scala
@@ -10,12 +10,12 @@ object AddSubscriptionManualTest extends App {
   val requestBody =
     """{
       |   "zuoraAccountId":"2c92c0f967640caa016764f73a0d22d3",
-      |   "startDate":"2019-02-25",
+      |   "startDate":"2019-02-01",
       |   "acquisitionSource":"CSR",
       |   "createdByCSR":"CSRName",
       |   "amountMinorUnits": 520,
       |   "acquisitionCase": "caseID",
-      |   "planId": "voucher_everyday"
+      |   "planId": "annual_contribution"
       |}
     """.stripMargin
 

--- a/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendConfirmationEmailsManualTest.scala
@@ -4,7 +4,6 @@ import java.time.LocalDate
 
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.i18n.{Country, Currency}
-import com.gu.newproduct.api.addsubscription.Steps.emailQueuesFor
 import com.gu.newproduct.api.addsubscription.email.EtSqsSend
 import com.gu.newproduct.api.addsubscription.email.contributions.SendConfirmationEmailContributions.ContributionsEmailData
 import com.gu.newproduct.api.addsubscription.email.contributions.{ContributionFields, SendConfirmationEmailContributions}
@@ -16,7 +15,7 @@ import com.gu.newproduct.api.addsubscription.zuora.GetAccount.SfContactId
 import com.gu.newproduct.api.productcatalog.AmountMinorUnits
 import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
 import com.gu.util.config.Stage
-
+import com.gu.newproduct.api.EmailQueueNames.emailQueuesFor
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/handlers/new-product-api/src/test/scala/manualTest/SendVoucherEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendVoucherEmailsManualTest.scala
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 import com.gu.effects.sqs.AwsSQSSend
 import com.gu.i18n.Country
-import com.gu.newproduct.api.addsubscription.Steps.emailQueuesFor
+import com.gu.newproduct.api.EmailQueueNames.emailQueuesFor
 import com.gu.newproduct.api.addsubscription.email.EtSqsSend
 import com.gu.newproduct.api.addsubscription.email.voucher.{SendConfirmationEmailVoucher, VoucherEmailData}
 import com.gu.newproduct.api.addsubscription.zuora.CreateSubscription.SubscriptionName

--- a/handlers/new-product-api/src/test/scala/manualTest/SendVoucherEmailsManualTest.scala
+++ b/handlers/new-product-api/src/test/scala/manualTest/SendVoucherEmailsManualTest.scala
@@ -73,15 +73,13 @@ object SendVoucherEmailsManualTest {
     )
   }
 
-  val fakeDate = LocalDate.of(2018, 8, 10)
-
   def main(args: Array[String]): Unit = {
     val result = for {
       email <- args.headOption.map(Email.apply)
       queueName = emailQueuesFor(Stage("PROD")).voucher
       sqsSend = AwsSQSSend(queueName) _
       voucherSqsSend = EtSqsSend[VoucherEmailData](sqsSend) _
-      sendConfirmationEmail = SendConfirmationEmailVoucher(voucherSqsSend, () => fakeDate) _
+      sendConfirmationEmail = SendConfirmationEmailVoucher(voucherSqsSend) _
       data = fakeVoucherEmailData(email)
       sendResult = sendConfirmationEmail(Some(SfContactId("sfContactId")), fakeVoucherEmailData(email))
     } yield sendResult

--- a/src/main/scala/com/gu/paymentFailure/ToMessage.scala
+++ b/src/main/scala/com/gu/paymentFailure/ToMessage.scala
@@ -78,7 +78,6 @@ object ToMessage {
       case None => -\/(s"Cannot create email message: no email address associated with accountId: ${callout.accountId} and sfContactId: ${callout.sfContactId}")
     }
 
-
   val currencySymbol = Map("GBP" -> "£", "AUD" -> "$", "EUR" -> "€", "USD" -> "$", "CAD" -> "$", "NZD" -> "$")
 
   val decimalFormat = new DecimalFormat("###,###.00")


### PR DESCRIPTION
There is some tech debt in new product api, The add subscription endpoint handler has all the code for wiring and running the steps for adding vouchers and contributions.
There is some more refactoring to be made but as a first improvement this PR removes the voucher and contribution specific code into its own objects without modifying it too much.