### PR TITLE
fix CSR acquisitions amount validation bug

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/Handler.scala
@@ -109,7 +109,7 @@ object Steps {
   def addContributionSteps(
     getPlanAndCharge: PlanId => Option[PlanAndCharge],
     getCustomerData: ZuoraAccountId => ApiGatewayOp[ContributionCustomerData],
-    contributionValidations: (ValidatableFields, Currency) => ValidationResult[AmountMinorUnits],
+    contributionValidations: (ValidatableFields, PlanId, Currency) => ValidationResult[AmountMinorUnits],
     createSubscription: ZuoraCreateSubRequest => ClientFailableOp[SubscriptionName],
     sendConfirmationEmail: (Option[SfContactId], ContributionsEmailData) => AsyncApiGatewayOp[Unit]
   )(request: AddSubscriptionRequest): AsyncApiGatewayOp[SubscriptionName] = {
@@ -117,7 +117,7 @@ object Steps {
       customerData <- getCustomerData(request.zuoraAccountId).toAsync
       ContributionCustomerData(account, paymentMethod, subscriptions, contacts) = customerData
       validatableFields = ValidatableFields(request.amountMinorUnits, request.startDate)
-      amountMinorUnits <- contributionValidations(validatableFields, account.currency).toApiGatewayOp.toAsync
+      amountMinorUnits <- contributionValidations(validatableFields, request.planId, account.currency).toApiGatewayOp.toAsync
       acceptanceDate = request.startDate.plusDays(paymentDelayFor(paymentMethod))
       planAndCharge <- getPlanAndCharge(request.planId).toApiGatewayContinueProcessing(internalServerError(s"no Zuora id for ${request.planId}!")).toAsync
       chargeOverride = ChargeOverride(amountMinorUnits, planAndCharge.productRatePlanChargeId)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/AmountLimits.scala
@@ -2,16 +2,56 @@ package com.gu.newproduct.api.addsubscription.validation
 
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency._
+import com.gu.newproduct.api.productcatalog.PlanId
+import com.gu.newproduct.api.productcatalog.PlanId.AnnualContribution
+
+case class ContributionLimits(monthly: AmountLimits, annual: AmountLimits)
 
 case class AmountLimits(min: Int, max: Int)
 
 object AmountLimits {
-  def limitsFor(currency: Currency): AmountLimits = currency match {
-    case GBP => AmountLimits(min = 200, max = 16600)
-    case AUD => AmountLimits(min = 200, max = 16600)
-    case USD => AmountLimits(min = 200, max = 16600)
-    case NZD => AmountLimits(min = 1000, max = 16600)
-    case CAD => AmountLimits(min = 500, max = 16600)
-    case EUR => AmountLimits(min = 200, max = 16600)
+
+  val gbp = ContributionLimits(
+    monthly = AmountLimits(min = 200, max = 16600),
+    annual = AmountLimits(min = 1000, max = 200000)
+  )
+
+  val aud = ContributionLimits(
+    monthly = AmountLimits(min = 1000, max = 20000),
+    annual = AmountLimits(min = 1000, max = 200000)
+  )
+
+  val usd = ContributionLimits(
+    monthly = AmountLimits(min = 200, max = 16600),
+    annual = AmountLimits(min = 1000, max = 200000)
+  )
+
+  val nzd = ContributionLimits(
+    monthly = AmountLimits(min = 1000, max = 20000),
+    annual = AmountLimits(min = 1000, max = 200000)
+  )
+
+  val cad = ContributionLimits(
+    monthly = AmountLimits(min = 500, max = 16600),
+    annual = AmountLimits(min = 1000, max = 200000)
+  )
+
+  val eur = ContributionLimits(
+    monthly = AmountLimits(min = 200, max = 16600),
+    annual = AmountLimits(min = 1000, max = 200000)
+  )
+
+  def limitsFor(planId: PlanId, currency: Currency): AmountLimits = {
+    val contributionLimits = contributionLimitsfor(currency)
+    if (planId == AnnualContribution) contributionLimits.annual else contributionLimits.monthly
+  }
+
+  def contributionLimitsfor(currency: Currency): ContributionLimits = currency match {
+    case GBP => gbp
+    case AUD => aud
+    case USD => usd
+    case NZD => nzd
+    case CAD => cad
+    case EUR => eur
   }
 }

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidations.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import com.gu.i18n.Currency
 import com.gu.newproduct.api.addsubscription.validation.{AmountLimits, ValidationResult}
 import com.gu.newproduct.api.addsubscription.validation.Validation._
-import com.gu.newproduct.api.productcatalog.AmountMinorUnits
+import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PlanId}
 object ContributionValidations {
 
   case class ValidatableFields(
@@ -15,15 +15,16 @@ object ContributionValidations {
 
   def apply(
     isValidStartDate: LocalDate => ValidationResult[Unit],
-    limitsFor: Currency => AmountLimits
+    limitsFor: (PlanId, Currency) => AmountLimits
   )(
     validatableFields: ValidatableFields,
+    planId:PlanId,
     currency: Currency
   ): ValidationResult[AmountMinorUnits] =
     for {
       amount <- validatableFields.amountMinorUnits getOrFailWith s"amountMinorUnits is missing"
       _ <- isValidStartDate(validatableFields.startDate)
-      limits = limitsFor(currency)
+      limits = limitsFor(planId, currency)
       _ <- (amount.value <= limits.max) orFailWith s"amount must not be more than ${limits.max}"
       _ <- (amount.value >= limits.min) orFailWith s"amount must be at least ${limits.min}"
     } yield (amount)

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/ContributionStepsTest.scala
@@ -60,7 +60,7 @@ class ContributionStepsTest extends FlatSpec with Matchers {
       ContinueProcessing(()).toAsync
     }
 
-    def fakeValidateRequest(fields: ValidatableFields, currency: Currency) = {
+    def fakeValidateRequest(fields: ValidatableFields, planId:PlanId, currency: Currency) = {
       fields.amountMinorUnits.map(Passed(_)).getOrElse(Failed("missing amount"))
     }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/contribution/ContributionValidationsTest.scala
@@ -6,7 +6,8 @@ import com.gu.i18n.Currency
 import com.gu.i18n.Currency._
 import com.gu.newproduct.api.addsubscription.validation.contribution.ContributionValidations.ValidatableFields
 import com.gu.newproduct.api.addsubscription.validation.{AmountLimits, Failed, Passed, ValidationResult}
-import com.gu.newproduct.api.productcatalog.AmountMinorUnits
+import com.gu.newproduct.api.productcatalog.PlanId.MonthlyContribution
+import com.gu.newproduct.api.productcatalog.{AmountMinorUnits, PlanId}
 import org.scalatest.{FlatSpec, Matchers}
 
 class ContributionValidationsTest extends FlatSpec with Matchers {
@@ -18,7 +19,8 @@ class ContributionValidationsTest extends FlatSpec with Matchers {
 
   def now = () => LocalDate.of(2018, 7, 20)
 
-  def amountLimitsFor(currency: Currency) = {
+  def amountLimitsFor(planId: PlanId, currency: Currency) = {
+    planId shouldBe MonthlyContribution
     currency shouldBe GBP
     AmountLimits(min = 100, max = 200)
   }
@@ -30,21 +32,21 @@ class ContributionValidationsTest extends FlatSpec with Matchers {
 
   it should "return error if date validation fails" in {
     val oldRequest = testRequest.copy(startDate = LocalDate.of(1985, 10, 26))
-    wiredValidator(oldRequest, GBP) shouldBe Failed("Date validation failed!")
+    wiredValidator(oldRequest, MonthlyContribution, GBP) shouldBe Failed("Date validation failed!")
   }
   it should "return error if amount is too small" in {
-    wiredValidator(testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(99))), GBP) shouldBe Failed("amount must be at least 100")
+    wiredValidator(testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(99))), MonthlyContribution, GBP) shouldBe Failed("amount must be at least 100")
   }
 
   it should "return error if amount is too large" in {
-    wiredValidator(testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(201))), GBP) shouldBe Failed("amount must not be more than 200")
+    wiredValidator(testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(201))), MonthlyContribution, GBP) shouldBe Failed("amount must not be more than 200")
   }
   it should "return success if amount is within valid range" in {
-    wiredValidator(testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(150))), GBP) shouldBe Passed((AmountMinorUnits(150)))
+    wiredValidator(testRequest.copy(amountMinorUnits = Some(AmountMinorUnits(150))), MonthlyContribution, GBP) shouldBe Passed((AmountMinorUnits(150)))
   }
 
   it should "return error if amount is missing" in {
-    wiredValidator(testRequest.copy(amountMinorUnits = None), GBP) shouldBe Failed("amountMinorUnits is missing")
+    wiredValidator(testRequest.copy(amountMinorUnits = None), MonthlyContribution, GBP) shouldBe Failed("amountMinorUnits is missing")
   }
 
 }


### PR DESCRIPTION
When annual contributions were added to the new product api we (I) forgot to modify the amount min and max validation code. This means that the same min and max amounts are enforced for monthly or annual contributions.
In this pr we apply the same limits that are enforced in the support frontend.