### PR TITLE
Payment failure Lambda: do not return status 400 if account on payment failure has no email address

### DIFF
--- a/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
+++ b/src/test/scala/com/gu/paymentFailure/PaymentFailureHandlerTest.scala
@@ -93,7 +93,7 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
     responseString jsonMatches successfulResponse
   }
 
-  it should "return error if no email is provided" in {
+  it should "return 200 response with warning message if no email is provided" in {
     //set up
     val stream = getClass.getResourceAsStream("/paymentFailure/missingEmail.json")
     var storedReq: Option[EmailMessage] = None
@@ -190,9 +190,9 @@ class PaymentFailureHandlerTest extends FlatSpec with Matchers {
 
   val missingEmailResponse =
     """{
-      |"statusCode":"400",
+      |"statusCode":"200",
       |"headers":{"Content-Type":"application/json"},
-      |"body":"{\n  \"message\" : \"Bad request: No email address provided\"\n}"
+      |"body":"{\n  \"message\" : \"Email address not provided, email will not be sent\"\n}"
       |}
       |""".stripMargin
 


### PR DESCRIPTION
in my previous [PR](https://github.com/guardian/zuora-auto-cancel/pull/251) I made the payment failure lambda return 400 for requests that did not provide a destination email address.
The problem is that there's a bunch of zuora accounts with no email address and this triggers our 4xx error alarm.

In this PR we log a warning and return status 200 with an informational message in case the email address is not provided, but still return error messages if the email could not be sent for any other reason