### PR TITLE
Fix another effects test

### DIFF
--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/zuora/CreateSubscriptionEffectsTest.scala
@@ -29,7 +29,7 @@ class CreateSubscriptionEffectsTest extends FlatSpec with Matchers {
         AmountMinorUnits(100),
         monthlyContribution.productRatePlanChargeId
       )),
-      LocalDate.now.plusDays(2),
+      currentDate().plusDays(2),
       validCaseIdToAvoidCausingSFErrors,
       AcquisitionSource("sourcesource"),
       CreatedByCSR("csrcsr")


### PR DESCRIPTION
An effects test was using the real current date instead the fake one defined for the test.