### PR TITLE
Remove missing field from DD_Mandate_Failure__c

### DIFF
--- a/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
+++ b/handlers/sf-datalake-export/src/main/scala/com/gu/sf_datalake_export/salesforce_bulk_api/SfQueries.scala
@@ -518,7 +518,6 @@ object SfQueries {
       |Invoice_Total_Amount__c,
       |Journey_Length__c,
       |Last_Attempt_Type__c,
-      |Latest_Email_Stage_Received_by_Braze__c,
       |Latest_Payment_Method__c,
       |Latest_Payment_Method_Created__c,
       |Next_Invoice_Date__c,


### PR DESCRIPTION
`Latest_Email_Stage_Received_by_Braze__c` does not seem to exist.