### PR TITLE
Schedule rules can invoke 5 lambdas each

### DIFF
--- a/handlers/sf-datalake-export/cfn.yaml
+++ b/handlers/sf-datalake-export/cfn.yaml
@@ -437,7 +437,7 @@ Resources:
                 Action:
                   - states:StartExecution
                 Resource: !Ref StateMachine
-  ScheduleRule:
+  ScheduleRule1:
     Type: "AWS::Events::Rule"
     Condition: IsProd
     Properties:
@@ -485,6 +485,14 @@ Resources:
              "objectName": "CardExpiry"
             }
           RoleArn: !GetAtt [ TriggerRole, Arn ]
+  ScheduleRule2:
+    Type: "AWS::Events::Rule"
+    Condition: IsProd
+    Properties:
+      Description: "trigger salesforce export every day at 01:00 GMT"
+      ScheduleExpression: "cron(0 1 ? * * *)"
+      State: "ENABLED"
+      Targets:
         -
           Arn: !Ref StateMachine
           Id: !Sub trigger_sf_export-Account-${Stage}


### PR DESCRIPTION
Related PR: https://github.com/guardian/zuora-auto-cancel/pull/263#issuecomment-463224319

https://forums.aws.amazon.com/thread.jspa?messageID=691320#jive-message-687756:

> We do recommend that you reuse existing schedules wherever possible since schedules can invoke 5 Lambda functions each.

