### PR TITLE
enable home delivery plans in csr acquisitions

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/AddPaperSub.scala
@@ -50,9 +50,9 @@ object AddPaperSub {
       chargeOverride = None,
       productRatePlanId = zuoraRatePlanId
     )
-    subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create voucher subscription")
+    subscriptionName <- createSubscription(createSubRequest).toAsyncApiGatewayOp("create paper subscription")
     plan = getPlan(request.planId)
-    voucherEmailData = PaperEmailData(
+    paperEmailData = PaperEmailData(
       plan = plan,
       firstPaymentDate = request.startDate,
       firstPaperDate = request.startDate,
@@ -60,7 +60,7 @@ object AddPaperSub {
       contacts = customerData.contacts,
       paymentMethod = customerData.paymentMethod
     )
-    _ <- sendConfirmationEmail(customerData.account.sfContactId, voucherEmailData).recoverAndLog("send voucher confirmation email")
+    _ <- sendConfirmationEmail(customerData.account.sfContactId, paperEmailData).recoverAndLog("send paper confirmation email")
   } yield subscriptionName
 
   def wireSteps(

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -111,7 +111,16 @@ object PlanId {
     MonthlyContribution,
     AnnualContribution
   )
-  val enabledHomeDeliveryPlans = List.empty
+  val enabledHomeDeliveryPlans = List(
+    HomeDeliveryEveryDay,
+    HomeDeliveryEveryDayPlus,
+    HomeDeliverySixDay,
+    HomeDeliverySixDayPlus,
+    HomeDeliverySunday,
+    HomeDeliverySundayPlus,
+    HomeDeliveryWeekend,
+    HomeDeliveryWeekendPlus
+  )
 
   val supportedPlans: List[PlanId] = enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans
   def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -19,10 +19,12 @@ case class Catalog(
   homeDeliverySixDay: Plan,
   homeDeliveryWeekend: Plan,
   homeDeliverySunday: Plan,
+  homeDeliverySaturday: Plan,
   homeDeliveryEveryDayPlus: Plan,
   homeDeliverySixDayPlus: Plan,
   homeDeliveryWeekendPlus: Plan,
-  homeDeliverySundayPlus: Plan
+  homeDeliverySundayPlus: Plan,
+  homeDeliverySaturdayPlus: Plan
 ) {
   val allPlans = List(
     voucherWeekend,
@@ -40,11 +42,13 @@ case class Catalog(
     homeDeliveryEveryDay,
     homeDeliverySixDay,
     homeDeliverySunday,
+    homeDeliverySaturday,
     homeDeliveryWeekend,
     homeDeliveryEveryDayPlus,
     homeDeliverySixDayPlus,
     homeDeliveryWeekendPlus,
-    homeDeliverySundayPlus
+    homeDeliverySundayPlus,
+    homeDeliverySaturdayPlus
   )
 
   val planForId: Map[PlanId, Plan] = allPlans.map(x => x.id -> x).toMap
@@ -95,6 +99,10 @@ object PlanId {
 
   case object HomeDeliverySundayPlus extends PlanId("home_delivery_sunday_plus") with HomeDeliveryPlanId
 
+  case object HomeDeliverySaturday extends PlanId("home_delivery_saturday") with HomeDeliveryPlanId
+
+  case object HomeDeliverySaturdayPlus extends PlanId("home_delivery_saturday_plus") with HomeDeliveryPlanId
+
   val enabledVoucherPlans = List(
     VoucherEveryDay,
     VoucherEveryDayPlus,
@@ -114,6 +122,8 @@ object PlanId {
   val enabledHomeDeliveryPlans = List(
     HomeDeliveryEveryDay,
     HomeDeliveryEveryDayPlus,
+    HomeDeliverySaturday,
+    HomeDeliverySaturdayPlus,
     HomeDeliverySixDay,
     HomeDeliverySixDayPlus,
     HomeDeliverySunday,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -44,6 +44,7 @@ object NewProductApi {
 
     val homeDeliverySixDayRules = homeDeliveryDateRules(Some(weekDays ++ List(SATURDAY)))
     val homeDeliverySundayDateRules = homeDeliveryDateRules(Some(List(SUNDAY)))
+    val homeDeliverySaturdayDateRules = homeDeliveryDateRules(Some(List(SATURDAY)))
     val homeDeliveryWeekendRules = homeDeliveryDateRules(Some(List(SATURDAY, SUNDAY)))
     val monthlyContributionWindow = WindowRule(
       maybeSize = Some(WindowSizeDays(1)),
@@ -78,7 +79,9 @@ object NewProductApi {
       homeDeliveryEveryDayPlus = planWithPayment(HomeDeliveryEveryDayPlus, PlanDescription("Everyday+"), homeDeliveryEveryDayRules),
       homeDeliverySundayPlus = planWithPayment(HomeDeliverySundayPlus, PlanDescription("Sunday+"), homeDeliverySundayDateRules),
       homeDeliverySixDayPlus = planWithPayment(HomeDeliverySixDayPlus, PlanDescription("Sixday+"), homeDeliverySixDayRules),
-      homeDeliveryWeekendPlus = planWithPayment(HomeDeliveryWeekendPlus, PlanDescription("Weekend+"), homeDeliveryWeekendRules)
+      homeDeliveryWeekendPlus = planWithPayment(HomeDeliveryWeekendPlus, PlanDescription("Weekend+"), homeDeliveryWeekendRules),
+      homeDeliverySaturday = planWithPayment(HomeDeliverySaturday, PlanDescription("Saturday"), homeDeliverySaturdayDateRules),
+      homeDeliverySaturdayPlus = planWithPayment(HomeDeliverySaturdayPlus, PlanDescription("Saturday+"), homeDeliverySaturdayDateRules),
     )
   }
 

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/ZuoraIds.scala
@@ -52,6 +52,8 @@ object ZuoraIds {
   case class HomeDeliveryZuoraIds(
     everyday: ProductRatePlanId,
     everydayPlus: ProductRatePlanId,
+    saturday:ProductRatePlanId,
+    saturdayPlus:ProductRatePlanId,
     sunday: ProductRatePlanId,
     sundayPlus: ProductRatePlanId,
     weekend: ProductRatePlanId,
@@ -63,6 +65,8 @@ object ZuoraIds {
       HomeDeliveryEveryDay -> everyday,
       HomeDeliveryWeekend -> weekend,
       HomeDeliverySixDay -> sixDay,
+      HomeDeliverySaturday -> saturday,
+      HomeDeliverySaturdayPlus -> saturdayPlus,
       HomeDeliverySunday -> sunday,
       HomeDeliveryEveryDayPlus -> everydayPlus,
       HomeDeliveryWeekendPlus -> weekendPlus,
@@ -110,6 +114,8 @@ object ZuoraIds {
           sixDay = ProductRatePlanId("2c92a0ff560d311b0156136f2afe5315"),
           weekend = ProductRatePlanId("2c92a0fd5614305c01561dc88f3275be"),
           sunday = ProductRatePlanId("2c92a0ff5af9b657015b0fea5b653f81"),
+          saturday = ProductRatePlanId("2c92a0fd5e1dcf0d015e3cb39d0a7ddb"),
+          saturdayPlus= ProductRatePlanId("2c92a0ff6205708e01622484bb2c4613"),
           sundayPlus = ProductRatePlanId("2c92a0fd560d13880156136b8e490f8b"),
           weekendPlus = ProductRatePlanId("2c92a0ff560d311b0156136b9f5c3968"),
           sixDayPlus = ProductRatePlanId("2c92a0ff560d311b0156136b697438a9"),
@@ -144,8 +150,10 @@ object ZuoraIds {
           sixDay = ProductRatePlanId("2c92c0f955ca02900155da27ff142e01"),
           weekend = ProductRatePlanId("2c92c0f955ca02900155da27f83c2d9b"),
           sunday = ProductRatePlanId("2c92c0f95aff3b54015b0ede33bc04f2"),
-         sundayPlus= ProductRatePlanId("2c92c0f955ca02900155da27f4872d4d"),
-         weekendPlus=ProductRatePlanId("2c92c0f955ca02900155da27f9402dad"),
+          sundayPlus= ProductRatePlanId("2c92c0f955ca02900155da27f4872d4d"),
+          saturday = ProductRatePlanId("2c92c0f85b8fa30e015b9108a83253c7"),
+          saturdayPlus = ProductRatePlanId("2c92c0f961f9cf300161fbfa943b6f54"),
+          weekendPlus=ProductRatePlanId("2c92c0f955ca02900155da27f9402dad"),
          sixDayPlus= ProductRatePlanId("2c92c0f955ca02900155da27f29e2d13"),
          everydayPlus= ProductRatePlanId("2c92c0f955ca02900155da2803b02e33")
         )
@@ -179,6 +187,8 @@ object ZuoraIds {
           weekend = ProductRatePlanId("2c92c0f955c3cf0f0155c5d9df433bf7"),
           sunday = ProductRatePlanId("2c92c0f85aff3453015b1041dfd2317f"),
           sundayPlus = ProductRatePlanId("2c92c0f955c3cf0f0155c5d9e83a3cb7"),
+          saturday = ProductRatePlanId("2c92c0f961f9cf300161fc4d2e3e3664"),
+          saturdayPlus = ProductRatePlanId("2c92c0f961f9cf300161fc4f71473a34"),
           weekendPlus = ProductRatePlanId("2c92c0f95aff3b56015b104aa9a13ea5"),
           sixDayPlus = ProductRatePlanId("2c92c0f85aff33ff015b1042d4ba0a05"),
           everydayPlus = ProductRatePlanId("2c92c0f85aff3453015b10496b5e3d17")

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -215,6 +215,34 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "paymentPlan": "GBP 9.99 every month"
      |        },
      |        {
+     |          "id": "home_delivery_saturday",
+     |          "label": "Saturday",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 333.33 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_saturday_plus",
+     |          "label": "Saturday+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 444.44 every month"
+     |        },
+     |        {
      |          "id": "home_delivery_sixday",
      |          "label": "Sixday",
      |          "startDateRules": {
@@ -338,6 +366,8 @@ class CatalogWireTest extends FlatSpec with Matchers {
       case HomeDeliverySundayPlus => Some(AmountMinorUnits(1010))
       case HomeDeliverySixDayPlus => Some(AmountMinorUnits(1111))
       case HomeDeliveryWeekendPlus => Some(AmountMinorUnits(2222))
+      case HomeDeliverySaturday => Some(AmountMinorUnits(33333))
+      case HomeDeliverySaturdayPlus => Some(AmountMinorUnits(44444))
     }
 
     val wireCatalog = WireCatalog.fromCatalog(NewProductApi.catalog(fakePricesFor))

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -188,6 +188,130 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "paymentPlan": "GBP 29.42 every month"
      |        }
      |      ]
+     |    },
+     |    {
+     |      "label": "Home delivery",
+     |      "plans": [
+     |        {
+     |          "id": "home_delivery_everyday",
+     |          "label": "Everyday",
+     |          "startDateRules": {
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 1.23 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_everyday_plus",
+     |          "label": "Everyday+",
+     |          "startDateRules": {
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 9.99 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_sixday",
+     |          "label": "Sixday",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Monday",
+     |              "Tuesday",
+     |              "Wednesday",
+     |              "Thursday",
+     |              "Friday",
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 7.77 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_sixday_plus",
+     |          "label": "Sixday+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Monday",
+     |              "Tuesday",
+     |              "Wednesday",
+     |              "Thursday",
+     |              "Friday",
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 11.11 every month"
+     |        },
+     |
+     |        {
+     |          "id": "home_delivery_sunday",
+     |          "label": "Sunday",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 3.21 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_sunday_plus",
+     |          "label": "Sunday+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 10.10 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_weekend",
+     |          "label": "Weekend",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Saturday",
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 8.88 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_weekend_plus",
+     |          "label": "Weekend+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+      |            "Saturday",
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 22.22 every month"
+     |        }
+     |      ]
      |    }
      |  ]
      |}


### PR DESCRIPTION
This PR enables home delivery acquisitions. We should only merge this when salesforce is ready