### PR TITLE
Enable hd plans

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -119,7 +119,18 @@ object PlanId {
     MonthlyContribution,
     AnnualContribution
   )
-  val enabledHomeDeliveryPlans = List.empty
+  val enabledHomeDeliveryPlans = List(
+    HomeDeliveryEveryDay,
+    HomeDeliveryEveryDayPlus,
+    HomeDeliverySaturday,
+    HomeDeliverySaturdayPlus,
+    HomeDeliverySixDay,
+    HomeDeliverySixDayPlus,
+    HomeDeliverySunday,
+    HomeDeliverySundayPlus,
+    HomeDeliveryWeekend,
+    HomeDeliveryWeekendPlus
+  )
 
   val supportedPlans: List[PlanId] = enabledVoucherPlans ++ enabledContributionPlans ++ enabledHomeDeliveryPlans
   def fromName(name: String): Option[PlanId] = supportedPlans.find(_.name == name)

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -120,7 +120,7 @@ object WireModel {
       )
 
       val homeDeliveryProduct = WireProduct(
-        label = "Home delivery",
+        label = "Home Delivery",
         plans = PlanId.enabledHomeDeliveryPlans.map(wirePlanForPlanId)
       )
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -209,7 +209,7 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |      ]
      |    },
      |    {
-     |      "label": "Home delivery",
+     |      "label": "Home Delivery",
      |      "plans": [
      |        {
      |          "id": "home_delivery_everyday",

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -215,6 +215,15 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "id": "home_delivery_everyday",
      |          "label": "Everyday",
      |          "startDateRules": {
+     |             "daysOfWeek": [
+     |                "Monday",
+     |                "Tuesday",
+     |                "Wednesday",
+     |                "Thursday",
+     |                "Friday",
+     |                "Saturday",
+     |                "Sunday"
+     |              ],
      |            "selectableWindow": {
      |              "startDaysAfterCutOff": 3,
      |              "sizeInDays": 28
@@ -226,6 +235,15 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "id": "home_delivery_everyday_plus",
      |          "label": "Everyday+",
      |          "startDateRules": {
+     |             "daysOfWeek": [
+     |                "Monday",
+     |                "Tuesday",
+     |                "Wednesday",
+     |                "Thursday",
+     |                "Friday",
+     |                "Saturday",
+     |                "Sunday"
+     |              ],
      |            "selectableWindow": {
      |              "startDaysAfterCutOff": 3,
      |              "sizeInDays": 28

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -188,6 +188,158 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "paymentPlan": "GBP 29.42 every month"
      |        }
      |      ]
+     |    },
+     |    {
+     |      "label": "Home delivery",
+     |      "plans": [
+     |        {
+     |          "id": "home_delivery_everyday",
+     |          "label": "Everyday",
+     |          "startDateRules": {
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 1.23 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_everyday_plus",
+     |          "label": "Everyday+",
+     |          "startDateRules": {
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 9.99 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_saturday",
+     |          "label": "Saturday",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 333.33 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_saturday_plus",
+     |          "label": "Saturday+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 444.44 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_sixday",
+     |          "label": "Sixday",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Monday",
+     |              "Tuesday",
+     |              "Wednesday",
+     |              "Thursday",
+     |              "Friday",
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 7.77 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_sixday_plus",
+     |          "label": "Sixday+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Monday",
+     |              "Tuesday",
+     |              "Wednesday",
+     |              "Thursday",
+     |              "Friday",
+     |              "Saturday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 11.11 every month"
+     |        },
+     |
+     |        {
+     |          "id": "home_delivery_sunday",
+     |          "label": "Sunday",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 3.21 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_sunday_plus",
+     |          "label": "Sunday+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 10.10 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_weekend",
+     |          "label": "Weekend",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+     |              "Saturday",
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 8.88 every month"
+     |        },
+     |        {
+     |          "id": "home_delivery_weekend_plus",
+     |          "label": "Weekend+",
+     |          "startDateRules": {
+     |            "daysOfWeek": [
+      |            "Saturday",
+     |              "Sunday"
+     |            ],
+     |            "selectableWindow": {
+     |              "startDaysAfterCutOff": 3,
+     |              "sizeInDays": 28
+     |            }
+     |          },
+     |          "paymentPlan": "GBP 22.22 every month"
+     |        }
+     |      ]
      |    }
      |  ]
      |}


### PR DESCRIPTION
This PR cannot be merged until
- PR https://github.com/guardian/zuora-auto-cancel/pull/267 is merged ( add saturday plans)
- the salesforce ui is ready to handle home delivery plans