### PR TITLE
made daysOfWeek not optional in catalog response for new product api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/DateValidation.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/DateValidation.scala
@@ -51,9 +51,9 @@ object StartDateValidator {
     validatorFor: DateRule => LocalDate => ValidationResult[Unit],
     startDateRules: StartDateRules
   ): LocalDate => ValidationResult[Unit] = {
-    val maybeDaysValidation = startDateRules.daysOfWeekRule.map(validatorFor)
+    val daysValidation = validatorFor(startDateRules.daysOfWeekRule)
     val maybeWindowValidation = startDateRules.windowRule.map(validatorFor)
-    StartDateValidator(maybeDaysValidation orPass, maybeWindowValidation orPass, _)
+    StartDateValidator(daysValidation, maybeWindowValidation orPass, _)
   }
 
   implicit class OptionalRuleOps(maybeRule: Option[LocalDate => ValidationResult[Unit]]) {

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -1,7 +1,6 @@
 package com.gu.newproduct.api.productcatalog
 
 import java.time.DayOfWeek
-
 case class Catalog(
   voucherWeekend: Plan,
   voucherSaturday: Plan,
@@ -137,10 +136,11 @@ case class WindowSizeDays(value: Int) extends AnyVal
 
 sealed trait DateRule
 
-case class StartDateRules(daysOfWeekRule: Option[DaysOfWeekRule] = None, windowRule: Option[WindowRule] = None)
+case class StartDateRules(daysOfWeekRule: DaysOfWeekRule = DaysOfWeekRule(DayOfWeek.values.toList), windowRule: Option[WindowRule] = None)
 
 case class DaysOfWeekRule(allowedDays: List[DayOfWeek]) extends DateRule
 
 case class WindowRule(maybeCutOffDay: Option[DayOfWeek], maybeStartDelay: Option[DelayDays], maybeSize: Option[WindowSizeDays]) extends DateRule
 
 case class AmountMinorUnits(value: Int) extends AnyVal
+

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/NewProductApi.scala
@@ -19,7 +19,7 @@ object NewProductApi {
       maybeSize = Some(WindowSizeDays(35))
     )
 
-    def voucherDateRules(allowedDays: List[DayOfWeek]) = StartDateRules(Some(DaysOfWeekRule(allowedDays)), Some(voucherWindowRule))
+    def voucherDateRules(allowedDays: List[DayOfWeek]) = StartDateRules((DaysOfWeekRule(allowedDays)), Some(voucherWindowRule))
 
     val voucherMondayRules = voucherDateRules(List(MONDAY))
     val voucherSundayDateRules = voucherDateRules(List(SUNDAY))
@@ -31,9 +31,9 @@ object NewProductApi {
       maybeSize = Some(WindowSizeDays(28))
     )
 
-    def homeDeliveryDateRules(allowedDays: Option[List[DayOfWeek]]) = StartDateRules(allowedDays.map(DaysOfWeekRule), Some(homeDeliveryWindowRule))
+    def homeDeliveryDateRules(allowedDays: List[DayOfWeek]) = StartDateRules(DaysOfWeekRule(allowedDays), Some(homeDeliveryWindowRule))
 
-    val homeDeliveryEveryDayRules = homeDeliveryDateRules(None)
+
     val weekDays = List(
       MONDAY,
       TUESDAY,
@@ -42,10 +42,18 @@ object NewProductApi {
       FRIDAY
     )
 
-    val homeDeliverySixDayRules = homeDeliveryDateRules(Some(weekDays ++ List(SATURDAY)))
-    val homeDeliverySundayDateRules = homeDeliveryDateRules(Some(List(SUNDAY)))
-    val homeDeliverySaturdayDateRules = homeDeliveryDateRules(Some(List(SATURDAY)))
-    val homeDeliveryWeekendRules = homeDeliveryDateRules(Some(List(SATURDAY, SUNDAY)))
+    val weekendDays = List(
+      SATURDAY,
+      SUNDAY
+    )
+
+    val everyDay = weekDays ++ weekendDays
+
+    val homeDeliveryEveryDayRules = homeDeliveryDateRules(everyDay)
+    val homeDeliverySixDayRules = homeDeliveryDateRules(weekDays ++ List(SATURDAY))
+    val homeDeliverySundayDateRules = homeDeliveryDateRules(List(SUNDAY))
+    val homeDeliverySaturdayDateRules = homeDeliveryDateRules(List(SATURDAY))
+    val homeDeliveryWeekendRules = homeDeliveryDateRules(weekendDays)
     val monthlyContributionWindow = WindowRule(
       maybeSize = Some(WindowSizeDays(1)),
       maybeCutOffDay = None,

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -36,7 +36,7 @@ object WireModel {
   )
 
   case class WireStartDateRules(
-    daysOfWeek: Option[List[WireDayOfWeek]] = None,
+    daysOfWeek: List[WireDayOfWeek],
     selectableWindow: Option[WireSelectableWindow] = None
   )
 
@@ -71,9 +71,9 @@ object WireModel {
     implicit val writes = Json.writes[WireStartDateRules]
 
     def fromStartDateRules(rule: StartDateRules): WireStartDateRules = {
-      val maybeWireAllowedDaysOfWeek = rule.daysOfWeekRule.map(_.allowedDays.map(WireDayOfWeek.fromDayOfWeek))
+      val wireAllowedDaysOfWeek = rule.daysOfWeekRule.allowedDays.map(WireDayOfWeek.fromDayOfWeek)
       val maybeWireWindowRules = rule.windowRule.map(WireSelectableWindow.fromWindowRule(_))
-      WireStartDateRules(maybeWireAllowedDaysOfWeek, maybeWireWindowRules)
+      WireStartDateRules(wireAllowedDaysOfWeek, maybeWireWindowRules)
     }
   }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -18,15 +18,34 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "id": "monthly_contribution",
      |          "label": "Monthly",
      |          "startDateRules": {
+     |           "daysOfWeek": [
+     |                "Monday",
+     |                "Tuesday",
+     |                "Wednesday",
+     |                "Thursday",
+     |                "Friday",
+     |                "Saturday",
+     |                "Sunday"
+     |              ],
      |            "selectableWindow": {
      |              "sizeInDays": 1
      |            }
+     |
      |          }
      |        },
      |        {
      |          "id": "annual_contribution",
      |          "label": "Annual",
      |          "startDateRules": {
+     |           "daysOfWeek": [
+     |                "Monday",
+     |                "Tuesday",
+     |                "Wednesday",
+     |                "Thursday",
+     |                "Friday",
+     |                "Saturday",
+     |                "Sunday"
+     |              ],
      |            "selectableWindow": {
      |              "sizeInDays": 1
      |            }


### PR DESCRIPTION
The catalog response for new product api returns the validation rules for plan start dates that salesforce should enforce.
The current version returns an empty whitelist of days of the week when no restriction should be applied.  The salesforce client code could not handle this correctly so instead the allowed days of the week will always be returned.