### PR TITLE
made daysOfWeek not optional in catalog response for new product api

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -1,7 +1,6 @@
 package com.gu.newproduct.api.productcatalog
 
 import java.time.DayOfWeek
-
 case class Catalog(
   voucherWeekend: Plan,
   voucherSaturday: Plan,
@@ -144,3 +143,4 @@ case class DaysOfWeekRule(allowedDays: List[DayOfWeek]) extends DateRule
 case class WindowRule(maybeCutOffDay: Option[DayOfWeek], maybeStartDelay: Option[DelayDays], maybeSize: Option[WindowSizeDays]) extends DateRule
 
 case class AmountMinorUnits(value: Int) extends AnyVal
+

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/Catalog.scala
@@ -1,6 +1,7 @@
 package com.gu.newproduct.api.productcatalog
 
 import java.time.DayOfWeek
+
 case class Catalog(
   voucherWeekend: Plan,
   voucherSaturday: Plan,
@@ -143,4 +144,3 @@ case class DaysOfWeekRule(allowedDays: List[DayOfWeek]) extends DateRule
 case class WindowRule(maybeCutOffDay: Option[DayOfWeek], maybeStartDelay: Option[DelayDays], maybeSize: Option[WindowSizeDays]) extends DateRule
 
 case class AmountMinorUnits(value: Int) extends AnyVal
-

--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/productcatalog/WireModel.scala
@@ -36,7 +36,7 @@ object WireModel {
   )
 
   case class WireStartDateRules(
-    daysOfWeek: Option[List[WireDayOfWeek]] = None,
+    daysOfWeek: List[WireDayOfWeek],
     selectableWindow: Option[WireSelectableWindow] = None
   )
 
@@ -71,9 +71,11 @@ object WireModel {
     implicit val writes = Json.writes[WireStartDateRules]
 
     def fromStartDateRules(rule: StartDateRules): WireStartDateRules = {
-      val maybeWireAllowedDaysOfWeek = rule.daysOfWeekRule.map(_.allowedDays.map(WireDayOfWeek.fromDayOfWeek))
+
+      val allowedDays = rule.daysOfWeekRule.map(_.allowedDays) getOrElse DayOfWeek.values.toList
+      val wireAllowedDaysOfWeek = allowedDays.map(WireDayOfWeek.fromDayOfWeek)
       val maybeWireWindowRules = rule.windowRule.map(WireSelectableWindow.fromWindowRule(_))
-      WireStartDateRules(maybeWireAllowedDaysOfWeek, maybeWireWindowRules)
+      WireStartDateRules(wireAllowedDaysOfWeek, maybeWireWindowRules)
     }
   }
 

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/productcatalog/CatalogWireTest.scala
@@ -18,15 +18,34 @@ class CatalogWireTest extends FlatSpec with Matchers {
      |          "id": "monthly_contribution",
      |          "label": "Monthly",
      |          "startDateRules": {
+     |           "daysOfWeek": [
+     |                "Monday",
+     |                "Tuesday",
+     |                "Wednesday",
+     |                "Thursday",
+     |                "Friday",
+     |                "Saturday",
+     |                "Sunday"
+     |              ],
      |            "selectableWindow": {
      |              "sizeInDays": 1
      |            }
+     |
      |          }
      |        },
      |        {
      |          "id": "annual_contribution",
      |          "label": "Annual",
      |          "startDateRules": {
+     |           "daysOfWeek": [
+     |                "Monday",
+     |                "Tuesday",
+     |                "Wednesday",
+     |                "Thursday",
+     |                "Friday",
+     |                "Saturday",
+     |                "Sunday"
+     |              ],
      |            "selectableWindow": {
      |              "sizeInDays": 1
      |            }


### PR DESCRIPTION
The catalog response for new product api returns the validation rules for plan start dates that salesforce should enforce.
The current version returns an empty whitelist of days of the week when no restriction should be applied. The salesforce client code could not handle this correctly so this PR changes the response so that a list of days of the week is always returned