### PR TITLE
remove sold to email address from welcome email payload

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/paper/PaperEmailData.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/email/paper/PaperEmailData.scala
@@ -39,7 +39,7 @@ object PaperEmailFields {
   ) = {
     Map(
       "ZuoraSubscriberId" -> data.subscriptionName.value,
-      "SubscriberKey" -> data.contacts.soldTo.email.map(_.value).getOrElse(""),
+      "SubscriberKey" -> data.contacts.billTo.email.map(_.value).getOrElse(""),
       "subscriber_id" -> data.subscriptionName.value,
       "IncludesDigipack" -> digipackPlans.contains(data.plan.id).toString,
       "date_of_first_paper" -> data.firstPaperDate.format(dateformat),
@@ -79,7 +79,7 @@ object PaperEmailFields {
       "title" -> soldTo.title.map(_.value).getOrElse(""),
       "first_name" -> soldTo.firstName.value,
       "last_name" -> soldTo.lastName.value,
-      "EmailAddress" -> soldTo.email.map(_.value).getOrElse(""),
+      "EmailAddress" -> billTo.email.map(_.value).getOrElse(""),
 
       "billing_address_line_1" -> billToAddress.address1.map(_.value).getOrElse(""),
       "billing_address_line_2" -> billToAddress.address2.map(_.value).getOrElse(""),

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/paper/PaperEmailDataTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/email/paper/PaperEmailDataTest.scala
@@ -72,7 +72,7 @@ class PaperEmailDataTest extends FlatSpec with Matchers {
       """
         |{
         |  "ZuoraSubscriberId" : "A-S000SubId",
-        |  "SubscriberKey" : "sold@contact.com",
+        |  "SubscriberKey" : "bill@contact.com",
         |  "subscriber_id" : "A-S000SubId",
         |  "IncludesDigipack" : "true",
         |  "date_of_first_paper" : "1 November 2018",
@@ -87,7 +87,7 @@ class PaperEmailDataTest extends FlatSpec with Matchers {
         |  "title" : "SoldToTitle",
         |  "first_name" : "FirstSold",
         |  "last_name" : "lastSold",
-        |  "EmailAddress" : "sold@contact.com",
+        |  "EmailAddress" : "bill@contact.com",
         |  
         |  "billing_address_line_1" : "billToAddress1",
         |  "billing_address_line_2" : "billToAddress2",


### PR DESCRIPTION
Turns out we repeat the email address several times in the json payload apart from the one that determines the destination of the email.
This should change all references to sold to email to bill to email