### PR TITLE
Improved error messages

### DIFF
--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/FindExistingIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/FindExistingIdentityId.scala
@@ -6,6 +6,7 @@ import com.gu.identity.GetByIdentityId.IdentityUser
 import com.gu.identityBackfill.Types.EmailAddress
 import com.gu.identityBackfill.salesforce.UpdateSalesforceIdentityId.IdentityId
 import com.gu.util.apigateway.ApiGatewayResponse
+import com.gu.util.apigateway.ApiGatewayResponse.notFound
 import com.gu.util.reader.Types.ApiGatewayOp
 import com.gu.util.reader.Types.ApiGatewayOp.{ContinueProcessing, ReturnWithResponse}
 import com.gu.util.resthttp.Types.{ClientFailableOp, ClientFailure, ClientSuccess, NotFound}
@@ -20,7 +21,7 @@ object FindExistingIdentityId {
     def continueIfNoPassword(identityId: IdentityId) = {
       getByIdentityId(identityId) match {
         case ClientSuccess(IdentityUser(_, false)) => ContinueProcessing(Some(identityId))
-        case _ => ReturnWithResponse(ApiGatewayResponse.notFound(s"Identity account not validated but password is set: ${identityId.value}"))
+        case _ => ReturnWithResponse(notFound(s"Identity account not validated but password is set: ${identityId.value}"))
       }
     }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/FindExistingIdentityId.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/FindExistingIdentityId.scala
@@ -20,7 +20,7 @@ object FindExistingIdentityId {
     def continueIfNoPassword(identityId: IdentityId) = {
       getByIdentityId(identityId) match {
         case ClientSuccess(IdentityUser(_, false)) => ContinueProcessing(Some(identityId))
-        case _ => ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set $identityId"))
+        case _ => ReturnWithResponse(ApiGatewayResponse.notFound(s"Identity account not validated but password is set: ${identityId.value}"))
       }
     }
 

--- a/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
+++ b/handlers/identity-backfill/src/main/scala/com/gu/identityBackfill/salesforce/GetSFContactSyncCheckFields.scala
@@ -63,15 +63,13 @@ object ContactSyncCheck {
 
     contactSyncCheckFields.filter(isStandardContact) match {
       case fields :: Nil => {
-        val hasFirstName = fields.FirstName.trim != ""
-        val hasLastName = fields.LastName.trim != ""
         val email = fields.Email.getOrElse("")
         val emailIsValid = email.length > 3 && email.contains("@")
         val country = fields.OtherCountry.getOrElse("").trim
-        val countryIsValid = country != "" && CountryGroup.byOptimisticCountryNameOrCode(country).isDefined
-        if (!hasFirstName) {
+        val countryIsValid = country.nonEmpty && CountryGroup.byOptimisticCountryNameOrCode(country).isDefined
+        if (fields.FirstName.trim.isEmpty) {
           \/.left(s"Contact ${fields.Id} is not syncable - does not have a first name")
-        } else if (!hasLastName) {
+        } else if (fields.LastName.trim.isEmpty) {
           \/.left(s"Contact ${fields.Id} is not syncable - does not have a last name")
         } else if (!emailIsValid) {
           \/.left(s"Contact ${fields.Id} is not syncable - does not have a valid email address: $email")

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/FindExistingIdentityIdTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/FindExistingIdentityIdTest.scala
@@ -35,7 +35,7 @@ class FindExistingIdentityIdTest extends FlatSpec with Matchers {
     FindExistingIdentityId(
       _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
       _ => ClientSuccess(IdentityUser(IdentityId("100"), hasPassword = true))
-    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set IdentityId(100)")))
+    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"Identity account not validated but password is set: 100")))
   }
 
   "findExistingIdentityId" should "ReturnWithResponse for unexpected identity response" in {
@@ -49,6 +49,6 @@ class FindExistingIdentityIdTest extends FlatSpec with Matchers {
     FindExistingIdentityId(
       _ => ClientSuccess(IdentityAccount(IdentityId("100"), isUserEmailValidated = false)),
       _ => GenericError("error"),
-    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"identity email not validated but password is set IdentityId(100)")))
+    )(EmailAddress("email@email.email")) should be(ReturnWithResponse(ApiGatewayResponse.notFound(s"Identity account not validated but password is set: 100")))
   }
 }

--- a/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/ContactSyncCheckTest.scala
+++ b/handlers/identity-backfill/src/test/scala/com/gu/identityBackfill/salesforce/getContact/ContactSyncCheckTest.scala
@@ -5,98 +5,114 @@ import com.gu.identityBackfill.salesforce.ContactSyncCheck.RecordTypeId
 import com.gu.identityBackfill.salesforce.GetSFContactSyncCheckFields.ContactSyncCheckFields
 import com.gu.salesforce.TypesForSFEffectsData.SFContactId
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.\/
 
 class ContactSyncCheckTest extends FlatSpec with Matchers {
 
-  it should "should return some contact if contact is valid for update" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "should return right contact if contact is valid for update" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
-      List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", Some("United Kingdom"), Some("foo@bar.com")))
+      List(
+        ContactSyncCheckFields("ContactId1", Some("wrong"), "last", "first", Some("United Kingdom"), Some("foo@bar.com")),
+        ContactSyncCheckFields("ContactId2", Some("correctId"), "last", "first", Some("United Kingdom"), Some("foo@bar.com")),
+        ContactSyncCheckFields("ContactId3", Some("wrong2"), "last", "first", Some("United Kingdom"), Some("foo@bar.com"))
+      )
     )
-    actual should be(Some(SFContactId("ContactId")))
+    actual shouldBe \/.right(SFContactId("ContactId2"))
   }
 
-  it should "no record type gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "no record type gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", None, "last", "first", Some("United Kingdom"), Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("There are no syncable SF Contacts within the customer's account: ContactId")
   }
 
-  it should "wrong record type gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "wrong record type gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("wrong"), "last", "first", Some("United Kingdom"), Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("There are no syncable SF Contacts within the customer's account: ContactId")
   }
 
-  it should "no last name gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "all wrong record type gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
+    val actual = areFieldsValid(
+      List(
+        ContactSyncCheckFields("ContactId1", Some("wrong"), "last", "first", Some("United Kingdom"), Some("foo@bar.com")),
+        ContactSyncCheckFields("ContactId2", Some("wrong2"), "last", "first", Some("United Kingdom"), Some("foo@bar.com"))
+      )
+    )
+    actual shouldBe \/.left("There are no syncable SF Contacts within the customer's account: ContactId1, ContactId2")
+  }
+
+  it should "no last name gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "", "first", Some("United Kingdom"), Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a last name")
   }
 
-  it should "no first name gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "no first name gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "", Some("United Kingdom"), Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a first name")
   }
 
-  it should "no country gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "no country gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", Some(""), Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a valid country: ")
   }
 
-  it should "none country gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "none country gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", None, Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a valid country: ")
   }
 
-  it should "wrong country gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "wrong country gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", Some("flurble"), Some("foo@bar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a valid country: flurble")
   }
 
-  it should "invalid email gives None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "invalid email gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", Some("United Kingdom"), Some("foobar.com")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a valid email address: foobar.com")
   }
 
-  it should "empty email is also None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "empty email gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(
       List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", Some("United Kingdom"), Some("")))
     )
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a valid email address: ")
   }
 
-  it should "none email is also None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "none email gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(List(ContactSyncCheckFields("ContactId", Some("correctId"), "last", "first", Some("United Kingdom"), None)))
-    actual should be(None)
+    actual shouldBe \/.left("Contact ContactId is not syncable - does not have a valid email address: ")
   }
 
-  it should "No contact found in query is also None" in {
-    val areFieldsValid: List[ContactSyncCheckFields] => Option[SFContactId] = ContactSyncCheck(RecordTypeId("correctId"))
+  it should "No contact found in query gives left error message" in {
+    val areFieldsValid: List[ContactSyncCheckFields] => String \/ SFContactId = ContactSyncCheck(RecordTypeId("correctId"))
     val actual = areFieldsValid(List.empty)
-    actual should be(None)
+    actual shouldBe \/.left("There are no SF Contacts within the customer's account")
   }
 }


### PR DESCRIPTION
- Improved error messages when an Identity account is not in a safe-enough state to assign to the CRM.
- Improved error messages which explain why a Salesforce Contact is not updatable - usually it's because we know it won't sync properly between Zuora and Identity.