### PR TITLE
Remove zuora datalake export code bucket

### DIFF
--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -12,21 +12,6 @@ Parameters:
         Default: CODE
 
 Resources:
-    LocalTargetCsvBucket:
-        Type: AWS::S3::Bucket
-        Properties:
-          BucketName: zuora-datalake-export-code
-          BucketEncryption:
-            ServerSideEncryptionConfiguration:
-              - ServerSideEncryptionByDefault:
-                  SSEAlgorithm: AES256
-          LifecycleConfiguration:
-            Rules:
-              - Id: DeleteOldFiles
-                Prefix: ""
-                Status: Enabled
-                ExpirationInDays: 1
-
     ExportLambdaRole:
         Type: AWS::IAM::Role
         Properties:
@@ -58,15 +43,6 @@ Resources:
                             Action: s3:GetObject
                             Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
 
-                - PolicyName: LocalTargetCsvBucket
-                  PolicyDocument:
-                    Statement:
-                      - Effect: Allow
-                        Action:
-                          - s3:PutObject
-                          - s3:PutObjectAcl
-                        Resource: !Sub ${LocalTargetCsvBucket.Arn}/*
-
                 - PolicyName: OphanTargetCsvBucket
                   PolicyDocument:
                     Statement:
@@ -75,7 +51,6 @@ Resources:
                           - s3:PutObject
                           - s3:PutObjectAcl
                         Resource:
-                          - arn:aws:s3:::ophan-temp-schema/marioTest/raw/zuora/increment/*
                           - arn:aws:s3:::ophan-raw-zuora-increment-*
 
     ExportLambda:
@@ -97,7 +72,6 @@ Resources:
             Timeout: 900
         DependsOn:
         - ExportLambdaRole
-        - LocalTargetCsvBucket
 
     ExportLambdaTriggerRule:
       Type: AWS::Events::Rule

--- a/handlers/zuora-datalake-export/cfn.yaml
+++ b/handlers/zuora-datalake-export/cfn.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Zuora to Datalake export
+Description: Zuora to Datalake export https://github.com/guardian/zuora-auto-cancel/tree/master/handlers/zuora-datalake-export
 
 Parameters:
     Stage:
@@ -10,6 +10,9 @@ Parameters:
             - CODE
             - PROD
         Default: CODE
+
+Conditions:
+  IsProd: !Equals [!Ref "Stage", "PROD"]
 
 Resources:
     ExportLambdaRole:
@@ -75,6 +78,7 @@ Resources:
 
     ExportLambdaTriggerRule:
       Type: AWS::Events::Rule
+      Condition: IsProd
       Properties:
         Description: Trigger Zuora-to-Datalake export every day at 00:30 AM UTC
         ScheduleExpression: cron(30 0 * * ? *)
@@ -87,6 +91,7 @@ Resources:
 
     TriggerStartExportJobPermission:
       Type: AWS::Lambda::Permission
+      Condition: IsProd
       Properties:
         Action: lambda:InvokeFunction
         FunctionName: !Sub ${ExportLambda.Arn}
@@ -95,6 +100,7 @@ Resources:
 
     FailedExportAlarm:
       Type: AWS::CloudWatch::Alarm
+      Condition: IsProd
       Properties:
         AlarmName: zuora-datalake-export
         AlarmDescription: Failed to export Zuora to Datalake. Corresponding Ophan clean tables, such as clean.zuora_account, will go out-of-date. Refer to https://github.com/guardian/zuora-auto-cancel/blob/master/handlers/sf-datalake-export/README.md on how to debug and retry.

--- a/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
+++ b/handlers/zuora-datalake-export/src/main/scala/com/gu/zuora/datalake/export/ExportLambda.scala
@@ -266,9 +266,7 @@ object SaveCsvToBucket {
   def apply(csvContent: String, batch: Batch) = {
     val s3Client = AmazonS3Client.builder.build()
     System.getenv("Stage") match {
-      case "CODE" =>
-        val requestWithAcl = putRequestWithAcl("zuora-datalake-export-code", Query(batch.name).s3Key, csvContent)
-        s3Client.putObject(requestWithAcl)
+      case "CODE" => // do nothing
 
       case "PROD" =>
         val requestWithAcl = putRequestWithAcl(Query(batch.name).s3Bucket, Query(batch.name).s3Key, csvContent)


### PR DESCRIPTION
In CODE to download CSV extract examine the logs for `Job ID` and `File ID` and either

**Get CSV content via Postman**
```http request
GET /apps/api/file/{{fileId}}
Host: apisandbox.zuora.com
Authorization: Bearer ***********
```

or 

**find Jobs in Zuora UI**

https://apisandbox.zuora.com/apps/BatchQuery.do

Related PR: https://github.com/guardian/zuora-auto-cancel/pull/281