### PR TITLE
Add braze to salesforce file upload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,7 +165,8 @@ lazy val root = all(project in file(".")).enablePlugins(RiffRaffArtifact).aggreg
   `effects-ses`,
   `sf-datalake-export`,
   `zuora-datalake-export`,
-  `batch-email-sender`
+  `batch-email-sender`,
+  `braze-to-salesforce-file-upload`,
 ).dependsOn(zuora, handler, effectsDepIncludingTestFolder, `effects-sqs`, testDep)
 
 lazy val `identity-backfill` = all(project in file("handlers/identity-backfill")) // when using the "project identity-backfill" command it uses the lazy val name
@@ -220,6 +221,9 @@ lazy val `zuora-datalake-export` = all(project in file("handlers/zuora-datalake-
 lazy val `batch-email-sender` = all(project in file("handlers/batch-email-sender"))
   .enablePlugins(RiffRaffArtifact)
   .dependsOn(handler, `effects-sqs`, effectsDepIncludingTestFolder, testDep)
+
+lazy val `braze-to-salesforce-file-upload` = all(project in file("handlers/braze-to-salesforce-file-upload"))
+  .enablePlugins(RiffRaffArtifact)
 
 // ==== END handlers ====
 

--- a/handlers/braze-to-salesforce-file-upload/README.md
+++ b/handlers/braze-to-salesforce-file-upload/README.md
@@ -2,9 +2,10 @@
 
 ## How does it work?
 
-1. Braze writes a file to S3 bucket `braze-to-salesforce-file-upload` in `membership` AWS account
+1. Braze writes a zipped CSV file to S3 bucket `braze-to-salesforce-file-upload` in `membership` AWS account
 1. Lambda `braze-to-salesforce-file-upload` is triggered by an event message which contains the filenames
-1. Salesforce REST API uploads csv blob to Salesforce Documents
+1. Unzip to get raw CSV file
+1. Salesforce REST API uploads CSV to Salesforce Documents
 1. Delete the file from S3 bucket after successful upload to Salesforce
 
 ## How do we know when it fails?

--- a/handlers/braze-to-salesforce-file-upload/README.md
+++ b/handlers/braze-to-salesforce-file-upload/README.md
@@ -2,7 +2,7 @@
 
 ## How does it work?
 
-1. Braze writes a zipped CSV file to S3 bucket `braze-to-salesforce-file-upload` in `membership` AWS account
+1. Braze [writes](https://www.braze.com/docs/developer_guide/rest_api/export/#users-by-segment-endpoint) a zipped CSV file to S3 bucket `braze-to-salesforce-file-upload` in `membership` AWS account
 1. Lambda `braze-to-salesforce-file-upload` is triggered by an event message which contains the filenames
 1. Unzip to get raw CSV file
 1. Salesforce REST API uploads CSV to Salesforce Documents

--- a/handlers/braze-to-salesforce-file-upload/README.md
+++ b/handlers/braze-to-salesforce-file-upload/README.md
@@ -1,0 +1,24 @@
+# braze-to-salesforce-file-upload
+
+## How does it work?
+
+1. Braze writes a file to S3 bucket `braze-to-salesforce-file-upload` in `membership` AWS account
+1. Lambda `braze-to-salesforce-file-upload` is triggered by an event message which contains the filenames
+1. Salesforce REST API uploads csv blob to Salesforce Documents
+1. Delete the file from S3 bucket after successful upload to Salesforce
+
+## How do we know when it fails?
+
+Cloudwatch Alert email is sent to SX mailing list.
+
+## How to retry?
+
+After successful upload to Salesforce, files are deleted from S3 bucket. Therefore, to retry upload:
+
+1. check what files are still in the S3 bucket,
+1. Download these files locally
+1. Re-upload them to S3 bucket
+
+
+
+

--- a/handlers/braze-to-salesforce-file-upload/README.md
+++ b/handlers/braze-to-salesforce-file-upload/README.md
@@ -18,7 +18,3 @@ After successful upload to Salesforce, files are deleted from S3 bucket. Therefo
 1. check what files are still in the S3 bucket,
 1. Download these files locally
 1. Re-upload them to S3 bucket
-
-
-
-

--- a/handlers/braze-to-salesforce-file-upload/build.sbt
+++ b/handlers/braze-to-salesforce-file-upload/build.sbt
@@ -1,0 +1,16 @@
+name := "braze-to-salesforce-file-upload"
+description:= "Braze to Salesforce file upload"
+scalacOptions += "-Ypartial-unification"
+assemblyJarName := s"${name.value}.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := s"MemSub::Membership Admin::${name.value}"
+riffRaffArtifactResources += (file(s"handlers/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
+libraryDependencies ++= Seq(
+  "io.github.mkotsur" %% "aws-lambda-scala" % "0.1.1",
+  "org.scalaj" %% "scalaj-http" % "2.4.1",
+  Dependencies.awsS3,
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+)

--- a/handlers/braze-to-salesforce-file-upload/build.sbt
+++ b/handlers/braze-to-salesforce-file-upload/build.sbt
@@ -12,5 +12,6 @@ libraryDependencies ++= Seq(
   "org.scalaj" %% "scalaj-http" % "2.4.1",
   Dependencies.awsS3,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+  "com.github.pathikrit" %% "better-files" % "3.7.1"
 )

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -1,0 +1,81 @@
+Description: When braze uploads file to S3 bucket, trigger a Lambda event which uploads file to Salesforce
+
+Parameters:
+  BucketName:
+    Description: S3 Bucket name
+    Type: String
+
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+    Default: CODE
+
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    DependsOn: BucketPermission
+    Properties:
+      BucketName: !Ref BucketName
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Function: !GetAtt BucketWatcher.Arn
+
+  BucketPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref BucketWatcher
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref "AWS::AccountId"
+      SourceArn: !Sub "arn:aws:s3:::${BucketName}"
+
+  BucketWatcher:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Upload file to Salesforce
+      FunctionName: !Sub braze-to-salesforce-file-upload-${Stage}
+      Code:
+        S3Bucket: zuora-auto-cancel-dist
+        S3Key: !Sub membership/${Stage}/braze-to-salesforce-file-upload/braze-to-salesforce-file-upload.jar
+      Handler: com.gu.salesforce.braze.upload.UploadFileToSalesforceLambda::handle
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: java8
+      MemorySize: 1536
+      Timeout: 60
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: {Service: [lambda.amazonaws.com]}
+            Action: ['sts:AssumeRole']
+      Path: /
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      Policies:
+        - PolicyName: S3Policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${BucketName}/*"
+
+        - PolicyName: ReadPrivateCredentials
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
+

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -78,6 +78,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:GetObject
+                  - s3:DeleteObject
                 Resource: !Sub
                   - "arn:aws:s3:::${BucketName}/*"
                   - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -79,9 +79,14 @@ Resources:
                 Action:
                   - s3:GetObject
                   - s3:DeleteObject
-                Resource: !Sub
-                  - "arn:aws:s3:::${BucketName}/*"
-                  - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}
+                  - s3:ListBucket
+                Resource:
+                  - !Sub
+                    - "arn:aws:s3:::${BucketName}"
+                    - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}
+                  - !Sub
+                    - "arn:aws:s3:::${BucketName}/*"
+                    - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}
 
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -119,3 +119,43 @@ Resources:
       Threshold: 1
       TreatMissingData: notBreaching
 
+  BrazeUser:
+    Type: AWS::IAM::User
+    Properties:
+      Path: "/"
+  BrazeUserKeys:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      Serial: 1
+      UserName: !Ref BrazeUser
+  BrazeUserPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Users:
+        - !Ref BrazeUser
+      PolicyName: BrazeToSalesforceFileUploadPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+              - s3:GetBucketLocation
+            Resource: !Sub
+              - "arn:aws:s3:::${BucketName}"
+              - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+            Resource: !Sub
+              - "arn:aws:s3:::${BucketName}/*"
+              - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}
+
+Outputs:
+  BrazeAwsAccessId:
+    Value: !Ref BrazeUserKeys
+  BrazeAwsSecretAccessKey:
+    Value: !GetAtt BrazeUserKeys.SecretAccessKey
+  BrazeAwsS3BucketName:
+    Value: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]
+

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -1,10 +1,6 @@
 Description: When braze uploads file to S3 bucket, trigger a Lambda event which uploads file to Salesforce
 
 Parameters:
-  BucketName:
-    Description: S3 Bucket name
-    Type: String
-
   Stage:
     Description: Stage name
     Type: String
@@ -13,12 +9,19 @@ Parameters:
       - PROD
     Default: CODE
 
+Mappings:
+  BucketNameByStageMap:
+    CODE:
+      "bucketName": "braze-to-salesforce-file-upload-code"
+    PROD:
+      "bucketName": "braze-to-salesforce-file-upload-prod"
+
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
     DependsOn: BucketPermission
     Properties:
-      BucketName: !Ref BucketName
+      BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: 's3:ObjectCreated:*'
@@ -31,7 +34,9 @@ Resources:
       FunctionName: !Ref BucketWatcher
       Principal: s3.amazonaws.com
       SourceAccount: !Ref "AWS::AccountId"
-      SourceArn: !Sub "arn:aws:s3:::${BucketName}"
+      SourceArn: !Sub
+        - "arn:aws:s3:::${BucketName}"
+        - { BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName] }
 
   BucketWatcher:
     Type: AWS::Lambda::Function
@@ -70,7 +75,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:GetObject
-                Resource: !Sub "arn:aws:s3:::${BucketName}/*"
+                Resource: !Sub
+                  - "arn:aws:s3:::${BucketName}/*"
+                  - {BucketName: !FindInMap [BucketNameByStageMap, !Ref Stage, bucketName]}
 
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -9,6 +9,9 @@ Parameters:
       - PROD
     Default: CODE
 
+Conditions:
+  IsProd: !Equals [!Ref "Stage", "PROD"]
+
 Mappings:
   BucketNameByStageMap:
     CODE:
@@ -85,4 +88,28 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfAuth-${Stage}*.json
+
+  FailedUploadAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: braze-to-salesforce-file-upload
+      AlarmDescription: >
+        Failed to upload file from braze to Salesforce.
+        Latcham will not be able to send physical letters.
+        Refer to https://github.com/guardian/zuora-auto-cancel/blob/master/handlers/braze-to-salesforce-file-upload/README.md
+        on how to debug and retry.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref BucketWatcher
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
 

--- a/handlers/braze-to-salesforce-file-upload/cfn.yaml
+++ b/handlers/braze-to-salesforce-file-upload/cfn.yaml
@@ -84,5 +84,5 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: s3:GetObject
-                Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/zuoraRest-${Stage}*.json
+                Resource: !Sub arn:aws:s3:::gu-reader-revenue-private/membership/support-service-lambdas/${Stage}/sfAuth-${Stage}*.json
 

--- a/handlers/braze-to-salesforce-file-upload/riff-raff.yaml
+++ b/handlers/braze-to-salesforce-file-upload/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     app: braze-to-salesforce-file-upload
     parameters:
       templatePath: cfn.yaml
-  zuora-datalake-export:
+  braze-to-salesforce-file-upload:
     type: aws-lambda
     parameters:
       fileName: braze-to-salesforce-file-upload.jar

--- a/handlers/braze-to-salesforce-file-upload/riff-raff.yaml
+++ b/handlers/braze-to-salesforce-file-upload/riff-raff.yaml
@@ -1,0 +1,19 @@
+stacks:
+- membership
+regions:
+- eu-west-1
+deployments:
+  cfn:
+    type: cloud-formation
+    app: braze-to-salesforce-file-upload
+    parameters:
+      templatePath: cfn.yaml
+  zuora-datalake-export:
+    type: aws-lambda
+    parameters:
+      fileName: braze-to-salesforce-file-upload.jar
+      bucket: zuora-auto-cancel-dist
+      prefixStack: false
+      functionNames:
+      - braze-to-salesforce-file-upload-
+    dependencies: [cfn]

--- a/handlers/braze-to-salesforce-file-upload/src/main/resources/logback.xml
+++ b/handlers/braze-to-salesforce-file-upload/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %level - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
+++ b/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
@@ -10,47 +10,6 @@ import com.typesafe.scalalogging.LazyLogging
 import scalaj.http.Http
 import scala.io.Source
 
-/*
-{
-    "Records": [
-        {
-            "eventVersion": "2.1",
-            "eventSource": "aws:s3",
-            "awsRegion": "eu-west-1",
-            "eventTime": "2019-03-21T14:40:00.210Z",
-            "eventName": "ObjectCreated:Put",
-            "userIdentity": {
-                "principalId": "AWS:AROAJ2472JG7IDEUTKPNU:mario.galic"
-            },
-            "requestParameters": {
-                "sourceIPAddress": "77.91.250.236"
-            },
-            "responseElements": {
-                "x-amz-request-id": "C53A0297488F6BAB",
-                "x-amz-id-2": "DS4x4B/R3dixDAcQJF2/08EUaUhiowK3hiW9V56cYeesG2HPXFwbjz1yewUGXde2QnzJ5jyIRE8="
-            },
-            "s3": {
-                "s3SchemaVersion": "1.0",
-                "configurationId": "9553147c-84da-4616-b446-7084781908b0",
-                "bucket": {
-                    "name": "braze-to-salesforce-upload-code",
-                    "ownerIdentity": {
-                        "principalId": "A3FCSJUA4O7GBA"
-                    },
-                    "arn": "arn:aws:s3:::braze-to-salesforce-upload-code"
-                },
-                "object": {
-                    "key": "Account.csv",
-                    "size": 1043872,
-                    "eTag": "aa47941dff62732c82effe6962e87451",
-                    "sequencer": "005C93A2401DBEE37E"
-                }
-            }
-        }
-    ]
-}
- */
-
 case class S3EventObject(key: String)
 case class S3Event(`object`: S3EventObject)
 case class Record(s3: S3Event)

--- a/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
+++ b/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
@@ -1,0 +1,39 @@
+package com.gu.salesforce.braze.upload
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import io.circe.generic.auto._
+import io.circe.parser._
+import io.github.mkotsur.aws.handler.Lambda._
+import io.github.mkotsur.aws.handler.Lambda
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata, PutObjectRequest}
+import com.typesafe.scalalogging.LazyLogging
+import scalaj.http.Http
+import scala.io.Source
+import scala.concurrent.duration._
+import scala.util.Try
+
+case class S3EventObject(key: String)
+case class S3Event(`object`: S3EventObject)
+case class Record(s3: S3Event)
+case class Event(Records: List[Record])
+
+//case class Event(Records: List[{
+//  val s3: {
+//    val `object`: {
+//      val key: String
+//    }
+//  }
+//}])
+
+class UploadFileToSalesforceLambda extends Lambda[Event, String] with LazyLogging {
+  override def handle(event: Event, context: Context) = {
+    logger.info(event.toString)
+    Right(s"Successfully uploaded file to Salesforce")
+  }
+}
+

--- a/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
+++ b/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
@@ -184,7 +184,7 @@ object UploadFileToSalesforce {
         |{
         |    "Description" : "Braze to Salesforce upload of Guardian Weekly price rise letters for Latcham Direct: $filename",
         |    "Keywords" : "Guardian Weekly,price rise,letters, latcham",
-        |    "FolderId" : "00l25000000FITF",
+        |    "FolderId" : "${SalesforceDocumentFolderId()}",
         |    "Name" : "$filename",
         |    "Type" : "csv"
         |}
@@ -224,5 +224,14 @@ object ReadCsvFileFromS3Bucket {
   def apply(key: String): String = {
     val inputStream = AmazonS3Client.builder.build().getObject(BucketName(), key).getObjectContent
     Source.fromInputStream(inputStream).mkString
+  }
+}
+
+object SalesforceDocumentFolderId {
+  def apply(): String = {
+    System.getenv("Stage") match {
+      case "CODE" => "00l25000000FITF"
+      case "PROD" => throw new RuntimeException("Not yet implemented")
+    }
   }
 }

--- a/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
+++ b/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
@@ -56,14 +56,6 @@ case class S3Event(`object`: S3EventObject)
 case class Record(s3: S3Event)
 case class Event(Records: List[Record])
 
-//case class Event(Records: List[{
-//  val s3: {
-//    val `object`: {
-//      val key: String
-//    }
-//  }
-//}])
-
 case class Config(
   stage: String,
   url: String,
@@ -146,33 +138,7 @@ object AccessToken {
   }
 }
 
-/*
-POST /services/data/v29.0/sobjects/Document/ HTTP/1.1
-Host: gnmtouchpoint--GNMUAT.cs80.my.salesforce.com
-Authorization: Bearer *************
-Content-Type: multipart/form-data; boundary=boundary
-
---boundary
-Content-Disposition: form-data; name="entity_document";
-Content-Type: application/json
-
-{
-    "Description" : "Braze to Salesforce upload",
-    "Keywords" : "marketing,sales,update",
-    "FolderId" : "00l25000000FITF",
-    "Name" : "Account test",
-    "Type" : "csv"
-}
-
---boundary
-Content-Type: application/csv
-Content-Disposition: form-data; name="Body"; filename="Account.csv"
-
-c11,c12,c13
-c21,c22,c23
-
---boundary--
- */
+// https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_insert_update_blob.htm
 object UploadFileToSalesforce {
   def apply(config: Config, csvContent: String, filename: String) = {
     val body =

--- a/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
+++ b/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
@@ -53,7 +53,7 @@ object Program {
   def apply(event: Event): Unit =
     FilesFromBraze(event).foreach { filename =>
       val csvContent = ReadCsvFileFromS3Bucket(filename)
-      UploadFileToSalesforce(csvContent, filename.dropRight(4))
+      UploadFileToSalesforce(csvContent, DropZipSuffix(filename))
       DeleteCsvFileFromS3Bucket(filename)
     }
 }
@@ -185,13 +185,17 @@ object ReadCsvFileFromS3Bucket {
   }
 }
 
+// https://github.com/pathikrit/better-files
 object ZipToString {
   def apply(inputStream: S3ObjectInputStream, filename: String): String = {
     Files.copy(inputStream, Paths.get(s"/tmp/$filename"), StandardCopyOption.REPLACE_EXISTING)
-    val zipFile: File = file"/tmp/$filename"
-    val rawCsv: File = zipFile.unzipTo(root / "tmp")
-    (root / "tmp" / s"${filename.dropRight(4)}").contentAsString
+    val rawCsv: File = file"/tmp/$filename".unzipTo(root / "tmp")
+    (root / "tmp" / s"${DropZipSuffix(filename)}").contentAsString
   }
+}
+
+object DropZipSuffix {
+  def apply(filename: String): String = filename.dropRight(4) // drop .zip
 }
 
 object DeleteCsvFileFromS3Bucket {

--- a/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
+++ b/handlers/braze-to-salesforce-file-upload/src/main/scala/com/gu/salesforce/braze/upload/UploadFileToSalesforceLambda.scala
@@ -17,6 +17,48 @@ import scala.io.Source
 import scala.concurrent.duration._
 import scala.util.Try
 
+
+/*
+{
+    "Records": [
+        {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "eu-west-1",
+            "eventTime": "2019-03-21T14:40:00.210Z",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+                "principalId": "AWS:AROAJ2472JG7IDEUTKPNU:mario.galic"
+            },
+            "requestParameters": {
+                "sourceIPAddress": "77.91.250.236"
+            },
+            "responseElements": {
+                "x-amz-request-id": "C53A0297488F6BAB",
+                "x-amz-id-2": "DS4x4B/R3dixDAcQJF2/08EUaUhiowK3hiW9V56cYeesG2HPXFwbjz1yewUGXde2QnzJ5jyIRE8="
+            },
+            "s3": {
+                "s3SchemaVersion": "1.0",
+                "configurationId": "9553147c-84da-4616-b446-7084781908b0",
+                "bucket": {
+                    "name": "braze-to-salesforce-upload-code",
+                    "ownerIdentity": {
+                        "principalId": "A3FCSJUA4O7GBA"
+                    },
+                    "arn": "arn:aws:s3:::braze-to-salesforce-upload-code"
+                },
+                "object": {
+                    "key": "Account.csv",
+                    "size": 1043872,
+                    "eTag": "aa47941dff62732c82effe6962e87451",
+                    "sequencer": "005C93A2401DBEE37E"
+                }
+            }
+        }
+    ]
+}
+ */
+
 case class S3EventObject(key: String)
 case class S3Event(`object`: S3EventObject)
 case class Record(s3: S3Event)


### PR DESCRIPTION
## How does it work?

1. Braze [writes](https://www.braze.com/docs/developer_guide/rest_api/export/#users-by-segment-endpoint) a zipped CSV file to S3 bucket `braze-to-salesforce-file-upload` in `membership` AWS account
1. Lambda `braze-to-salesforce-file-upload` is triggered by an event message which contains the filenames
1. Unzip to get raw CSV file
1. Salesforce REST API uploads CSV to Salesforce Documents
1. Delete the file from S3 bucket after successful upload to Salesforce

## How do we know when it fails?

Cloudwatch Alert email is sent to SX mailing list.

## How to retry?

After successful upload to Salesforce, files are deleted from S3 bucket. Therefore, to retry upload:

1. check what files are still in the S3 bucket,
1. Download these files locally
1. Re-upload them to S3 bucket