### PR TITLE
Contact merge: Make last name check a little bit more permissive

### DIFF
--- a/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/GetVariations.scala
+++ b/handlers/sf-contact-merge/src/main/scala/com/gu/sf_contact_merge/validate/GetVariations.scala
@@ -22,8 +22,8 @@ object GetVariations {
 
   val forLastName: GetVariations[LastName] = apply[LastName](
     "last names",
-    lastName => LastName(lastName.value.toLowerCase)
-  // some seem to be entered entirely lower case, but this isn't a significant difference, so ignore
+    lastName => LastName(lastName.value.toLowerCase.filter(_.isLetterOrDigit))
+  // some seem to be entered entirely lower case, and have trailing punctuation, but these aren't significant differences, so ignore
   )
 
   val forEmailAddress: GetVariations[EmailAddress] = GetVariations[EmailAddress](

--- a/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/validate/AssertSameEmailsTest.scala
+++ b/handlers/sf-contact-merge/src/test/scala/com/gu/sf_contact_merge/validate/AssertSameEmailsTest.scala
@@ -42,10 +42,9 @@ class AssertSameEmailsTest extends FlatSpec with Matchers {
   }
 
   it should "be happy that superficially different items are the same if they are transformed" in {
-    val testData = List("JOHN", "john").map(LastName.apply)
+    val testData = List("JOHN", "JOHN.", "john", "john ", " john").map(LastName.apply)
 
     GetVariations.forLastName.apply(testData) should be(HasAllowableVariations(LastName("john")))
-
   }
 
   it should "be happy that actually different items are the still different if they are transformed" in {


### PR DESCRIPTION
A fair few contacts are not merging because their last names have whitespace or dots and commas 
on one contact and not the other. This makes the check a little bit more permissive, whilst still ensuring a sensible check is performed.

cc @abhichawla