### PR TITLE
Remove "Zuora account balance is not zero" validation step

### DIFF
--- a/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccount.scala
+++ b/handlers/new-product-api/src/main/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccount.scala
@@ -17,7 +17,6 @@ object ValidateAccount {
   def apply(account: Account): ValidationResult[ValidatedAccount] = {
     for {
       _ <- account.autoPay.value orFailWith "Zuora account has autopay disabled"
-      _ <- (account.accountBalanceMinorUnits.value == 0) orFailWith "Zuora account balance is not zero"
       paymentMethodId <- account.paymentMethodId getOrFailWith "Zuora account has no default payment method"
     } yield ValidatedAccount(
       account.identityId,

--- a/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccountTest.scala
+++ b/handlers/new-product-api/src/test/scala/com/gu/newproduct/api/addsubscription/validation/ValidateAccountTest.scala
@@ -40,9 +40,5 @@ class ValidateAccountTest extends FlatSpec with Matchers {
     val noAutoPayAccount = validAccount.copy(autoPay = AutoPay(false))
     ValidateAccount(noAutoPayAccount) shouldBe Failed("Zuora account has autopay disabled")
   }
-  it should "fail if account balance is not zero" in {
-    val balanceNotZeroAccount = validAccount.copy(accountBalanceMinorUnits = AccountBalanceMinorUnits(1000))
-    ValidateAccount(balanceNotZeroAccount) shouldBe Failed("Zuora account balance is not zero")
-  }
 
 }


### PR DESCRIPTION
Whilst Home Delivery acquisitions are disabled in `support-frontend` it's increasingly likely CSRs will need to create new Home Delivery subs in SalesForce (i.e. via `new-product-api` in this repo). However currently there is a validation requirement for the account balance to be zero, which again is increasingly likely not to be the case for the time being, so removing this validation.

The corresponding changes to SalesForce (to WARN the CSR if non-zero) look like this...
#### Zero Account Balance
![image](https://user-images.githubusercontent.com/19289579/56151864-2452dc80-5faa-11e9-8851-83c99d743c68.png)

#### NON-Zero Account Balance
![image](https://user-images.githubusercontent.com/19289579/56151886-32a0f880-5faa-11e9-9ceb-2b7a404b1168.png) 